### PR TITLE
Update connect-to-the-network.mdx

### DIFF
--- a/docs/devnet/connect-to-the-network.mdx
+++ b/docs/devnet/connect-to-the-network.mdx
@@ -72,7 +72,7 @@ await window.ethereum.request({
 </Tip>
 
 <Footnote>
-See the [tooling/libraries](./tooling-and-resources/testing-and-fuzzing.mdx) page for more wallet-related resources.
+See the [tooling/libraries](./tooling-and-resources/testing-and-fuzzing) page for more wallet-related resources.
 </Footnote>
 
 ### CLI


### PR DESCRIPTION
fix broken URL in connect-to.. page

[do not add file extensions to relative path refs I guess]