### PR TITLE
Adds solidity snippets for precompiles, aligns all example references to 'evmd' network

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -190,6 +190,7 @@
                                         "group": "Getting Started",
                                         "pages": [
                                             "docs/next/documentation/getting-started/index",
+                                            "docs/next/documentation/getting-started/reference-network",
                                             "docs/next/documentation/getting-started/faq",
                                             "docs/next/documentation/getting-started/development-environment",
                                             "docs/next/documentation/getting-started/local-network-setup",

--- a/docs/next/api-reference/ethereum-json-rpc/index.mdx
+++ b/docs/next/api-reference/ethereum-json-rpc/index.mdx
@@ -76,7 +76,7 @@ max-open-connections = 0
 rpc-gas-cap = 0
 
 # RPCEVMTimeout sets a timeout used for eth_call queries.
-rpc-evm-timeout = "10s"
+evm-timeout = "10s"
 ```
 </Expandable>
 
@@ -85,7 +85,7 @@ rpc-evm-timeout = "10s"
 Alternatively, enable JSON-RPC when starting the node:
 
 ```bash
-appd start \
+evmd start \
   --json-rpc.enable \
   --json-rpc.address="0.0.0.0:8545" \
   --json-rpc.ws-address="0.0.0.0:8546" \
@@ -166,7 +166,7 @@ Since Cosmos EVM is built with the Cosmos SDK framework and uses CometBFT as it'
 You can start a connection with the Ethereum websocket using the `--json-rpc.ws-address` flag when starting the node (default `"0.0.0.0:8546"`):
 
 ```
-appd start --json-rpc.address="0.0.0.0:8545" --json-rpc.ws-address="0.0.0.0:8546" --json-rpc.api="eth,web3,net,txpool,debug" --json-rpc.enable
+evmd start --json-rpc.address="0.0.0.0:8545" --json-rpc.ws-address="0.0.0.0:8546" --json-rpc.api="eth,web3,net,txpool,debug" --json-rpc.enable
 ```
 
 Then, start a websocket subscription with [`ws`](https://github.com/hashrocket/ws)

--- a/docs/next/api-reference/ethereum-json-rpc/methods.mdx
+++ b/docs/next/api-reference/ethereum-json-rpc/methods.mdx
@@ -33,15 +33,15 @@ The following namespaces are not implemented in Cosmos EVM but may be present in
   </Accordion>
 
   <Accordion title="miner - Mining Operations (Not Applicable)">
-    The `miner` namespace controls Proof of Work mining operations. Cosmos EVM uses Tendermint Byzantine Fault Tolerant consensus instead of mining.
+    The `miner` namespace controls Proof of Work mining operations. Cosmos EVM uses 'CometBFT' Byzantine Fault Tolerant consensus instead of mining.
   </Accordion>
 
   <Accordion title="engine - Post-Merge Engine API (Not Applicable)">
-    The `engine` namespace implements Ethereum's post-merge Engine API for communication with the consensus layer. Cosmos EVM uses Tendermint consensus instead of the beacon chain.
+    The `engine` namespace implements Ethereum's post-merge Engine API for communication with the consensus layer. Cosmos EVM uses 'CometBFT' consensus instead of the beacon chain.
   </Accordion>
 
   <Accordion title="clique - Proof of Authority (Not Applicable)">
-    The `clique` namespace implements Proof of Authority consensus for private networks. Cosmos EVM uses Tendermint consensus.
+    The `clique` namespace implements Proof of Authority consensus for private networks. Cosmos EVM uses 'CometBFT' consensus.
   </Accordion>
 
   <Accordion title="les - Light Client Protocol (Not Supported)">
@@ -281,10 +281,10 @@ Block Number can be entered as a Hex string, `"earliest"`, `"latest"` or `"pendi
 <Info>
 **EIP-1559 Support**: Cosmos EVM supports EIP-1559 transaction types with `eth_maxPriorityFeePerGas`, though `eth_feeHistory` is not yet implemented.
 
-**Consensus Differences**: Due to using Tendermint BFT consensus instead of Proof of Work/Stake:
+**Consensus Differences**: Due to using 'CometBFT' BFT consensus instead of Proof of Work/Stake:
 * Uncle-related methods always return 0 or null
 * Block reorganizations are not possible
-* Engine API (`engine_*`) is not applicable - Tendermint handles consensus
+* Engine API (`engine_*`) is not applicable - 'CometBFT' handles consensus
 
 **Methods Not Implemented**:
 * `eth_createAccessList` (EIP-2930) - Access list transactions
@@ -297,7 +297,7 @@ Block Number can be entered as a Hex string, `"earliest"`, `"latest"` or `"pendi
 * `debug_getRaw*` methods - Raw data access methods
 * `debug_printBlock` - Block printing utility
 * `trace_*` methods - Advanced tracing features
-* `engine_*` methods - Post-merge Engine API (uses Tendermint instead)
+* `engine_*` methods - Post-merge Engine API (uses 'CometBFT' instead)
 * `admin_*` methods - Node administration
 * `les_*` methods - Light Ethereum Subprotocol
 * `clique_*` methods - Proof of Authority consensus
@@ -716,7 +716,7 @@ Creates an access list for a transaction. Access lists specify which addresses a
   - `gasPrice`: `QUANTITY` - (optional) Gas price for each unit of gas
   - `value`: `QUANTITY` - (optional) Value sent with the transaction
   - `data`: `DATA` - (optional) Transaction data payload
-  
+
 - Block number or Block Hash ([EIP-1898](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1898.md))
 
 #### Returns
@@ -748,9 +748,9 @@ curl -X POST --data '{
 Websocket
 ```shell
 wscat -c ws://localhost:8546 -x '{
-  "jsonrpc": "2.0", 
-  "id": 1, 
-  "method": "eth_createAccessList", 
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "eth_createAccessList",
   "params": [{
     "from":"0x8ba1f109551bD432803012645Hac136c5dd7E3D40",
     "to":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1053,7 +1053,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_coinbase","params":[],"id":1
 Returns whether the client is actively mining new blocks.
 
 <Info>
-Always returns `false` as Cosmos EVM uses Tendermint consensus instead of mining.
+Always returns `false` as Cosmos EVM uses 'CometBFT' consensus instead of mining.
 </Info>
 
 ```shell
@@ -1068,7 +1068,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_mining","params":[],"id":1}'
 Returns the number of hashes per second that the node is mining with.
 
 <Info>
-Always returns `0x0` as Cosmos EVM uses Tendermint consensus instead of mining.
+Always returns `0x0` as Cosmos EVM uses 'CometBFT' consensus instead of mining.
 </Info>
 
 ```shell
@@ -1094,7 +1094,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}
 Returns the number of uncles in a block matching the given block hash.
 
 <Info>
-Always returns `0x0` as Cosmos EVM does not have uncles due to using Tendermint consensus.
+Always returns `0x0` as Cosmos EVM does not have uncles due to using 'CometBFT' consensus.
 </Info>
 
 #### Parameters
@@ -1113,7 +1113,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockHash","p
 Returns the number of uncles in a block matching the given block number.
 
 <Info>
-Always returns `0x0` as Cosmos EVM does not have uncles due to using Tendermint consensus.
+Always returns `0x0` as Cosmos EVM does not have uncles due to using 'CometBFT' consensus.
 </Info>
 
 #### Parameters
@@ -1132,7 +1132,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockNumber",
 Returns information about an uncle by block hash and uncle index position.
 
 <Info>
-Always returns `null` as Cosmos EVM does not have uncles due to using Tendermint consensus.
+Always returns `null` as Cosmos EVM does not have uncles due to using 'CometBFT' consensus.
 </Info>
 
 #### Parameters
@@ -1152,7 +1152,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getUncleByBlockHashAndIndex"
 Returns information about an uncle by block number and uncle index position.
 
 <Info>
-Always returns `null` as Cosmos EVM does not have uncles due to using Tendermint consensus.
+Always returns `null` as Cosmos EVM does not have uncles due to using 'CometBFT' consensus.
 </Info>
 
 #### Parameters
@@ -2220,9 +2220,9 @@ Websocket
 
 ```shell
 wscat -c ws://localhost:8546 -x '{
-  "jsonrpc": "2.0", 
-  "id": 1, 
-  "method": "eth_createAccessList", 
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "eth_createAccessList",
   "params": [{
     "from": "0x8D97689C9818892B700e27F316cc3E41e17fBeb9",
     "to": "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",

--- a/docs/next/documentation/concepts/accounts.mdx
+++ b/docs/next/documentation/concepts/accounts.mdx
@@ -128,12 +128,12 @@ cosmos1z3t55m0l9h0eupuz3dp5t5cypyv674jj7mz2jw
 
 ### Address conversion
 
-The `appd debug addr <address>` can be used to convert an address between hex and bech32 formats:
+The `evmd debug addr <address>` can be used to convert an address between hex and bech32 formats:
 
 <CodeGroup>
 
 ```bash Bech32 to Hex
-$ appd debug addr cosmos1z3t55m0l9h0eupuz3dp5t5cypyv674jj7mz2jw
+$ evmd debug addr cosmos1z3t55m0l9h0eupuz3dp5t5cypyv674jj7mz2jw
 
 Address: [20 87 74 109 255 45 223 158 7 130 139 67 69 211 4 9 25 175 86 82]
 Address (hex): 14574A6DFF2DDF9E07828B4345D3040919AF5652
@@ -142,7 +142,7 @@ Bech32 Val: cosmosvaloper1z3t55m0l9h0eupuz3dp5t5cypyv674jjn4d6nn
 ```
 
 ```bash Hex to Bech32
-$ appd debug addr 14574A6DFF2DDF9E07828B4345D3040919AF5652
+$ evmd debug addr 14574A6DFF2DDF9E07828B4345D3040919AF5652
 
 Address: [20 87 74 109 255 45 223 158 7 130 139 67 69 211 4 9 25 175 86 82]
 Address (hex): 14574A6DFF2DDF9E07828B4345D3040919AF5652
@@ -155,7 +155,7 @@ Bech32 Val: cosmosvaloper1z3t55m0l9h0eupuz3dp5t5cypyv674jjn4d6nn
 ### Key output
 
 <Check>
-  The Cosmos SDK Keyring output (i.e `appd keys`) only supports addresses and public keys in Bech32 format.
+  The Cosmos SDK Keyring output (i.e `evmd keys`) only supports addresses and public keys in Bech32 format.
 </Check>
 
 We can use the `keys show` command with the flag `--bech <type>` to obtain different address formats:
@@ -163,7 +163,7 @@ We can use the `keys show` command with the flag `--bech <type>` to obtain diffe
 <Tabs>
   <Tab title="Account (acc)">
     ```bash
-    $ appd keys show dev0 --bech acc
+    $ evmd keys show dev0 --bech acc
 
     - name: dev0
       type: local
@@ -175,7 +175,7 @@ We can use the `keys show` command with the flag `--bech <type>` to obtain diffe
 
   <Tab title="Validator (val)">
     ```bash
-    $ appd keys show dev0 --bech val
+    $ evmd keys show dev0 --bech val
 
     - name: dev0
       type: local
@@ -187,7 +187,7 @@ We can use the `keys show` command with the flag `--bech <type>` to obtain diffe
 
   <Tab title="Consensus (cons)">
     ```bash
-    $ appd keys show dev0 --bech cons
+    $ evmd keys show dev0 --bech cons
 
     - name: dev0
       type: local
@@ -206,7 +206,7 @@ You can query an account address using CLI, gRPC, REST, or JSON-RPC:
   <Tab title="CLI">
     ```bash "Query Account via CLI" expandable
     # NOTE: the --output (-o) flag defines the output format
-    appd q auth account $(appd keys show dev0 -a) -o text
+    evmd q auth account $(evmd keys show dev0 -a) -o text
 
     '@type': /ethermint.types.v1.EthAccount
     base_account:

--- a/docs/next/documentation/concepts/mempool.mdx
+++ b/docs/next/documentation/concepts/mempool.mdx
@@ -306,7 +306,7 @@ func customPriorityFunction(goCtx context.Context, tx sdk.Tx) math.Int {
         return math.ZeroInt()
     }
     
-    fee := feeTx.GetFee().AmountOf("uatom")
+    fee := feeTx.GetFee().AmountOf("test")
     gas := feeTx.GetGas()
     if gas == 0 {
         return fee

--- a/docs/next/documentation/concepts/migrations.mdx
+++ b/docs/next/documentation/concepts/migrations.mdx
@@ -9,19 +9,19 @@ icon: "git-branch"
 Export state with:
 
 ```
-appd export > new_genesis.json
+evmd export > new_genesis.json
 ```
 
 You can also export state from a particular height (at the end of processing the block of that height):
 
 ```
-appd export --height [height] > new_genesis.json
+evmd export --height [height] > new_genesis.json
 ```
 
 If you plan to start a new network for 0 height (i.e genesis) from the exported state, export with the `--for-zero-height` flag:
 
 ```
-appd export --height [height] --for-zero-height > new_genesis.json
+evmd export --height [height] --for-zero-height > new_genesis.json
 ```
 
 ## Manually Migrate State[​](#manually-migrate-state "Direct link to Manually Migrate State")
@@ -39,6 +39,6 @@ At this point, you might want to run a script to update the exported genesis int
 You can use the `migrate` command to migrate from a given version to the next one (eg: `v0.X.X` to `v1.X.X`):
 
 ```
-appd migrate TARGET_VERSION GENESIS_FILE --chain-id=<new_chain_id> --genesis-time=<yyyy-mm-ddThh:mm:ssZ>
+evmd migrate TARGET_VERSION GENESIS_FILE --chain-id=<new_chain_id> --genesis-time=<yyyy-mm-ddThh:mm:ssZ>
 ```
 

--- a/docs/next/documentation/concepts/precision-handling.mdx
+++ b/docs/next/documentation/concepts/precision-handling.mdx
@@ -8,7 +8,7 @@ icon: "calculator"
 
 Cosmos SDK and Ethereum use different decimal precisions for their native tokens:
 
-- **Cosmos SDK**: 6 decimals (1 ATOM = 10^6 uatom)
+- **Cosmos SDK**: 6 decimals (1 ATOM = 10^6 test)
 - **Ethereum**: 18 decimals (1 ETH = 10^18 wei)
 
 This 12-decimal difference creates challenges when bridging the two ecosystems. Simply scaling values would lose precision or create rounding errors.
@@ -30,22 +30,22 @@ a(n) = b(n) × C + f(n)
 ```
 
 Where:
-- `a(n)` = Total balance in 18-decimal units (aatom)
-- `b(n)` = Integer balance in 6-decimal units (uatom)
+- `a(n)` = Total balance in 18-decimal units (atest)
+- `b(n)` = Integer balance in 6-decimal units (test)
 - `f(n)` = Fractional balance (remainder)
 - `C` = Conversion factor (10^12)
 - Constraint: `0 ≤ f(n) < C`
 
 ### Example Decomposition
 
-Consider a balance of 1,234,567,890,123,456,789 aatom:
+Consider a balance of 1,234,567,890,123,456,789 atest:
 
 ```
 1,234,567,890,123,456,789 = 1,234,567 × 10^12 + 890,123,456,789
 
 Where:
-- b(n) = 1,234,567 uatom (stored in bank)
-- f(n) = 890,123,456,789 aatom (stored in precisebank)
+- b(n) = 1,234,567 test (stored in bank)
+- f(n) = 890,123,456,789 atest (stored in precisebank)
 - Total = 1.234567890123456789 ATOM
 ```
 
@@ -65,7 +65,7 @@ b(R) × C = Σf(n) + r
 ```
 
 Where:
-- `b(R)` = Reserve balance in uatom
+- `b(R)` = Reserve balance in test
 - `Σf(n)` = Sum of all account fractional balances
 - `r` = Remainder (fractional amount not in circulation)
 - Constraint: `0 ≤ r < C`
@@ -74,10 +74,10 @@ Where:
 
 This ensures the fundamental invariant:
 ```
-Total_aatom = Total_uatom × 10^12 - remainder
+Total_atest = Total_test × 10^12 - remainder
 ```
 
-The remainder represents sub-uatom amounts that exist in the system but aren't assigned to any specific account.
+The remainder represents sub-test amounts that exist in the system but aren't assigned to any specific account.
 
 ## Operation Algorithms
 
@@ -158,32 +158,32 @@ The system manages three precision levels:
 | Unit | Precision | Decimals | Usage |
 |------|-----------|----------|-------|
 | **ATOM** | 10^0 | 0 | Human display |
-| **uatom** | 10^-6 | 6 | Cosmos native |
-| **aatom** | 10^-18 | 18 | EVM native |
+| **test** | 10^-6 | 6 | Cosmos native |
+| **atest** | 10^-18 | 18 | EVM native |
 
 ### Conversion Examples
 
 ```
-1 ATOM = 1,000,000 uatom = 1,000,000,000,000,000,000 aatom
-0.000001 ATOM = 1 uatom = 1,000,000,000,000 aatom
-0.000000000000000001 ATOM = 0.000000000001 uatom = 1 aatom
+1 ATOM = 1,000,000 test = 1,000,000,000,000,000,000 atest
+0.000001 ATOM = 1 test = 1,000,000,000,000 atest
+0.000000000000000001 ATOM = 0.000000000001 test = 1 atest
 ```
 
 ## Edge Cases and Limits
 
 ### Minimum Transferable Amount
-- **In Cosmos**: 1 uatom (0.000001 ATOM)
-- **In EVM**: 1 aatom (0.000000000000000001 ATOM)
+- **In Cosmos**: 1 test (0.000001 ATOM)
+- **In EVM**: 1 atest (0.000000000000000001 ATOM)
 
 ### Maximum Precision
-- **Cosmos operations**: Limited to uatom granularity
-- **EVM operations**: Full aatom precision
+- **Cosmos operations**: Limited to test granularity
+- **EVM operations**: Full atest precision
 - **Cross-system**: Automatic precision handling
 
 ### Dust Amounts
-Amounts smaller than 1 uatom but larger than 0 aatom:
+Amounts smaller than 1 test but larger than 0 atest:
 - Tracked in fractional balances
-- Accumulate until reaching 1 uatom
+- Accumulate until reaching 1 test
 - Never lost or rounded away
 
 ## Implementation Strategy
@@ -212,7 +212,7 @@ This single multiplication and addition reconstructs the full 18-decimal balance
 ## Why This Matters
 
 ### For Users
-- **No precision loss**: Every aatom is accounted for
+- **No precision loss**: Every atest is accounted for
 - **Seamless experience**: Automatic handling across systems
 - **Fair transactions**: No rounding advantages or disadvantages
 
@@ -233,7 +233,7 @@ This single multiplication and addition reconstructs the full 18-decimal balance
 // Naive approach - loses precision
 evmAmount = cosmosAmount * 10^12
 ```
-**Problems**: Loses sub-uatom amounts, rounding errors accumulate
+**Problems**: Loses sub-test amounts, rounding errors accumulate
 
 ### Fixed-Point Arithmetic
 ```
@@ -245,8 +245,8 @@ amount = FixedPoint{mantissa: 123456, exponent: -18}
 ### Separate Balances
 ```
 // Maintain two separate balance systems
-cosmosBalance: 1000000 uatom
-evmBalance: 1000000000000000000 aatom
+cosmosBalance: 1000000 test
+evmBalance: 1000000000000000000 atest
 ```
 **Problems**: Synchronization issues, double accounting, complexity
 

--- a/docs/next/documentation/concepts/single-token-representation.mdx
+++ b/docs/next/documentation/concepts/single-token-representation.mdx
@@ -38,13 +38,13 @@ Unlike wrapped tokens that require contract calls, STRv2 tokens operate at nativ
 A TokenPair links a Cosmos denomination with an ERC20 contract address, establishing the canonical mapping:
 
 ```
-Cosmos Coin (uatom) ←→ TokenPair ←→ ERC20 Contract (0x...)
+Cosmos Coin (test) ←→ TokenPair ←→ ERC20 Contract (0x...)
 ```
 
 ### Origin Types
 
 **Native Cosmos Coins**
-- Start as Cosmos SDK coins (uatom, uosmo, etc.)
+- Start as Cosmos SDK coins (test, uosmo, etc.)
 - Module deploys an ERC20 contract representation
 - Contract owned by module (OWNER_MODULE)
 - Conversions use mint/burn mechanism

--- a/docs/next/documentation/concepts/tokens.mdx
+++ b/docs/next/documentation/concepts/tokens.mdx
@@ -7,7 +7,7 @@ icon: "coins"
 * Cosmos tokens issued by the `x/bank` module
 * Ethereum-typed tokens, e.g. ERC-20, issued by the EVM
 
-`1 stake = 10<sup>18</sup> astake`
+`1 stake = 10<sup>18</sup> atest`
 
 This matches Ethereum denomination of:
 

--- a/docs/next/documentation/cosmos-sdk/cli.mdx
+++ b/docs/next/documentation/cosmos-sdk/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Command Line Interface (CLI)"
-description: "The CLI tool ('appd') provides a full-feature interface for interacting with the blockchain. This includes commands for node operations, key management, querying blockchain state, submitting transactions, and more."
+description: "The CLI tool ('evmd') provides a full-feature interface for interacting with the blockchain. This includes commands for node operations, key management, querying blockchain state, submitting transactions, and more."
 ---
 
 import { footnote } from '/snippets/footnote.mdx'
@@ -8,10 +8,10 @@ import { footnote } from '/snippets/footnote.mdx'
 <Info>
 **Node Requirements**
 
-To use the `query` and `tx` commands, your `appd` node must either:
+To use the `query` and `tx` commands, your `evmd` node must either:
 
 - Be fully synced with the network you're interacting with, OR
-- Be configured to use an external RPC endpoint in `~/.appd/config/client.toml`
+- Be configured to use an external RPC endpoint in `~/.evmd/config/client.toml`
 
 Example client.toml configuration:
 
@@ -39,11 +39,11 @@ These flags are available for all commands:
 |------|-------------|---------|
 | `-b, --broadcast-mode` | Transaction broadcasting mode (sync\|async) | `sync` |
 | `--chain-id` | Specify Chain ID for sending Tx | |
-| `--fees` | Fees to pay along with transaction (e.g., 10ustake) | |
+| `--fees` | Fees to pay along with transaction (e.g., 10atest) | |
 | `--from` | Name or address of private key with which to sign | |
 | `--gas-adjustment` | Adjustment factor to multiply against the estimate returned by tx simulation | `1` |
-| `--gas-prices` | Gas prices to determine the transaction fee (e.g., 10ustake) | |
-| `--home` | Directory for config and data | `~/.appd` |
+| `--gas-prices` | Gas prices to determine the transaction fee (e.g., 10atest) | |
+| `--home` | Directory for config and data | `~/.evmd` |
 | `--keyring-backend` | Select keyring's backend | `os` |
 | `--log_format` | The logging format (json\|plain) | `plain` |
 | `--log_level` | The logging level | `info` |
@@ -60,17 +60,17 @@ These flags are available for all commands:
 
 <CodeGroup>
 ```bash Basic
-appd start
+evmd start
 ```
 
 ```bash "With JSON-RPC"
-appd start \
+evmd start \
   --json-rpc.enable \
   --json-rpc.api eth,net,web3,txpool
 ```
 
 ```bash "Full Configuration"
-appd start \
+evmd start \
   --json-rpc.enable \
   --json-rpc.address 0.0.0.0:8545 \
   --json-rpc.ws-address 0.0.0.0:8546 \
@@ -84,18 +84,18 @@ appd start \
 
 <CodeGroup>
 ```bash "Basic Init"
-appd init my-node --chain-id cosmos-evm-1
+evmd init my-node --chain-id cosmos-evm-1
 ```
 
 ```bash "Custom Settings"
-appd init my-validator \
+evmd init my-validator \
   --chain-id cosmos-evm-1 \
-  --default-denom aatom \
+  --default-denom atest \
   --initial-height 1
 ```
 
 ```bash "Overwrite Existing"
-appd init my-node \
+evmd init my-node \
   --chain-id cosmos-evm-1 \
   --overwrite
 ```
@@ -104,18 +104,18 @@ appd init my-node \
 ### Node Status
 
 ```bash
-appd status
+evmd status
 ```
 
 ### Transaction Indexing
 
 <CodeGroup>
 ```bash "Index Forward"
-appd index-eth-tx forward
+evmd index-eth-tx forward
 ```
 
 ```bash "Index Backward"
-appd index-eth-tx backward
+evmd index-eth-tx backward
 ```
 </CodeGroup>
 
@@ -126,15 +126,15 @@ appd index-eth-tx backward
 
 <CodeGroup>
 ```bash "Create New Key"
-appd keys add my-account
+evmd keys add my-account
 ```
 
 ```bash "Recover from Mnemonic"
-appd keys add my-account --recover
+evmd keys add my-account --recover
 ```
 
 ```bash "Create ETH Key"
-appd keys add my-eth-account \
+evmd keys add my-eth-account \
   --algo eth_secp256k1 \
   --coin-type 60
 ```
@@ -144,23 +144,23 @@ appd keys add my-eth-account \
 
 <CodeGroup>
 ```bash "List All Keys"
-appd keys list
+evmd keys list
 ```
 
 ```bash "Show Key Info"
-appd keys show my-account
+evmd keys show my-account
 ```
 
 ```bash "Show Address Only"
-appd keys show my-account --address
+evmd keys show my-account --address
 ```
 
 ```bash "Export Key"
-appd keys export my-account
+evmd keys export my-account
 ```
 
 ```bash "Import Key"
-appd keys import new-account keyfile.json
+evmd keys import new-account keyfile.json
 ```
 </CodeGroup>
 
@@ -168,11 +168,11 @@ appd keys import new-account keyfile.json
 
 <CodeGroup>
 ```bash "Export ETH Key"
-appd keys unsafe-export-eth-key my-eth-account
+evmd keys unsafe-export-eth-key my-eth-account
 ```
 
 ```bash "Import ETH Key"
-appd keys unsafe-import-eth-key imported-account 0x...
+evmd keys unsafe-import-eth-key imported-account 0x...
 ```
 </CodeGroup>
 
@@ -183,15 +183,15 @@ appd keys unsafe-import-eth-key imported-account 0x...
 
 <CodeGroup>
 ```bash "Account Info"
-appd query evm account 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb81
+evmd query evm account 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb81
 ```
 
 ```bash "Bank Balance"
-appd query evm balance-bank 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb81 aatom
+evmd query evm balance-bank 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb81 atest
 ```
 
 ```bash "ERC20 Balance"
-appd query evm balance-erc20 \
+evmd query evm balance-erc20 \
   0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb81 \
   0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
 ```
@@ -201,11 +201,11 @@ appd query evm balance-erc20 \
 
 <CodeGroup>
 ```bash "Get Contract Code"
-appd query evm code 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+evmd query evm code 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
 ```
 
 ```bash "Get Storage Value"
-appd query evm storage \
+evmd query evm storage \
   0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 \
   0x0000000000000000000000000000000000000000000000000000000000000001
 ```
@@ -215,11 +215,11 @@ appd query evm storage \
 
 <CodeGroup>
 ```bash "EVM Config"
-appd query evm config
+evmd query evm config
 ```
 
 ```bash "EVM Params"
-appd query evm params
+evmd query evm params
 ```
 </CodeGroup>
 
@@ -227,11 +227,11 @@ appd query evm params
 
 <CodeGroup>
 ```bash "0x to Bech32"
-appd query evm 0x-to-bech32 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb81
+evmd query evm 0x-to-bech32 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb81
 ```
 
 ```bash "Bech32 to 0x"
-appd query evm bech32-to-0x cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s
+evmd query evm bech32-to-0x cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s
 ```
 </CodeGroup>
 
@@ -242,19 +242,19 @@ appd query evm bech32-to-0x cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s
 
 <CodeGroup>
 ```bash "All Token Pairs"
-appd query erc20 token-pairs
+evmd query erc20 token-pairs
 ```
 
 ```bash "Specific Token Pair"
-appd query erc20 token-pair 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+evmd query erc20 token-pair 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
 ```
 
 ```bash "Query by Denom"
-appd query erc20 token-pair usdc
+evmd query erc20 token-pair usdc
 ```
 
 ```bash "Module Parameters"
-appd query erc20 params
+evmd query erc20 params
 ```
 </CodeGroup>
 
@@ -265,15 +265,15 @@ appd query erc20 params
 
 <CodeGroup>
 ```bash "Current Base Fee"
-appd query feemarket base-fee
+evmd query feemarket base-fee
 ```
 
 ```bash "Block Gas Usage"
-appd query feemarket block-gas
+evmd query feemarket block-gas
 ```
 
 ```bash "Module Parameters"
-appd query feemarket params
+evmd query feemarket params
 ```
 </CodeGroup>
 
@@ -284,11 +284,11 @@ appd query feemarket params
 
 <CodeGroup>
 ```bash "Module Remainder"
-appd query precisebank remainder
+evmd query precisebank remainder
 ```
 
 ```bash "Fractional Balance"
-appd query precisebank fractional-balance cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s
+evmd query precisebank fractional-balance cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s
 ```
 </CodeGroup>
 
@@ -299,15 +299,15 @@ appd query precisebank fractional-balance cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04
 
 <CodeGroup>
 ```bash "All Balances"
-appd query bank balances cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s
+evmd query bank balances cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s
 ```
 
 ```bash "Specific Denom"
-appd query bank balance cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s aatom
+evmd query bank balance cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s atest
 ```
 
 ```bash "Total Supply"
-appd query bank total
+evmd query bank total
 ```
 </CodeGroup>
 
@@ -315,15 +315,15 @@ appd query bank total
 
 <CodeGroup>
 ```bash "All Validators"
-appd query staking validators
+evmd query staking validators
 ```
 
 ```bash "Delegations"
-appd query staking delegations cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s
+evmd query staking delegations cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s
 ```
 
 ```bash "Unbonding"
-appd query staking unbonding-delegations cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s
+evmd query staking unbonding-delegations cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s
 ```
 </CodeGroup>
 
@@ -331,13 +331,13 @@ appd query staking unbonding-delegations cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04s
 
 <CodeGroup>
 ```bash "Delegation Rewards"
-appd query distribution rewards \
+evmd query distribution rewards \
   cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s \
   cosmosvaloper1xyz...
 ```
 
 ```bash "Validator Commission"
-appd query distribution commission cosmosvaloper1xyz...
+evmd query distribution commission cosmosvaloper1xyz...
 ```
 </CodeGroup>
 
@@ -345,15 +345,15 @@ appd query distribution commission cosmosvaloper1xyz...
 
 <CodeGroup>
 ```bash "All Proposals"
-appd query gov proposals
+evmd query gov proposals
 ```
 
 ```bash "Specific Proposal"
-appd query gov proposal 1
+evmd query gov proposal 1
 ```
 
 ```bash "Proposal Votes"
-appd query gov votes 1
+evmd query gov votes 1
 ```
 </CodeGroup>
 
@@ -364,15 +364,15 @@ appd query gov votes 1
 
 <CodeGroup>
 ```bash "Send Transaction"
-appd tx evm send \
+evmd tx evm send \
   my-account \
   0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb81 \
-  1000000aatom \
-  --gas-prices 10aatom
+  1000000atest \
+  --gas-prices 10atest
 ```
 
 ```bash "Raw Transaction"
-appd tx evm raw \
+evmd tx evm raw \
   0xf86c0485... \
   --from my-account
 ```
@@ -385,15 +385,15 @@ appd tx evm raw \
 
 <CodeGroup>
 ```bash "Coin to ERC20"
-appd tx erc20 convert-coin \
-  1000000aatom \
+evmd tx erc20 convert-coin \
+  1000000atest \
   0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb81 \
   --from my-account \
-  --gas-prices 10aatom
+  --gas-prices 10atest
 ```
 
 ```bash "ERC20 to Coin"
-appd tx erc20 convert-erc20 \
+evmd tx erc20 convert-erc20 \
   0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 \
   1000000 \
   cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s \
@@ -405,13 +405,13 @@ appd tx erc20 convert-erc20 \
 
 <CodeGroup>
 ```bash "Register ERC20"
-appd tx erc20 register-erc20 \
+evmd tx erc20 register-erc20 \
   0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 \
   --from validator
 ```
 
 ```bash "Toggle Conversion"
-appd tx erc20 toggle-conversion \
+evmd tx erc20 toggle-conversion \
   0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 \
   --from validator
 ```
@@ -424,19 +424,19 @@ appd tx erc20 toggle-conversion \
 
 <CodeGroup>
 ```bash "Send Tokens"
-appd tx bank send \
+evmd tx bank send \
   my-account \
   cosmos1abc... \
-  1000000aatom \
-  --gas-prices 10aatom
+  1000000atest \
+  --gas-prices 10atest
 ```
 
 ```bash "Multi-Send"
-appd tx bank multi-send \
+evmd tx bank multi-send \
   my-account \
-  cosmos1abc... 500000aatom \
-  cosmos1xyz... 500000aatom \
-  --gas-prices 10aatom
+  cosmos1abc... 500000atest \
+  cosmos1xyz... 500000atest \
+  --gas-prices 10atest
 ```
 </CodeGroup>
 
@@ -444,25 +444,25 @@ appd tx bank multi-send \
 
 <CodeGroup>
 ```bash "Delegate"
-appd tx staking delegate \
+evmd tx staking delegate \
   cosmosvaloper1abc... \
-  1000000aatom \
+  1000000atest \
   --from my-account \
-  --gas-prices 10aatom
+  --gas-prices 10atest
 ```
 
 ```bash "Unbond"
-appd tx staking unbond \
+evmd tx staking unbond \
   cosmosvaloper1abc... \
-  1000000aatom \
+  1000000atest \
   --from my-account
 ```
 
 ```bash "Redelegate"
-appd tx staking redelegate \
+evmd tx staking redelegate \
   cosmosvaloper1abc... \
   cosmosvaloper1xyz... \
-  1000000aatom \
+  1000000atest \
   --from my-account
 ```
 </CodeGroup>
@@ -471,22 +471,22 @@ appd tx staking redelegate \
 
 <CodeGroup>
 ```bash "Submit Proposal"
-appd tx gov submit-proposal \
+evmd tx gov submit-proposal \
   --title="Upgrade Proposal" \
   --description="Upgrade to v2.0.0" \
   --type="Text" \
-  --deposit="1000000aatom" \
+  --deposit="1000000atest" \
   --from my-account
 ```
 
 ```bash "Vote"
-appd tx gov vote 1 yes \
+evmd tx gov vote 1 yes \
   --from my-account \
-  --gas-prices 10aatom
+  --gas-prices 10atest
 ```
 
 ```bash "Deposit"
-appd tx gov deposit 1 1000000aatom \
+evmd tx gov deposit 1 1000000atest \
   --from my-account
 ```
 </CodeGroup>
@@ -498,20 +498,20 @@ appd tx gov deposit 1 1000000aatom \
 
 <CodeGroup>
 ```bash "Add Account"
-appd genesis add-genesis-account \
+evmd genesis add-genesis-account \
   cosmos1abc... \
-  1000000000aatom
+  1000000000atest
 ```
 
 ```bash "Create GenTx"
-appd genesis gentx \
+evmd genesis gentx \
   my-validator \
-  1000000aatom \
+  1000000atest \
   --chain-id cosmos-evm-1
 ```
 
 ```bash "Collect GenTxs"
-appd genesis collect-gentxs
+evmd genesis collect-gentxs
 ```
 </CodeGroup>
 
@@ -519,15 +519,15 @@ appd genesis collect-gentxs
 
 <CodeGroup>
 ```bash "Show Node ID"
-appd comet show-node-id
+evmd comet show-node-id
 ```
 
 ```bash "Show Validator"
-appd comet show-validator
+evmd comet show-validator
 ```
 
 ```bash "Reset State"
-appd comet unsafe-reset-all
+evmd comet unsafe-reset-all
 ```
 </CodeGroup>
 
@@ -535,15 +535,15 @@ appd comet unsafe-reset-all
 
 <CodeGroup>
 ```bash "Address Info"
-appd debug addr cosmos1abc...
+evmd debug addr cosmos1abc...
 ```
 
 ```bash "Decode Hex"
-appd debug raw-bytes 0xdeadbeef
+evmd debug raw-bytes 0xdeadbeef
 ```
 
 ```bash "Public Key"
-appd debug pubkey '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"...."}'
+evmd debug pubkey '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"...."}'
 ```
 </CodeGroup>
 
@@ -559,7 +559,7 @@ appd debug pubkey '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"...."}'
     <CodeGroup>
     ```bash "Create Account"
     # Create new Cosmos account
-    appd keys add my-account
+    evmd keys add my-account
     
     # Save mnemonic safely!
     # Address will be shown as cosmos1...
@@ -567,23 +567,23 @@ appd debug pubkey '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"...."}'
     
     ```bash "Import ETH Key"
     # Import existing Ethereum private key
-    appd keys unsafe-import-eth-key \
+    evmd keys unsafe-import-eth-key \
       eth-account \
       0x1234567890abcdef...
     
     # Show the imported account
-    appd keys show eth-account
+    evmd keys show eth-account
     ```
     
     ```bash "List & Export"
     # List all accounts
-    appd keys list
+    evmd keys list
     
     # Export account (encrypted)
-    appd keys export my-account > account.backup
+    evmd keys export my-account > account.backup
     
     # Show account address only
-    appd keys show my-account --address
+    evmd keys show my-account --address
     ```
     </CodeGroup>
   </Tab>
@@ -592,35 +592,35 @@ appd debug pubkey '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"...."}'
     <CodeGroup>
     ```bash "Account Info"
     # Query Cosmos account
-    appd query bank balances \
+    evmd query bank balances \
       cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s
     
     # Query EVM account
-    appd query evm account \
+    evmd query evm account \
       0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb81
     ```
     
     ```bash "Token Balances"
     # Native token balance
-    appd query bank balance \
+    evmd query bank balance \
       cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s \
-      aatom
+      atest
     
     # ERC20 token balance
-    appd query evm balance-erc20 \
+    evmd query evm balance-erc20 \
       0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb81 \
       0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
     ```
     
     ```bash "Network State"
     # Current base fee
-    appd query feemarket base-fee
+    evmd query feemarket base-fee
     
     # Node sync status
-    appd status | jq .sync_info
+    evmd status | jq .sync_info
     
     # Latest block height
-    appd status | jq .sync_info.latest_block_height
+    evmd status | jq .sync_info.latest_block_height
     ```
     </CodeGroup>
   </Tab>
@@ -629,33 +629,33 @@ appd debug pubkey '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"...."}'
     <CodeGroup>
     ```bash "Native Transfer"
     # Send tokens via bank module
-    appd tx bank send \
+    evmd tx bank send \
       my-account \
       cosmos1abc... \
-      1000000aatom \
-      --gas-prices 10aatom \
+      1000000atest \
+      --gas-prices 10atest \
       --gas-adjustment 1.5
     ```
     
     ```bash "EVM Transfer"
     # Send via EVM module
-    appd tx evm send \
+    evmd tx evm send \
       my-account \
       0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb81 \
-      1000000aatom \
-      --gas-prices 10aatom
+      1000000atest \
+      --gas-prices 10atest
     ```
     
     ```bash "Token Conversion"
     # Convert native to ERC20
-    appd tx erc20 convert-coin \
-      1000000aatom \
+    evmd tx erc20 convert-coin \
+      1000000atest \
       0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb81 \
       --from my-account \
-      --gas-prices 10aatom
+      --gas-prices 10atest
     
     # Convert ERC20 to native
-    appd tx erc20 convert-erc20 \
+    evmd tx erc20 convert-erc20 \
       0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 \
       1000000 \
       cosmos1wsk4trnzfszs55jlt5ugz76lwl2hp04slh5s5s \
@@ -667,9 +667,9 @@ appd debug pubkey '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"...."}'
 
 ## Configuration
 
-- Configuration directory: `~/.appd/`
+- Configuration directory: `~/.evmd/`
 - Key storage: Managed by the keyring backend (os, file, test)
-- Node configuration: `~/.appd/config/config.toml`
-- App configuration: `~/.appd/config/app.toml`
+- Node configuration: `~/.evmd/config/config.toml`
+- App configuration: `~/.evmd/config/app.toml`
 
 <Info>If you use the `--home` flag upon initializing the light client, the root/config directory will be generated there</Info>

--- a/docs/next/documentation/cosmos-sdk/modules/erc20.mdx
+++ b/docs/next/documentation/cosmos-sdk/modules/erc20.mdx
@@ -320,13 +320,13 @@ evmd query erc20 params
 evmd query erc20 token-pairs
 
 # Query specific token pair
-evmd query erc20 token-pair uatom
+evmd query erc20 token-pair test
 evmd query erc20 token-pair 0x80b5a32e4f032b2a058b4f29ec95eefeeb87adcd
 ```
 
 ```bash Convert-Tokens
 # Convert Cosmos coin to ERC20
-evmd tx erc20 convert-coin 100uatom 0xReceiverAddress --from mykey
+evmd tx erc20 convert-coin 100test 0xReceiverAddress --from mykey
 
 # Convert ERC20 to Cosmos coin
 evmd tx erc20 convert-erc20 0xTokenAddress 100000000000000000000 cosmos1receiver --from mykey
@@ -366,7 +366,7 @@ await dexRouter.swapExactTokensForTokens(...);
 const packet = {
     sender: "cosmos1...",
     receiver: "0x...",  // EVM address triggers conversion
-    token: { denom: "uatom", amount: "1000000" }
+    token: { denom: "test", amount: "1000000" }
 };
 // Token arrives as ERC20 in receiver's EVM account
 ```
@@ -379,7 +379,7 @@ await client.signAndBroadcast(address, [
     {
         typeUrl: "/cosmos.evm.erc20.v1.MsgConvertCoin",
         value: {
-            coin: { denom: "uatom", amount: "1000000" },
+            coin: { denom: "test", amount: "1000000" },
             receiver: "0xEthereumAddress",
             sender: "cosmos1..."
         }
@@ -441,7 +441,7 @@ await client.signAndBroadcast(address, [
 
 ```bash
 # Check if token is registered
-evmd query erc20 token-pair uatom
+evmd query erc20 token-pair test
 
 # Check module parameters
 evmd query erc20 params

--- a/docs/next/documentation/cosmos-sdk/modules/feemarket.mdx
+++ b/docs/next/documentation/cosmos-sdk/modules/feemarket.mdx
@@ -184,7 +184,7 @@ Submit with:
 # Source: github.com/cosmos/evm/blob/v0.4.1/x/feemarket/keeper/msg_server.go#L17-L39
 evmd tx gov submit-proposal update-feemarket-params.json \
   --from <key> \
-  --deposit 1000000000stake
+  --deposit 1000000000test
 ```
 
 ## Best Practices

--- a/docs/next/documentation/cosmos-sdk/modules/precisebank.mdx
+++ b/docs/next/documentation/cosmos-sdk/modules/precisebank.mdx
@@ -16,7 +16,7 @@ The module acts as a wrapper around `x/bank`, providing:
 - **18 decimal precision** for EVM (10^18 sub-atomic units)
 - **Backward compatibility** with 6 decimal Cosmos operations
 - **Transparent conversion** between precision levels
-- **Fractional balance tracking** for sub-uatom amounts
+- **Fractional balance tracking** for sub-test amounts
 
 <Note>
   Developed with contributions from the [Kava](https://www.kava.io/) team.
@@ -35,13 +35,13 @@ The module maintains fractional balances and remainder ([source](https://github.
 
 Full balance calculation:
 ```
-aatom_balance = uatom_balance × 10^12 + fractional_balance
+atest_balance = test_balance × 10^12 + fractional_balance
 ```
 
 Where:
-- `uatom_balance`: Stored in x/bank (6 decimals)
+- `test_balance`: Stored in x/bank (6 decimals)
 - `fractional_balance`: Stored in x/precisebank (0 to 10^12-1)
-- `aatom_balance`: Full 18-decimal precision
+- `atest_balance`: Full 18-decimal precision
 
 ## Keeper Interface
 
@@ -66,9 +66,9 @@ type Keeper interface {
 
 ### Extended Coin Support
 
-Automatic handling of "aatom" denomination:
-- Converts between uatom and aatom transparently
-- Maintains fractional balances for sub-uatom amounts
+Automatic handling of "atest" denomination:
+- Converts between test and atest transparently
+- Maintains fractional balances for sub-test amounts
 - Ensures consistency between x/bank and x/precisebank
 
 ## Operations
@@ -80,7 +80,7 @@ Handles both integer and fractional components:
 ```go
 // SendCoins automatically handles precision
 keeper.SendCoins(ctx, from, to, sdk.NewCoins(
-    sdk.NewCoin("aatom", sdk.NewInt(1500000000000)), // 0.0015 uatom
+    sdk.NewCoin("atest", sdk.NewInt(1500000000000)), // 0.0015 test
 ))
 ```
 
@@ -97,7 +97,7 @@ Creates new tokens with proper backing:
 ```go
 // MintCoins with extended precision
 keeper.MintCoins(ctx, moduleName, sdk.NewCoins(
-    sdk.NewCoin("aatom", sdk.NewInt(1000000000000000000)), // 1 uatom
+    sdk.NewCoin("atest", sdk.NewInt(1000000000000000000)), // 1 test
 ))
 ```
 
@@ -113,7 +113,7 @@ Removes tokens from circulation:
 ```go
 // BurnCoins with extended precision
 keeper.BurnCoins(ctx, moduleName, sdk.NewCoins(
-    sdk.NewCoin("aatom", sdk.NewInt(500000000000)),  // 0.0005 uatom
+    sdk.NewCoin("atest", sdk.NewInt(500000000000)),  // 0.0005 test
 ))
 ```
 
@@ -130,7 +130,7 @@ Standard bank events with extended precision amounts:
 
 | Event | Attributes | Description |
 |-------|------------|-------------|
-| `transfer` | `sender`, `recipient`, `amount` | Full aatom amount |
+| `transfer` | `sender`, `recipient`, `amount` | Full atest amount |
 | `coin_spent` | `spender`, `amount` | Extended precision |
 | `coin_received` | `receiver`, `amount` | Extended precision |
 
@@ -170,7 +170,7 @@ service Query {
 evmd query precisebank total-fractional-balances
 
 # Example output:
-# total: "2000000000000aatom"
+# total: "2000000000000atest"
 ```
 
 ```bash Query-Remainder
@@ -178,7 +178,7 @@ evmd query precisebank total-fractional-balances
 evmd query precisebank remainder
 
 # Example output:
-# remainder: "100aatom"
+# remainder: "100atest"
 ```
 
 ```bash Query-Balance
@@ -186,7 +186,7 @@ evmd query precisebank remainder
 evmd query precisebank fractional-balance cosmos1...
 
 # Example output:
-# fractional_balance: "10000aatom"
+# fractional_balance: "10000atest"
 ```
 
 </CodeGroup>
@@ -209,12 +209,12 @@ app.EvmKeeper = evmkeeper.NewKeeper(
 Query extended balances through standard interface:
 
 ```go
-// Automatically handles aatom denomination
-balance := keeper.GetBalance(ctx, addr, "aatom")
+// Automatically handles atest denomination
+balance := keeper.GetBalance(ctx, addr, "atest")
 
 // Transfer with 18 decimal precision
 err := keeper.SendCoins(ctx, from, to, 
-    sdk.NewCoins(sdk.NewCoin("aatom", amount)))
+    sdk.NewCoins(sdk.NewCoin("atest", amount)))
 ```
 
 ## Reserve Account
@@ -222,7 +222,7 @@ err := keeper.SendCoins(ctx, from, to,
 The reserve account maintains backing for fractional balances:
 
 ```
-Reserve_uatom × 10^12 = Σ(all fractional balances) + remainder
+Reserve_test × 10^12 = Σ(all fractional balances) + remainder
 ```
 
 ### Monitoring Reserve
@@ -242,10 +242,10 @@ Critical invariants maintained by the module:
 
 | Invariant | Formula | Description |
 |-----------|---------|-------------|
-| **Supply** | `Total_aatom = Total_uatom × 10^12 - remainder` | Total supply consistency |
+| **Supply** | `Total_atest = Total_test × 10^12 - remainder` | Total supply consistency |
 | **Fractional Range** | `0 ≤ f(n) < 10^12` | Valid fractional bounds |
 | **Reserve Backing** | `Reserve × 10^12 = Σf(n) + r` | Full backing guarantee |
-| **Conservation** | `Δ(Total_aatom) = Δ(Total_uatom × 10^12)` | No creation/destruction |
+| **Conservation** | `Δ(Total_atest) = Δ(Total_test × 10^12)` | No creation/destruction |
 
 ## Best Practices
 
@@ -278,7 +278,7 @@ Critical invariants maintained by the module:
 
 1. **Balance Queries**
    ```javascript
-   // Query in aatom (18 decimals)
+   // Query in atest (18 decimals)
    const balance = await queryClient.precisebank.fractionalBalance({
        address: "cosmos1..."
    });
@@ -287,8 +287,8 @@ Critical invariants maintained by the module:
 2. **Precision Handling**
    ```javascript
    // Convert between precisions
-   const uatomAmount = aatomAmount / BigInt(10**12);
-   const aatomAmount = uatomAmount * BigInt(10**12);
+   const testAmount = atestAmount / BigInt(10**12);
+   const atestAmount = testAmount * BigInt(10**12);
    ```
 
 ## Security Considerations
@@ -332,7 +332,7 @@ Critical invariants maintained by the module:
 | Issue | Cause | Solution |
 |-------|-------|----------|
 | "fractional overflow" | Fractional > 10^12 | Check calculation logic |
-| "insufficient balance" | Including fractional | Verify full aatom balance |
+| "insufficient balance" | Including fractional | Verify full atest balance |
 | "invariant violation" | Supply mismatch | Audit reserve and remainder |
 
 ### Validation Commands
@@ -343,7 +343,7 @@ evmd query precisebank total-fractional-balances
 evmd query precisebank remainder
 
 # Check specific account
-evmd query bank balances cosmos1... --denom uatom
+evmd query bank balances cosmos1... --denom test
 evmd query precisebank fractional-balance cosmos1...
 ```
 

--- a/docs/next/documentation/cosmos-sdk/modules/vm.mdx
+++ b/docs/next/documentation/cosmos-sdk/modules/vm.mdx
@@ -34,7 +34,7 @@ Defines the token used for gas and value transfers in EVM:
 - Must be registered in bank module
 - Should have 18 decimal precision
 - Used for all EVM operations (gas, transfers, contracts)
-- Example: `"aatom"`, `"aevmos"`, `"wei"`
+- Example: `"atest"`, `"aevmos"`, `"wei"`
 </Expandable>
 
 <Expandable title="extra_eips">
@@ -504,7 +504,7 @@ finalGasUsed = gasUsed - refund
 2. **Precompile Usage**
    ```solidity
    IBank bank = IBank(0x0000000000000000000000000000000000000804);
-   uint256 balance = bank.balances(msg.sender, "aatom");
+   uint256 balance = bank.balances(msg.sender, "atest");
    ```
 
 ### dApp Integration

--- a/docs/next/documentation/evm-compatibility/overview.mdx
+++ b/docs/next/documentation/evm-compatibility/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overview"
 mode: "wide"
-keywords: ['differences', 'ethereum', 'evm', 'cosmos', 'tendermint', 'consensus', 'finality', 'json-rpc', 'compatibility', 'precompiles', 'ibc', 'mev', 'gas', 'basefee', 'reorganization', 'bft', 'validator', 'staking']
+keywords: ['differences', 'ethereum', 'evm', 'cosmos', ''CometBFT'', 'consensus', 'finality', 'json-rpc', 'compatibility', 'precompiles', 'ibc', 'mev', 'gas', 'basefee', 'reorganization', 'bft', 'validator', 'staking']
 ---
 
 The EVM module provides **developer and end-user Ethereum compatibility** for Cosmos-SDK based chains. All standard / common Ethereum dApps, tools, and workflows work seamlessly while gaining the benefits of Cosmos consensus and interoperability.
@@ -41,7 +41,7 @@ Cosmos EVM maintains all critical EVM behaviors that developers expect. The tabl
 
 ### Faster & Final Transactions
 
-**Instant Finality:** Transactions are final after one block (~2 seconds) thanks to Tendermint BFT consensus. No waiting for confirmations, no reorganizations possible.
+**Instant Finality:** Transactions are final after one block (~2 seconds) thanks to 'CometBFT' BFT consensus. No waiting for confirmations, no reorganizations possible.
 
 **Validator Set:** Fixed validator set with stake-based voting power. Requires 2/3+ stake agreement for consensus.
 
@@ -114,7 +114,7 @@ Unlike with legacy Ethermint, these values are independent.
 
 **Implementation notes:**
 - Some methods return stub values for compatibility (e.g., `eth_gasPrice` returns 0)
-- Mining-related methods are not applicable (Cosmos uses Tendermint consensus)
+- Mining-related methods are not applicable (Cosmos uses 'CometBFT' consensus)
 - `txpool` methods require experimental mempool configuration
 - Debug namespace includes functional tracing and profiling tools
 
@@ -218,7 +218,7 @@ Key breaking changes when migrating:
 -  **Production Ready:** Core EVM implementation is stable and deployed on multiple mainnets
 -  **Enhanced Security:** No reorganization attacks possible due to instant finality
 -  **Byzantine Fault Tolerant:** Requires 2/3+ validator stake for any state changes
--  **Proven Stack:** Built on Cosmos SDK and Tendermint, powering hundreds of chains
+-  **Proven Stack:** Built on Cosmos SDK and 'CometBFT', powering hundreds of chains
 
 ## Resources
 

--- a/docs/next/documentation/getting-started/node-configuration.mdx
+++ b/docs/next/documentation/getting-started/node-configuration.mdx
@@ -304,7 +304,7 @@ Configure EVM-specific settings in `~/.evmd/config/app.toml`. This guide covers 
     # The minimum gas prices a validator is willing to accept for processing a
     # transaction. A transaction's fees must meet the minimum of any denomination
     # specified in this config (e.g. 0.25token1,0.0001token2).
-    minimum-gas-prices = "0aatom"
+    minimum-gas-prices = "0atest"
 
     # The maximum gas a query coming over rest/grpc may consume.
     # If this is set to zero, the query can consume an unbounded amount of gas.

--- a/docs/next/documentation/getting-started/reference-network.mdx
+++ b/docs/next/documentation/getting-started/reference-network.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Reference Network (evmd)"
-description: "Understanding the evmd reference implementation used throughout this documentation for consistent examples and testing"
+description: "Reference network used throughout this documentation"
 ---
 
 ## Overview

--- a/docs/next/documentation/getting-started/reference-network.mdx
+++ b/docs/next/documentation/getting-started/reference-network.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Reference Network (evmd)"
 description: "Understanding the evmd reference implementation used throughout this documentation for consistent examples and testing"
-icon: "network-wired"
 ---
 
 ## Overview
@@ -20,9 +19,7 @@ The intention is to provide direct examples for hands-on testing, rather than ab
 **Testing Environment**: Quickly spin up a local network using the `local-node.sh` script in the `cosmos/evm` repo
 **Integration Reference**: See exactly how the EVM module integrates with Cosmos SDK
 
-### Why Use a Reference Implementation?
-
-All examples are immediately executable:
+Code and CLI examples are immediately executable:
 
 ```bash
 evmd query bank balances cosmos1... --denom test

--- a/docs/next/documentation/getting-started/reference-network.mdx
+++ b/docs/next/documentation/getting-started/reference-network.mdx
@@ -1,0 +1,115 @@
+---
+title: "Reference Network (evmd)"
+description: "Understanding the evmd reference implementation used throughout this documentation for consistent examples and testing"
+icon: "network-wired"
+---
+
+## Overview
+
+Throughout this documentation, you'll notice consistent references to:
+- **Binary name**: `evmd`
+- **Token denominations**: `test` (6 decimals) and `atest` (18 decimals)
+
+This approach provides **concrete, testable examples** that you can immediately try out rather than abstract placeholders.
+
+## The evmd Reference Network
+
+**evmd** is the official Cosmos EVM reference implementation available in the [cosmos/evm](https://github.com/cosmos/evm) repository. It serves as:
+
+1. **Living Documentation**: Every command and example in these docs can be executed directly
+2. **Testing Environment**: Quickly spin up a local network for development and testing
+3. **Integration Reference**: See exactly how EVM modules integrate with Cosmos SDK
+
+### Why Use a Reference Implementation?
+
+All examples are immediately executable:
+```bash
+evmd query bank balances cosmos1... --denom test
+evmd start --chain-id local-1
+evmd keys add alice
+```
+
+No placeholders or generic commands - every example works directly with the evmd reference implementation.
+
+## Token Denomination System
+
+The evmd network uses a clear, consistent token system:
+
+| **Token** | **Decimals** | **Usage** | **Example Amount** |
+|-----------|--------------|-----------|-------------------|
+| `test` | 6 | Native Cosmos operations | `1000000test` = 1 TEST |
+| `atest` | 18 | EVM operations and gas | `1000000000000000000atest` = 1 TEST |
+
+**Key Point**: Both `test` and `atest` represent the same underlying token - just at different decimal precisions. Use `atest` for EVM-related operations and gas fees.
+
+This mirrors real-world Cosmos chains where tokens have both 6-decimal (native) and 18-decimal (EVM) representations.
+
+## Quick Start with evmd
+
+### 1. Get the Binary
+
+```bash
+git clone https://github.com/cosmos/evm.git
+cd evm
+make install
+```
+
+### 2. Initialize Local Network
+
+```bash
+evmd init mynode --chain-id local-1 --default-denom atest
+```
+
+### 3. Create Test Account
+
+```bash
+evmd keys add alice
+evmd genesis add-genesis-account alice 1000000000000atest
+```
+
+### 4. Start the Network
+
+```bash
+evmd start --json-rpc.enable --json-rpc.api eth,web3,net
+```
+
+Now you can execute **every example** from this documentation immediately!
+
+## Documentation Benefits
+
+Using evmd as the reference provides:
+
+###  **Consistency**
+- All CLI examples use the same binary (`evmd`)
+- All token amounts use the same denominations (`test`/`atest`)
+- All commands are copy-pasteable
+
+###  **Testability**
+- Spin up a local network in seconds
+- Test precompiles, transactions, and integrations immediately
+- Validate documentation accuracy against real implementation
+
+###  **Real-World Relevance**
+- Same patterns used by production Cosmos EVM chains
+- Actual module configurations and parameters
+- Working examples of advanced features
+
+## Adapting to Your Chain
+
+When building your own Cosmos EVM chain, the concepts and commands remain the same - just replace the reference values:
+
+- Replace `evmd` with your chain's binary name
+- Replace `test`/`atest` with your token denominations  
+- Replace `local-1` with your chain ID
+
+The documentation patterns work universally across all Cosmos EVM implementations.
+
+## Next Steps
+
+- **Try it out**: [Set up your local evmd network](/docs/next/documentation/getting-started/local-network-setup)
+- **Configure**: [Node configuration options](/docs/next/documentation/getting-started/node-configuration)
+- **Integrate**: [Add EVM to your chain config](/docs/next/documentation/integration/evm-module-integration)
+
+<Info>
+**Pro tip**: Having trouble with an example? The evmd reference network lets you test the exact command from the documentation to verify expected behavior.
+</Info>

--- a/docs/next/documentation/getting-started/reference-network.mdx
+++ b/docs/next/documentation/getting-started/reference-network.mdx
@@ -33,16 +33,11 @@ No placeholders or generic commands - every example works directly with the evmd
 
 ## Token Denomination System
 
-The evmd network uses a clear, consistent token system:
-
+The evmd network uses the EVM standard 18-decimal format for the native/staking token.
 | **Token** | **Decimals** | **Usage** | **Example Amount** |
 |-----------|--------------|-----------|-------------------|
-| `test` | 6 | Native Cosmos operations | `1000000test` = 1 TEST |
-| `atest` | 18 | EVM operations and gas | `1000000000000000000atest` = 1 TEST |
-
-**Key Point**: Both `test` and `atest` represent the same underlying token - just at different decimal precisions. Use `atest` for EVM-related operations and gas fees.
-
-This mirrors real-world Cosmos chains where tokens have both 6-decimal (native) and 18-decimal (EVM) representations.
+| `test` | 0 | Native Cosmos operations | 1 `TEST` = `1000000000000000000atest` |
+| `atest` | 18 | EVM operations and gas | `1000000000000000000atest` = 1 `TEST` |
 
 ## Quick Start with evmd
 
@@ -73,36 +68,8 @@ evmd genesis add-genesis-account alice 1000000000000atest
 evmd start --json-rpc.enable --json-rpc.api eth,web3,net
 ```
 
-Now you can execute **every example** from this documentation immediately!
+Now you can follow along with / test documentation examples verbatim.
 
-## Documentation Benefits
-
-Using evmd as the reference provides:
-
-###  **Consistency**
-- All CLI examples use the same binary (`evmd`)
-- All token amounts use the same denominations (`test`/`atest`)
-- All commands are copy-pasteable
-
-###  **Testability**
-- Spin up a local network in seconds
-- Test precompiles, transactions, and integrations immediately
-- Validate documentation accuracy against real implementation
-
-###  **Real-World Relevance**
-- Same patterns used by production Cosmos EVM chains
-- Actual module configurations and parameters
-- Working examples of advanced features
-
-## Adapting to Your Chain
-
-When building your own Cosmos EVM chain, the concepts and commands remain the same - just replace the reference values:
-
-- Replace `evmd` with your chain's binary name
-- Replace `test`/`atest` with your token denominations  
-- Replace `local-1` with your chain ID
-
-The documentation patterns work universally across all Cosmos EVM implementations.
 
 ## Next Steps
 
@@ -111,5 +78,5 @@ The documentation patterns work universally across all Cosmos EVM implementation
 - **Integrate**: [Add EVM to your chain config](/docs/next/documentation/integration/evm-module-integration)
 
 <Info>
-**Pro tip**: Having trouble with an example? The evmd reference network lets you test the exact command from the documentation to verify expected behavior.
+Having trouble understanding a concept or example? The `evmd` reference network lets you test the exact command from the documentation to verify expected behavior.
 </Info>

--- a/docs/next/documentation/getting-started/reference-network.mdx
+++ b/docs/next/documentation/getting-started/reference-network.mdx
@@ -8,21 +8,22 @@ icon: "network-wired"
 
 Throughout this documentation, you'll notice consistent references to:
 - **Binary name**: `evmd`
-- **Token denominations**: `test` (6 decimals) and `atest` (18 decimals)
+- **Token denominations**: `test` (whole token) and `atest` (18 decimals)
 
-This approach provides **concrete, testable examples** that you can immediately try out rather than abstract placeholders.
+The intention is to provide direct examples for hands-on testing, rather than abstract placeholders wherever possible.
 
 ## The evmd Reference Network
 
 **evmd** is the official Cosmos EVM reference implementation available in the [cosmos/evm](https://github.com/cosmos/evm) repository. It serves as:
 
-1. **Living Documentation**: Every command and example in these docs can be executed directly
-2. **Testing Environment**: Quickly spin up a local network for development and testing
-3. **Integration Reference**: See exactly how EVM modules integrate with Cosmos SDK
+**Living Documentation**: Most examples in these docs can be run verbatim using `evmd`
+**Testing Environment**: Quickly spin up a local network using the `local-node.sh` script in the `cosmos/evm` repo
+**Integration Reference**: See exactly how the EVM module integrates with Cosmos SDK
 
 ### Why Use a Reference Implementation?
 
 All examples are immediately executable:
+
 ```bash
 evmd query bank balances cosmos1... --denom test
 evmd start --chain-id local-1
@@ -75,8 +76,4 @@ Now you can follow along with / test documentation examples verbatim.
 
 - **Try it out**: [Set up your local evmd network](/docs/next/documentation/getting-started/local-network-setup)
 - **Configure**: [Node configuration options](/docs/next/documentation/getting-started/node-configuration)
-- **Integrate**: [Add EVM to your chain config](/docs/next/documentation/integration/evm-module-integration)
-
-<Info>
-Having trouble understanding a concept or example? The `evmd` reference network lets you test the exact command from the documentation to verify expected behavior.
-</Info>
+- **Integrate**: [Add EVM compatibility to your chain](/docs/next/documentation/integration/evm-module-integration)

--- a/docs/next/documentation/integration/evm-module-integration.mdx
+++ b/docs/next/documentation/integration/evm-module-integration.mdx
@@ -26,7 +26,7 @@ Contact [Interchain Labs](https://share-eu1.hsforms.com/2g6yO-PVaRoKj50rUgG4Pjg2
 - Basic knowledge of Go and Cosmos SDK
 
 <Note>
-Throughout this guide, `appd` refers to your chain's binary (e.g., `gaiad`, `dydxd`, etc.).
+Throughout this guide, `evmd` refers to your chain's binary (e.g., `gaiad`, `dydxd`, etc.).
 </Note>
 
 ## Version Compatibility
@@ -840,9 +840,9 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 
 ## Step 9: Update Command Files
 
-### Update cmd/appd/commands.go
+### Update cmd/evmd/commands.go
 
-```go "cmd/appd/commands.go Updates" expandable
+```go "cmd/evmd/commands.go Updates" expandable
 import (
     // Add imports
     evmcmd "github.com/cosmos/evm/client"
@@ -895,9 +895,9 @@ func initRootCmd(...) {
 }
 ```
 
-### Update cmd/appd/root.go
+### Update cmd/evmd/root.go
 
-```go "cmd/appd/root.go Updates" expandable
+```go "cmd/evmd/root.go Updates" expandable
 import (
     // ... existing imports
     evmkeyring "github.com/cosmos/evm/crypto/keyring"
@@ -965,7 +965,7 @@ If your chain requires Sign Mode Textual support, ensure your ante handler and c
 make test-all
 
 # Run EVM-specific tests
-make test-appd
+make test-evmd
 
 # Run integration tests
 make test-integration
@@ -990,7 +990,7 @@ chmod +x local_node.sh
 ### Genesis Validation
 
 ```bash
-appd genesis validate-genesis
+evmd genesis validate-genesis
 ```
 
 ---

--- a/docs/next/documentation/integration/fresh-v0.5-integration.mdx
+++ b/docs/next/documentation/integration/fresh-v0.5-integration.mdx
@@ -644,7 +644,7 @@ go build -v ./cmd/myapp
 
 ```bash Functionality Testing expandable
 # Start node
-myappd start
+myevmd start
 
 # Test JSON-RPC connectivity
 curl -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
@@ -671,13 +671,13 @@ cast call 0x0000000000000000000000000000000000000804 \
 
 ```bash
 # Verify configuration is loaded correctly
-myappd start --help | grep "evm\."
+myevmd start --help | grep "evm\."
 
 # Check genesis parameters
-myappd export | jq '.app_state.evm.params'
+myevmd export | jq '.app_state.evm.params'
 
 # Verify mempool configuration
-myappd export | jq '.app_state.erc20'
+myevmd export | jq '.app_state.erc20'
 ```
 
 ## Step 12: Production Considerations

--- a/docs/next/documentation/integration/mempool-integration.mdx
+++ b/docs/next/documentation/integration/mempool-integration.mdx
@@ -155,7 +155,7 @@ priorityConfig := sdkmempool.PriorityNonceMempoolConfig[math.Int]{
             }
 
             // Get fee in bond denomination
-            bondDenom := "uatom" // or your chain's bond denom
+            bondDenom := "test" // or your chain's bond denom
             fee := feeTx.GetFee()
             found, coin := fee.Find(bondDenom)
             if !found {

--- a/docs/next/documentation/overview.mdx
+++ b/docs/next/documentation/overview.mdx
@@ -14,7 +14,7 @@ import { EthereumIcon, CosmosLogo } from '/snippets/icons.mdx'
     Access staking, governance, IBC, and other Cosmos SDK modules directly from smart contracts
   </Card>
   <Card title="Instant Finality" icon="zap" href="/docs/next/documentation/concepts/transactions">
-    1-2 second block times with instant finality via Tendermint consensus
+    1-2 second block times with instant finality via 'CometBFT' consensus
   </Card>
   <Card title="Cross-Chain Ready" icon="globe" href="/docs/next/documentation/concepts/ibc">
     Built-in IBC support for interoperability across a growing list of ecosystems

--- a/docs/next/documentation/smart-contracts/precompiles/bank.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/bank.mdx
@@ -28,6 +28,34 @@ The Bank precompile provides ERC20-style access to native Cosmos SDK tokens, ena
 **Description**: Queries all native token balances for a specific account address and returns an array of `Balance` (ERC-20 contract address & amount) structures.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract BankExample {
+    address constant BANK_PRECOMPILE = 0x0000000000000000000000000000000000000804;
+    
+    struct Balance {
+        address contractAddress;
+        uint256 amount;
+    }
+    
+    function getAccountBalances(address account) external view returns (Balance[] memory balances) {
+        (bool success, bytes memory result) = BANK_PRECOMPILE.staticcall(
+            abi.encodeWithSignature("balances(address)", account)
+        );
+        
+        require(success, "Balance query failed");
+        balances = abi.decode(result, (Balance[]));
+        return balances;
+    }
+    
+    // Convenience function to get caller's balances
+    function getMyBalances() external view returns (Balance[] memory balances) {
+        return this.getAccountBalances(msg.sender);
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -87,6 +115,29 @@ curl -X POST --data '{
 **Description**: Queries the total supply of all native tokens in the system. Returns comprehensive supply information for every token registered in the system.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract BankExample {
+    address constant BANK_PRECOMPILE = 0x0000000000000000000000000000000000000804;
+    
+    struct Balance {
+        address contractAddress;
+        uint256 amount;
+    }
+    
+    function getTotalSupply() external view returns (Balance[] memory totalSupply) {
+        (bool success, bytes memory result) = BANK_PRECOMPILE.staticcall(
+            abi.encodeWithSignature("totalSupply()")
+        );
+        
+        require(success, "Total supply query failed");
+        totalSupply = abi.decode(result, (Balance[]));
+        return totalSupply;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -142,6 +193,30 @@ curl -X POST --data '{
 **Description**: Queries the total supply of a specific token by providing its ERC20 contract address. More efficient when you need supply information for a single token.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract BankExample {
+    address constant BANK_PRECOMPILE = 0x0000000000000000000000000000000000000804;
+    
+    function getTokenSupply(address erc20Address) external view returns (uint256 supply) {
+        (bool success, bytes memory result) = BANK_PRECOMPILE.staticcall(
+            abi.encodeWithSignature("supplyOf(address)", erc20Address)
+        );
+        
+        require(success, "Token supply query failed");
+        supply = abi.decode(result, (uint256));
+        return supply;
+    }
+    
+    // Helper function to check if token exists (has supply > 0)
+    function tokenExists(address erc20Address) external view returns (bool) {
+        uint256 supply = this.getTokenSupply(erc20Address);
+        return supply > 0;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 

--- a/docs/next/documentation/smart-contracts/precompiles/bech32.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/bech32.mdx
@@ -32,6 +32,82 @@ Both methods use a configurable base gas amount that is set during chain initial
 **Description**: Converts an Ethereum hex address to Cosmos bech32 format using the specified prefix.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Bech32Example {
+    address constant BECH32_PRECOMPILE = 0x0000000000000000000000000000000000000400;
+    
+    interface IBech32 {
+        function hexToBech32(address addr, string memory prefix) external returns (string memory bech32Address);
+        function bech32ToHex(string memory bech32Address) external returns (address addr);
+    }
+    
+    IBech32 public immutable bech32;
+    
+    event AddressConverted(address indexed hexAddress, string bech32Address, string prefix);
+    
+    constructor() {
+        bech32 = IBech32(BECH32_PRECOMPILE);
+    }
+    
+    function hexToBech32(address addr, string calldata prefix) 
+        external 
+        returns (string memory bech32Address) 
+    {
+        require(addr != address(0), "Invalid address");
+        require(bytes(prefix).length > 0, "Prefix cannot be empty");
+        
+        bech32Address = bech32.hexToBech32(addr, prefix);
+        
+        emit AddressConverted(addr, bech32Address, prefix);
+        return bech32Address;
+    }
+    
+    // Convert multiple addresses with the same prefix
+    function batchHexToBech32(address[] calldata addresses, string calldata prefix) 
+        external 
+        returns (string[] memory bech32Addresses) 
+    {
+        bech32Addresses = new string[](addresses.length);
+        
+        for (uint256 i = 0; i < addresses.length; i++) {
+            require(addresses[i] != address(0), "Invalid address in batch");
+            bech32Addresses[i] = bech32.hexToBech32(addresses[i], prefix);
+            emit AddressConverted(addresses[i], bech32Addresses[i], prefix);
+        }
+        
+        return bech32Addresses;
+    }
+    
+    // Get common address formats for a single hex address
+    function getCommonFormats(address addr) 
+        external 
+        returns (
+            string memory cosmosAddr,
+            string memory evmosAddr,
+            string memory osmosisAddr
+        ) 
+    {
+        require(addr != address(0), "Invalid address");
+        
+        cosmosAddr = bech32.hexToBech32(addr, "cosmos");
+        evmosAddr = bech32.hexToBech32(addr, "evmos");
+        osmosisAddr = bech32.hexToBech32(addr, "osmo");
+        
+        return (cosmosAddr, evmosAddr, osmosisAddr);
+    }
+    
+    // Convert caller's address to bech32 format
+    function getMyBech32Address(string calldata prefix) 
+        external 
+        returns (string memory) 
+    {
+        return bech32.hexToBech32(msg.sender, prefix);
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -93,6 +169,99 @@ curl -X POST --data '{
 **Description**: Converts a Cosmos bech32 address to Ethereum hex format.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Bech32Example {
+    address constant BECH32_PRECOMPILE = 0x0000000000000000000000000000000000000400;
+    
+    interface IBech32 {
+        function bech32ToHex(string memory bech32Address) external returns (address addr);
+        function hexToBech32(address addr, string memory prefix) external returns (string memory bech32Address);
+    }
+    
+    IBech32 public immutable bech32;
+    
+    event Bech32Converted(string bech32Address, address indexed hexAddress);
+    
+    constructor() {
+        bech32 = IBech32(BECH32_PRECOMPILE);
+    }
+    
+    function bech32ToHex(string calldata bech32Address) 
+        external 
+        returns (address hexAddress) 
+    {
+        require(bytes(bech32Address).length > 0, "Bech32 address cannot be empty");
+        
+        hexAddress = bech32.bech32ToHex(bech32Address);
+        require(hexAddress != address(0), "Invalid bech32 address");
+        
+        emit Bech32Converted(bech32Address, hexAddress);
+        return hexAddress;
+    }
+    
+    // Convert multiple bech32 addresses to hex format
+    function batchBech32ToHex(string[] calldata bech32Addresses) 
+        external 
+        returns (address[] memory hexAddresses) 
+    {
+        hexAddresses = new address[](bech32Addresses.length);
+        
+        for (uint256 i = 0; i < bech32Addresses.length; i++) {
+            require(bytes(bech32Addresses[i]).length > 0, "Invalid bech32 address");
+            hexAddresses[i] = bech32.bech32ToHex(bech32Addresses[i]);
+            require(hexAddresses[i] != address(0), "Invalid bech32 address in batch");
+            emit Bech32Converted(bech32Addresses[i], hexAddresses[i]);
+        }
+        
+        return hexAddresses;
+    }
+    
+    // Validate address conversion by converting back and forth
+    function validateAddressConversion(address addr, string calldata prefix) 
+        external 
+        returns (bool isValid) 
+    {
+        try bech32.hexToBech32(addr, prefix) returns (string memory bech32Addr) {
+            try bech32.bech32ToHex(bech32Addr) returns (address convertedBack) {
+                isValid = (convertedBack == addr);
+                return isValid;
+            } catch {
+                return false;
+            }
+        } catch {
+            return false;
+        }
+    }
+    
+    // Check if two addresses (hex and bech32) represent the same account
+    function areAddressesEqual(address hexAddr, string calldata bech32Addr) 
+        external 
+        returns (bool isEqual) 
+    {
+        try bech32.bech32ToHex(bech32Addr) returns (address convertedHex) {
+            isEqual = (convertedHex == hexAddr);
+            return isEqual;
+        } catch {
+            return false;
+        }
+    }
+    
+    // Safely convert bech32 to hex with error handling
+    function safeBech32ToHex(string calldata bech32Address) 
+        external 
+        returns (bool success, address hexAddress) 
+    {
+        try bech32.bech32ToHex(bech32Address) returns (address addr) {
+            return (true, addr);
+        } catch {
+            return (false, address(0));
+        }
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 

--- a/docs/next/documentation/smart-contracts/precompiles/bech32.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/bech32.mdx
@@ -36,13 +36,14 @@ Both methods use a configurable base gas amount that is set during chain initial
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Interface for the Bech32 precompile
+interface IBech32 {
+    function hexToBech32(address addr, string memory prefix) external returns (string memory bech32Address);
+    function bech32ToHex(string memory bech32Address) external returns (address addr);
+}
+
 contract Bech32Example {
     address constant BECH32_PRECOMPILE = 0x0000000000000000000000000000000000000400;
-    
-    interface IBech32 {
-        function hexToBech32(address addr, string memory prefix) external returns (string memory bech32Address);
-        function bech32ToHex(string memory bech32Address) external returns (address addr);
-    }
     
     IBech32 public immutable bech32;
     
@@ -173,13 +174,14 @@ curl -X POST --data '{
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Interface for the Bech32 precompile
+interface IBech32 {
+    function bech32ToHex(string memory bech32Address) external returns (address addr);
+    function hexToBech32(address addr, string memory prefix) external returns (string memory bech32Address);
+}
+
 contract Bech32Example {
     address constant BECH32_PRECOMPILE = 0x0000000000000000000000000000000000000400;
-    
-    interface IBech32 {
-        function bech32ToHex(string memory bech32Address) external returns (address addr);
-        function hexToBech32(address addr, string memory prefix) external returns (string memory bech32Address);
-    }
     
     IBech32 public immutable bech32;
     

--- a/docs/next/documentation/smart-contracts/precompiles/callbacks.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/callbacks.mdx
@@ -25,11 +25,426 @@ Critically, **only the IBC packet sender can set the callback**.
 
 **Description**: Callback function invoked on the source chain after a packet lifecycle is completed and acknowledgement is processed. The contract implementing this interface receives packet information and acknowledgement data to execute custom callback logic.
 
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract CallbacksExample {
+    // Address of the authorized IBC module
+    address public immutable ibcModule;
+    
+    // Mapping to track packet statuses
+    mapping(bytes32 => PacketStatus) public packetStatuses;
+    mapping(address => uint256) public userBalances;
+    
+    enum PacketStatus { None, Pending, Acknowledged, TimedOut }
+    
+    event PacketAcknowledged(bytes32 indexed packetId, string channelId, uint64 sequence);
+    event RefundIssued(address indexed user, uint256 amount, bytes32 indexed packetId);
+    event CrossChainOrderExecuted(bytes32 indexed packetId, address recipient, uint256 amount);
+    
+    error UnauthorizedCaller();
+    error PacketAlreadyProcessed();
+    error InvalidPacketData();
+    
+    modifier onlyIBC() {
+        if (msg.sender != ibcModule) revert UnauthorizedCaller();
+        _;
+    }
+    
+    constructor(address _ibcModule) {
+        require(_ibcModule != address(0), "Invalid IBC module address");
+        ibcModule = _ibcModule;
+    }
+    
+    function onPacketAcknowledgement(
+        string memory channelId,
+        string memory portId,
+        uint64 sequence,
+        bytes memory data,
+        bytes memory acknowledgement
+    ) external onlyIBC {
+        bytes32 packetId = keccak256(abi.encodePacked(channelId, portId, sequence));
+        
+        // Ensure packet hasn't been processed already
+        if (packetStatuses[packetId] != PacketStatus.None) {
+            revert PacketAlreadyProcessed();
+        }
+        
+        packetStatuses[packetId] = PacketStatus.Acknowledged;
+        
+        // Parse acknowledgement to determine success/failure
+        bool success = _parseAcknowledgement(acknowledgement);
+        
+        if (success) {
+            _handleSuccessfulAcknowledgement(packetId, data, acknowledgement);
+        } else {
+            _handleFailedAcknowledgement(packetId, data, acknowledgement);
+        }
+        
+        emit PacketAcknowledged(packetId, channelId, sequence);
+    }
+    
+    function _parseAcknowledgement(bytes memory acknowledgement) 
+        internal 
+        pure 
+        returns (bool success) 
+    {
+        if (acknowledgement.length == 0) return false;
+        
+        // Check for error indicators in acknowledgement
+        bytes5 errorPrefix = bytes5(acknowledgement);
+        if (errorPrefix == bytes5("error")) {
+            return false;
+        }
+        
+        return true; // Non-error acknowledgement indicates success
+    }
+    
+    function _handleSuccessfulAcknowledgement(
+        bytes32 packetId,
+        bytes memory data,
+        bytes memory acknowledgement
+    ) internal {
+        // Parse packet data to get sender and amount
+        (address sender, uint256 amount, string memory operation) = _parsePacketData(data);
+        
+        if (keccak256(bytes(operation)) == keccak256(bytes("cross_chain_swap"))) {
+            emit CrossChainOrderExecuted(packetId, sender, amount);
+        }
+        
+        // Credit any rewards or returns
+        userBalances[sender] += amount;
+    }
+    
+    function _handleFailedAcknowledgement(
+        bytes32 packetId,
+        bytes memory data,
+        bytes memory acknowledgement
+    ) internal {
+        (address sender, uint256 amount, ) = _parsePacketData(data);
+        
+        // Issue refund for failed transaction
+        userBalances[sender] += amount;
+        emit RefundIssued(sender, amount, packetId);
+    }
+    
+    function _parsePacketData(bytes memory data) 
+        internal 
+        pure 
+        returns (address sender, uint256 amount, string memory operation) 
+    {
+        // Simplified parser - extract sender, amount, and operation from packet data
+        if (data.length < 64) {
+            revert InvalidPacketData();
+        }
+        
+        assembly {
+            sender := mload(add(data, 32))
+            amount := mload(add(data, 64))
+        }
+        
+        // Extract operation string (simplified)
+        operation = "cross_chain_swap"; // Default operation
+        return (sender, amount, operation);
+    }
+}
+```
+```javascript Ethers.js expandable lines
+import { ethers } from "ethers";
+
+// Deploy a contract that implements IBC callbacks
+class IBCCallbackHandler {
+    constructor(provider, signer, contractAddress) {
+        this.provider = provider;
+        this.signer = signer;
+        this.contractAddress = contractAddress;
+        
+        // ABI for the callback interface
+        this.abi = [
+            "function onPacketAcknowledgement(string channelId, string portId, uint64 sequence, bytes data, bytes acknowledgement)",
+            "event PacketAcknowledged(bytes32 indexed packetId, string channelId, uint64 sequence)",
+            "event RefundIssued(address indexed user, uint256 amount, bytes32 indexed packetId)"
+        ];
+        
+        this.contract = new ethers.Contract(contractAddress, this.abi, signer);
+    }
+    
+    // Listen for packet acknowledgement events
+    async listenForAcknowledgements() {
+        console.log("Listening for packet acknowledgements...");
+        
+        this.contract.on("PacketAcknowledged", (packetId, channelId, sequence) => {
+            console.log(`Packet acknowledged:`);
+            console.log(`  Packet ID: ${packetId}`);
+            console.log(`  Channel: ${channelId}`);
+            console.log(`  Sequence: ${sequence}`);
+        });
+        
+        this.contract.on("RefundIssued", (user, amount, packetId) => {
+            console.log(`Refund issued:`);
+            console.log(`  User: ${user}`);
+            console.log(`  Amount: ${ethers.formatEther(amount)} ETH`);
+            console.log(`  Packet ID: ${packetId}`);
+        });
+    }
+    
+    // Get packet status
+    async getPacketStatus(channelId, portId, sequence) {
+        const packetId = ethers.solidityPackedKeccak256(
+            ["string", "string", "uint64"],
+            [channelId, portId, sequence]
+        );
+        
+        // Assuming the contract has a packetStatuses mapping
+        const statusAbi = ["function packetStatuses(bytes32) view returns (uint8)"];
+        const contract = new ethers.Contract(this.contractAddress, statusAbi, this.provider);
+        
+        const status = await contract.packetStatuses(packetId);
+        const statusNames = ["None", "Pending", "Acknowledged", "TimedOut"];
+        
+        return {
+            packetId,
+            status: statusNames[status] || "Unknown",
+            statusCode: status
+        };
+    }
+}
+
+// Example usage
+async function setupCallbackHandler() {
+    const provider = new ethers.JsonRpcProvider("<RPC_URL>");
+    const signer = new ethers.Wallet("<PRIVATE_KEY>", provider);
+    const contractAddress = "<CALLBACK_CONTRACT_ADDRESS>";
+    
+    const handler = new IBCCallbackHandler(provider, signer, contractAddress);
+    
+    // Start listening for events
+    await handler.listenForAcknowledgements();
+    
+    // Check a packet status
+    const status = await handler.getPacketStatus("channel-0", "transfer", 123);
+    console.log("Packet status:", status);
+}
+
+// setupCallbackHandler();
+```
+</CodeGroup>
+
 ### `onPacketTimeout`
 
 **Signature**: `onPacketTimeout(string memory channelId, string memory portId, uint64 sequence, bytes memory data)`
 
 **Description**: Callback function invoked on the source chain after a packet lifecycle is completed and the packet has timed out. The contract implementing this interface receives packet information to execute custom timeout handling logic.
+
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract CallbacksExample {
+    address public immutable ibcModule;
+    
+    mapping(bytes32 => PacketStatus) public packetStatuses;
+    mapping(address => uint256) public userBalances;
+    
+    enum PacketStatus { None, Pending, Acknowledged, TimedOut }
+    
+    event PacketTimedOut(bytes32 indexed packetId, string channelId, uint64 sequence);
+    event RefundIssued(address indexed user, uint256 amount, bytes32 indexed packetId);
+    
+    error UnauthorizedCaller();
+    error PacketAlreadyProcessed();
+    error InvalidPacketData();
+    
+    modifier onlyIBC() {
+        if (msg.sender != ibcModule) revert UnauthorizedCaller();
+        _;
+    }
+    
+    constructor(address _ibcModule) {
+        ibcModule = _ibcModule;
+    }
+    
+    function onPacketTimeout(
+        string memory channelId,
+        string memory portId,
+        uint64 sequence,
+        bytes memory data
+    ) external onlyIBC {
+        bytes32 packetId = keccak256(abi.encodePacked(channelId, portId, sequence));
+        
+        // Ensure packet hasn't been processed already
+        if (packetStatuses[packetId] != PacketStatus.None) {
+            revert PacketAlreadyProcessed();
+        }
+        
+        packetStatuses[packetId] = PacketStatus.TimedOut;
+        
+        // Handle timeout by issuing refunds
+        _handleTimeout(packetId, data);
+        
+        emit PacketTimedOut(packetId, channelId, sequence);
+    }
+    
+    function _handleTimeout(bytes32 packetId, bytes memory data) internal {
+        // Parse packet data to extract sender and amount for refund
+        (address sender, uint256 amount, string memory operation) = _parsePacketData(data);
+        
+        // Issue full refund for timed out packets
+        _issueRefund(sender, amount, packetId);
+        
+        // Additional timeout-specific logic based on operation type
+        if (keccak256(bytes(operation)) == keccak256(bytes("stake_remote"))) {
+            _handleStakeTimeout(sender, amount, packetId);
+        } else if (keccak256(bytes(operation)) == keccak256(bytes("cross_chain_swap"))) {
+            _handleSwapTimeout(sender, amount, packetId);
+        }
+    }
+    
+    function _issueRefund(address user, uint256 amount, bytes32 packetId) internal {
+        userBalances[user] += amount;
+        emit RefundIssued(user, amount, packetId);
+    }
+    
+    function _handleStakeTimeout(address user, uint256 amount, bytes32 packetId) internal {
+        // Handle staking timeout - might need to cancel staking plans
+        // Restore user's staking availability
+        userBalances[user] += amount; // Return staked amount
+        
+        // Additional staking-specific cleanup logic here
+    }
+    
+    function _handleSwapTimeout(address user, uint256 amount, bytes32 packetId) internal {
+        // Handle swap timeout - return original tokens
+        userBalances[user] += amount;
+        
+        // Additional swap-specific cleanup logic here
+    }
+    
+    function _parsePacketData(bytes memory data) 
+        internal 
+        pure 
+        returns (address sender, uint256 amount, string memory operation) 
+    {
+        if (data.length < 64) {
+            revert InvalidPacketData();
+        }
+        
+        assembly {
+            sender := mload(add(data, 32))
+            amount := mload(add(data, 64))
+        }
+        
+        operation = "timeout_operation"; // Default
+        return (sender, amount, operation);
+    }
+    
+    // User functions to interact with refunds
+    function withdraw(uint256 amount) external {
+        require(userBalances[msg.sender] >= amount, "Insufficient balance");
+        userBalances[msg.sender] -= amount;
+        payable(msg.sender).transfer(amount);
+    }
+    
+    function getAvailableBalance(address user) external view returns (uint256) {
+        return userBalances[user];
+    }
+    
+    function isPacketTimedOut(
+        string memory channelId,
+        string memory portId,
+        uint64 sequence
+    ) external view returns (bool) {
+        bytes32 packetId = keccak256(abi.encodePacked(channelId, portId, sequence));
+        return packetStatuses[packetId] == PacketStatus.TimedOut;
+    }
+}
+```
+```javascript Ethers.js expandable lines
+import { ethers } from "ethers";
+
+// Handle timeout callbacks
+class TimeoutHandler {
+    constructor(provider, signer, contractAddress) {
+        this.provider = provider;
+        this.signer = signer;
+        this.contractAddress = contractAddress;
+        
+        // ABI for timeout handling
+        this.abi = [
+            "function onPacketTimeout(string channelId, string portId, uint64 sequence, bytes data)",
+            "event PacketTimedOut(bytes32 indexed packetId, string channelId, uint64 sequence)",
+            "event RefundIssued(address indexed user, uint256 amount, bytes32 indexed packetId)",
+            "function userBalances(address) view returns (uint256)"
+        ];
+        
+        this.contract = new ethers.Contract(contractAddress, this.abi, signer);
+    }
+    
+    // Listen for timeout events
+    async listenForTimeouts() {
+        console.log("Listening for packet timeouts...");
+        
+        this.contract.on("PacketTimedOut", (packetId, channelId, sequence) => {
+            console.log(`Packet timed out:`);
+            console.log(`  Packet ID: ${packetId}`);
+            console.log(`  Channel: ${channelId}`);
+            console.log(`  Sequence: ${sequence}`);
+        });
+        
+        this.contract.on("RefundIssued", async (user, amount, packetId) => {
+            console.log(`Refund issued for timeout:`);
+            console.log(`  User: ${user}`);
+            console.log(`  Amount: ${ethers.formatEther(amount)} ETH`);
+            console.log(`  Packet ID: ${packetId}`);
+            
+            // Check new balance
+            const newBalance = await this.contract.userBalances(user);
+            console.log(`  New user balance: ${ethers.formatEther(newBalance)} ETH`);
+        });
+    }
+    
+    // Check user balance after refund
+    async checkUserBalance(userAddress) {
+        const balance = await this.contract.userBalances(userAddress);
+        return {
+            address: userAddress,
+            balance: balance,
+            formatted: ethers.formatEther(balance) + " ETH"
+        };
+    }
+    
+    // Encode packet data for testing
+    static encodePacketData(sender, amount, operation = "cross_chain_swap") {
+        // Simple encoding for testing
+        return ethers.AbiCoder.defaultAbiCoder().encode(
+            ["address", "uint256", "string"],
+            [sender, amount, operation]
+        );
+    }
+}
+
+// Example usage
+async function handleTimeouts() {
+    const provider = new ethers.JsonRpcProvider("<RPC_URL>");
+    const signer = new ethers.Wallet("<PRIVATE_KEY>", provider);
+    const contractAddress = "<CALLBACK_CONTRACT_ADDRESS>";
+    
+    const handler = new TimeoutHandler(provider, signer, contractAddress);
+    
+    // Start listening
+    await handler.listenForTimeouts();
+    
+    // Check balance after refund
+    const balance = await handler.checkUserBalance("0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8");
+    console.log("User balance:", balance.formatted);
+}
+
+// handleTimeouts();
+```
+</CodeGroup>
 
 ## Security Considerations
 

--- a/docs/next/documentation/smart-contracts/precompiles/distribution.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/distribution.mdx
@@ -44,20 +44,285 @@ Claims staking rewards from multiple validators.
 The `maxRetrieve` parameter limits the number of validators from which to claim rewards in a single transaction. This prevents excessive gas consumption when a delegator has rewards from many validators.
 </Info>
 
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract DistributionClaimRewards {
+    address constant DISTRIBUTION_PRECOMPILE = 0x0000000000000000000000000000000000000801;
+    
+    event RewardsClaimed(address indexed delegator, uint256 maxRetrieve, bool success);
+    
+    function claimRewards(uint32 maxRetrieve) external returns (bool success) {
+        (bool callSuccess, bytes memory result) = DISTRIBUTION_PRECOMPILE.call(
+            abi.encodeWithSignature("claimRewards(address,uint32)", msg.sender, maxRetrieve)
+        );
+        
+        require(callSuccess, "Claim rewards call failed");
+        success = abi.decode(result, (bool));
+        
+        emit RewardsClaimed(msg.sender, maxRetrieve, success);
+        return success;
+    }
+    
+    function claimAllRewards() external returns (bool success) {
+        // Use a high maxRetrieve value to claim from all validators
+        return claimRewards(100);
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Claiming rewards requires a signed transaction"
+```
+</CodeGroup>
+
 ### withdrawDelegatorRewards
 Withdraws staking rewards from a single, specific validator.
+
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract DistributionExample {
+    address constant DISTRIBUTION_PRECOMPILE = 0x0000000000000000000000000000000000000801;
+    
+    struct Coin {
+        string denom;
+        uint256 amount;
+    }
+    
+    event RewardsWithdrawn(address indexed delegator, string indexed validator, uint256 amount);
+    
+    function withdrawRewards(string calldata validatorAddress) external returns (Coin[] memory amount) {
+        (bool success, bytes memory result) = DISTRIBUTION_PRECOMPILE.call(
+            abi.encodeWithSignature("withdrawDelegatorRewards(address,string)", msg.sender, validatorAddress)
+        );
+        
+        require(success, "Withdraw rewards failed");
+        amount = abi.decode(result, (Coin[]));
+        
+        uint256 totalAmount = 0;
+        for (uint i = 0; i < amount.length; i++) {
+            totalAmount += amount[i].amount;
+        }
+        emit RewardsWithdrawn(msg.sender, validatorAddress, totalAmount);
+        
+        return amount;
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Reward withdrawal requires a signed transaction"
+```
+</CodeGroup>
 
 ### setWithdrawAddress
 Sets or changes the withdrawal address for receiving staking rewards.
 
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract DistributionSetWithdrawAddress {
+    address constant DISTRIBUTION_PRECOMPILE = 0x0000000000000000000000000000000000000801;
+    
+    event WithdrawAddressSet(address indexed delegator, string withdrawerAddress, bool success);
+    
+    function setWithdrawAddress(string calldata withdrawerAddress) external returns (bool success) {
+        (bool callSuccess, bytes memory result) = DISTRIBUTION_PRECOMPILE.call(
+            abi.encodeWithSignature("setWithdrawAddress(address,string)", msg.sender, withdrawerAddress)
+        );
+        
+        require(callSuccess, "Set withdraw address call failed");
+        success = abi.decode(result, (bool));
+        
+        emit WithdrawAddressSet(msg.sender, withdrawerAddress, success);
+        return success;
+    }
+    
+    function resetWithdrawAddress() external returns (bool success) {
+        // Reset to delegator's own address by converting msg.sender to bech32
+        // Note: In practice, you'd need to convert the EVM address to bech32 format
+        string memory selfAddress = "art1..."; // This would be the bech32 equivalent
+        return setWithdrawAddress(selfAddress);
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Setting withdraw address requires a signed transaction"
+```
+</CodeGroup>
+
 ### withdrawValidatorCommission
 Withdraws a validator's accumulated commission rewards.
+
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract DistributionWithdrawCommission {
+    address constant DISTRIBUTION_PRECOMPILE = 0x0000000000000000000000000000000000000801;
+    
+    struct Coin {
+        string denom;
+        uint256 amount;
+    }
+    
+    event ValidatorCommissionWithdrawn(string indexed validatorAddress, uint256 totalAmount);
+    
+    function withdrawValidatorCommission(string calldata validatorAddress) external returns (Coin[] memory amount) {
+        (bool success, bytes memory result) = DISTRIBUTION_PRECOMPILE.call(
+            abi.encodeWithSignature("withdrawValidatorCommission(string)", validatorAddress)
+        );
+        
+        require(success, "Withdraw validator commission failed");
+        amount = abi.decode(result, (Coin[]));
+        
+        uint256 totalAmount = 0;
+        for (uint i = 0; i < amount.length; i++) {
+            totalAmount += amount[i].amount;
+        }
+        emit ValidatorCommissionWithdrawn(validatorAddress, totalAmount);
+        
+        return amount;
+    }
+    
+    // Helper function for validator operators to withdraw their own commission
+    function withdrawMyCommission(string calldata myValidatorAddress) external returns (Coin[] memory) {
+        return withdrawValidatorCommission(myValidatorAddress);
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Withdrawing validator commission requires a signed transaction"
+```
+</CodeGroup>
 
 ### fundCommunityPool
 Sends tokens directly to the community pool.
 
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract DistributionFundCommunityPool {
+    address constant DISTRIBUTION_PRECOMPILE = 0x0000000000000000000000000000000000000801;
+    
+    struct Coin {
+        string denom;
+        uint256 amount;
+    }
+    
+    event CommunityPoolFunded(address indexed depositor, string denom, uint256 amount, bool success);
+    
+    function fundCommunityPool(Coin[] calldata amount) external returns (bool success) {
+        (bool callSuccess, bytes memory result) = DISTRIBUTION_PRECOMPILE.call(
+            abi.encodeWithSignature("fundCommunityPool(address,(string,uint256)[])", msg.sender, amount)
+        );
+        
+        require(callSuccess, "Fund community pool call failed");
+        success = abi.decode(result, (bool));
+        
+        // Emit events for each coin funded
+        for (uint i = 0; i < amount.length; i++) {
+            emit CommunityPoolFunded(msg.sender, amount[i].denom, amount[i].amount, success);
+        }
+        
+        return success;
+    }
+    
+    function fundCommunityPoolSingleCoin(string calldata denom, uint256 amount) external returns (bool success) {
+        Coin[] memory coins = new Coin[](1);
+        coins[0] = Coin(denom, amount);
+        return fundCommunityPool(coins);
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Funding community pool requires a signed transaction"
+```
+</CodeGroup>
+
 ### depositValidatorRewardsPool
 Deposits tokens into a specific validator's rewards pool.
+
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract DistributionDepositValidatorRewards {
+    address constant DISTRIBUTION_PRECOMPILE = 0x0000000000000000000000000000000000000801;
+    
+    struct Coin {
+        string denom;
+        uint256 amount;
+    }
+    
+    event ValidatorRewardsPoolDeposited(
+        address indexed depositor, 
+        string indexed validatorAddress, 
+        string denom, 
+        uint256 amount, 
+        bool success
+    );
+    
+    function depositValidatorRewardsPool(
+        string calldata validatorAddress,
+        Coin[] calldata amount
+    ) external returns (bool success) {
+        (bool callSuccess, bytes memory result) = DISTRIBUTION_PRECOMPILE.call(
+            abi.encodeWithSignature(
+                "depositValidatorRewardsPool(address,string,(string,uint256)[])", 
+                msg.sender, 
+                validatorAddress, 
+                amount
+            )
+        );
+        
+        require(callSuccess, "Deposit validator rewards pool call failed");
+        success = abi.decode(result, (bool));
+        
+        // Emit events for each coin deposited
+        for (uint i = 0; i < amount.length; i++) {
+            emit ValidatorRewardsPoolDeposited(
+                msg.sender, 
+                validatorAddress, 
+                amount[i].denom, 
+                amount[i].amount, 
+                success
+            );
+        }
+        
+        return success;
+    }
+    
+    function depositSingleCoinToValidator(
+        string calldata validatorAddress,
+        string calldata denom, 
+        uint256 amount
+    ) external returns (bool success) {
+        Coin[] memory coins = new Coin[](1);
+        coins[0] = Coin(denom, amount);
+        return depositValidatorRewardsPool(validatorAddress, coins);
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Depositing to validator rewards pool requires a signed transaction"
+```
+</CodeGroup>
 
 ## Query Methods
 

--- a/docs/next/documentation/smart-contracts/precompiles/distribution.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/distribution.mdx
@@ -728,7 +728,7 @@ import { ethers } from "ethers";
 
 // ABI definition for the function
 const precompileAbi = [
-  "function validatorSlashes(string memory validatorAddress, uint64 startingHeight, uint64 endingHeight, tuple(bytes key, uint64 offset, uint64 limit, bool countTotal, bool reverse) pageRequest) view returns (tuple(uint64 validatorPeriod, tuple(uint256 amount, uint8 precision) fraction)[] slashes, tuple(bytes nextKey, uint64 total) pageResponse)"
+  "function validatorSlashes(string validatorAddress, uint64 startingHeight, uint64 endingHeight, tuple(bytes key, uint64 offset, uint64 limit, bool countTotal, bool reverse) pageRequest) view returns (tuple(uint64 validatorPeriod, tuple(uint256 value, uint8 precision) fraction, int64 height)[] slashes, tuple(bytes nextKey, uint64 total) pageResponse)"
 ];
 
 // Provider and contract setup

--- a/docs/next/documentation/smart-contracts/precompiles/erc20.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/erc20.mdx
@@ -36,7 +36,7 @@ Gas costs are approximated and may vary based on token complexity and chain sett
 
 The ERC20 precompile works through a token pair registration system:
 
-1. **Native Cosmos Token**: Each Cosmos SDK denomination (e.g., `uatom`, `stake`) exists as a native token in the bank module
+1. **Native Cosmos Token**: Each Cosmos SDK denomination (e.g., `test`, `atest`) exists as a native token in the bank module
 2. **ERC20 Interface**: A corresponding ERC20 precompile contract provides an interface at a unique address
 3. **Direct Bank Module Access**: The ERC20 interface operates directly on bank module balances - there is no separate ERC20 token state
 4. **Dynamic Addresses**: Each token pair gets its own precompile address when registered
@@ -51,6 +51,28 @@ The precompile address is deterministically generated based on the token denomin
 Returns the total amount of tokens in existence.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ERC20Example {
+    address public immutable tokenContract;
+    
+    constructor(address _tokenContract) {
+        tokenContract = _tokenContract;
+    }
+    
+    function getTotalSupply() external view returns (uint256 totalSupply) {
+        (bool success, bytes memory result) = tokenContract.staticcall(
+            abi.encodeWithSignature("totalSupply()")
+        );
+        
+        require(success, "Total supply query failed");
+        totalSupply = abi.decode(result, (uint256));
+        return totalSupply;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -95,6 +117,33 @@ curl -X POST --data '{
 Returns the token balance of a specified account.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ERC20Example {
+    address public immutable tokenContract;
+    
+    constructor(address _tokenContract) {
+        tokenContract = _tokenContract;
+    }
+    
+    function getBalance(address account) external view returns (uint256 balance) {
+        (bool success, bytes memory result) = tokenContract.staticcall(
+            abi.encodeWithSignature("balanceOf(address)", account)
+        );
+        
+        require(success, "Balance query failed");
+        balance = abi.decode(result, (uint256));
+        return balance;
+    }
+    
+    // Get caller's balance
+    function getMyBalance() external view returns (uint256) {
+        return this.getBalance(msg.sender);
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -137,16 +186,154 @@ curl -X POST --data '{
 ### `transfer`
 Moves tokens from the caller's account to a recipient.
 
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ERC20Example {
+    address public immutable tokenContract;
+    
+    constructor(address _tokenContract) {
+        tokenContract = _tokenContract;
+    }
+    
+    event TokenTransfer(address indexed from, address indexed to, uint256 amount);
+    
+    function transferTokens(address to, uint256 amount) external returns (bool success) {
+        require(to != address(0), "Cannot transfer to zero address");
+        require(amount > 0, "Amount must be positive");
+        
+        (bool callSuccess, bytes memory result) = tokenContract.call(
+            abi.encodeWithSignature("transfer(address,uint256)", to, amount)
+        );
+        
+        require(callSuccess, "Transfer call failed");
+        success = abi.decode(result, (bool));
+        require(success, "Transfer returned false");
+        
+        emit TokenTransfer(msg.sender, to, amount);
+        return success;
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Token transfer requires a signed transaction"
+```
+</CodeGroup>
+
 ### `transferFrom`
 Moves tokens from one account to another using an allowance.
 
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ERC20Example {
+    address public immutable tokenContract;
+    
+    constructor(address _tokenContract) {
+        tokenContract = _tokenContract;
+    }
+    
+    event TokenTransferFrom(address indexed from, address indexed to, uint256 amount, address indexed spender);
+    
+    function transferFromTokens(address from, address to, uint256 amount) external returns (bool success) {
+        require(from != address(0), "Cannot transfer from zero address");
+        require(to != address(0), "Cannot transfer to zero address");
+        require(amount > 0, "Amount must be positive");
+        
+        (bool callSuccess, bytes memory result) = tokenContract.call(
+            abi.encodeWithSignature("transferFrom(address,address,uint256)", from, to, amount)
+        );
+        
+        require(callSuccess, "TransferFrom call failed");
+        success = abi.decode(result, (bool));
+        require(success, "TransferFrom returned false");
+        
+        emit TokenTransferFrom(from, to, amount, msg.sender);
+        return success;
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Token transferFrom requires a signed transaction"
+```
+</CodeGroup>
+
 ### `approve`
 Sets the allowance of a spender over the caller's tokens.
+
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ERC20Example {
+    address public immutable tokenContract;
+    
+    constructor(address _tokenContract) {
+        tokenContract = _tokenContract;
+    }
+    
+    event TokenApproval(address indexed owner, address indexed spender, uint256 amount);
+    
+    function approveSpender(address spender, uint256 amount) external returns (bool success) {
+        require(spender != address(0), "Cannot approve zero address");
+        
+        (bool callSuccess, bytes memory result) = tokenContract.call(
+            abi.encodeWithSignature("approve(address,uint256)", spender, amount)
+        );
+        
+        require(callSuccess, "Approve call failed");
+        success = abi.decode(result, (bool));
+        require(success, "Approve returned false");
+        
+        emit TokenApproval(msg.sender, spender, amount);
+        return success;
+    }
+    
+    // Helper function to approve maximum amount
+    function approveMax(address spender) external returns (bool) {
+        return this.approveSpender(spender, type(uint256).max);
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Token approval requires a signed transaction"
+```
+</CodeGroup>
 
 ### `allowance`
 Returns the remaining number of tokens that a spender is allowed to spend on behalf of an owner.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ERC20Example {
+    address public immutable tokenContract;
+    
+    constructor(address _tokenContract) {
+        tokenContract = _tokenContract;
+    }
+    
+    function checkAllowance(address owner, address spender) external view returns (uint256 allowance) {
+        (bool success, bytes memory result) = tokenContract.staticcall(
+            abi.encodeWithSignature("allowance(address,address)", owner, spender)
+        );
+        
+        require(success, "Allowance query failed");
+        allowance = abi.decode(result, (uint256));
+        return allowance;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -191,6 +378,28 @@ curl -X POST --data '{
 Returns the name of the token.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ERC20Example {
+    address public immutable tokenContract;
+    
+    constructor(address _tokenContract) {
+        tokenContract = _tokenContract;
+    }
+    
+    function getTokenName() external view returns (string memory name) {
+        (bool success, bytes memory result) = tokenContract.staticcall(
+            abi.encodeWithSignature("name()")
+        );
+        
+        require(success, "Name query failed");
+        name = abi.decode(result, (string));
+        return name;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -233,6 +442,28 @@ curl -X POST --data '{
 Returns the symbol of the token.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ERC20Example {
+    address public immutable tokenContract;
+    
+    constructor(address _tokenContract) {
+        tokenContract = _tokenContract;
+    }
+    
+    function getTokenSymbol() external view returns (string memory symbol) {
+        (bool success, bytes memory result) = tokenContract.staticcall(
+            abi.encodeWithSignature("symbol()")
+        );
+        
+        require(success, "Symbol query failed");
+        symbol = abi.decode(result, (string));
+        return symbol;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -275,10 +506,32 @@ curl -X POST --data '{
 Returns the number of decimals used for the token.
 
 <Warning>
-**Decimal Handling**: The ERC20 precompile may need to handle complex decimal conversions between Cosmos native tokens and ERC20 representation. Some Cosmos tokens use 6 decimals (e.g., `uatom`) while ERC20 typically uses 18. Always verify the decimal count for accurate amount calculations.
+**Decimal Handling**: The ERC20 precompile may need to handle complex decimal conversions between Cosmos native tokens and ERC20 representation. Some Cosmos tokens use 6 decimals (e.g., `test`) while ERC20 typically uses 18. Always verify the decimal count for accurate amount calculations.
 </Warning>
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ERC20Example {
+    address public immutable tokenContract;
+    
+    constructor(address _tokenContract) {
+        tokenContract = _tokenContract;
+    }
+    
+    function getTokenDecimals() external view returns (uint8 decimals) {
+        (bool success, bytes memory result) = tokenContract.staticcall(
+            abi.encodeWithSignature("decimals()")
+        );
+        
+        require(success, "Decimals query failed");
+        decimals = abi.decode(result, (uint8));
+        return decimals;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 

--- a/docs/next/documentation/smart-contracts/precompiles/governance.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/governance.mdx
@@ -28,17 +28,333 @@ Gas costs are approximated and may vary based on proposal complexity and chain s
 ### `submitProposal`
 Submits a new governance proposal.
 
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceExample {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    struct Coin {
+        string denom;
+        uint256 amount;
+    }
+    
+    event ProposalSubmitted(address indexed proposer, uint64 indexed proposalId);
+    
+    function submitProposal(bytes calldata jsonProposal, Coin[] calldata initialDeposit) 
+        external 
+        payable 
+        returns (uint64 proposalId) 
+    {
+        require(jsonProposal.length > 0, "Proposal cannot be empty");
+        require(initialDeposit.length > 0, "Initial deposit required");
+        
+        // Call the governance precompile
+        (bool success, bytes memory result) = GOVERNANCE_PRECOMPILE.call(
+            abi.encodeWithSignature(
+                "submitProposal(address,bytes,tuple(string,uint256)[])",
+                msg.sender,
+                jsonProposal,
+                initialDeposit
+            )
+        );
+        
+        require(success, "Proposal submission failed");
+        proposalId = abi.decode(result, (uint64));
+        
+        emit ProposalSubmitted(msg.sender, proposalId);
+        return proposalId;
+    }
+    
+    // Helper function to create a coin struct
+    function createCoin(string memory denom, uint256 amount) external pure returns (Coin memory) {
+        return Coin({denom: denom, amount: amount});
+    }
+}
+```
+</CodeGroup>
+
 ### `vote`
 Casts a single vote on an active proposal.
+
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceExample {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    enum VoteOption {
+        Unspecified,
+        Yes,
+        Abstain,
+        No,
+        NoWithVeto
+    }
+    
+    event VoteCast(address indexed voter, uint64 indexed proposalId, VoteOption option);
+    
+    function vote(uint64 proposalId, VoteOption option, string calldata metadata) external {
+        require(proposalId > 0, "Invalid proposal ID");
+        require(option != VoteOption.Unspecified, "Must specify a vote option");
+        
+        (bool success, bytes memory result) = GOVERNANCE_PRECOMPILE.call(
+            abi.encodeWithSignature(
+                "vote(address,uint64,uint8,string)",
+                msg.sender,
+                proposalId,
+                uint8(option),
+                metadata
+            )
+        );
+        
+        require(success, "Vote failed");
+        bool voteSuccess = abi.decode(result, (bool));
+        require(voteSuccess, "Vote was rejected");
+        
+        emit VoteCast(msg.sender, proposalId, option);
+    }
+    
+    // Convenience function to vote yes
+    function voteYes(uint64 proposalId) external {
+        this.vote(proposalId, VoteOption.Yes, "");
+    }
+    
+    // Convenience function to vote no
+    function voteNo(uint64 proposalId) external {
+        this.vote(proposalId, VoteOption.No, "");
+    }
+}
+```
+</CodeGroup>
 
 ### `voteWeighted`
 Casts a weighted vote, splitting voting power across multiple options.
 
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceWeightedVote {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    enum VoteOption {
+        Unspecified,
+        Yes,
+        Abstain,
+        No,
+        NoWithVeto
+    }
+    
+    struct WeightedVoteOption {
+        VoteOption option;
+        string weight;
+    }
+    
+    event WeightedVoteCast(
+        address indexed voter, 
+        uint64 indexed proposalId, 
+        WeightedVoteOption[] options
+    );
+    
+    function voteWeighted(
+        uint64 proposalId, 
+        WeightedVoteOption[] calldata options, 
+        string calldata metadata
+    ) external returns (bool success) {
+        require(proposalId > 0, "Invalid proposal ID");
+        require(options.length > 0, "Must provide vote options");
+        
+        // Validate that weights sum to 1.0 (represented as "1.000000000000000000")
+        // This is just a basic check - in practice you'd want more robust validation
+        
+        (bool callSuccess, bytes memory result) = GOVERNANCE_PRECOMPILE.call(
+            abi.encodeWithSignature(
+                "voteWeighted(address,uint64,tuple(uint8,string)[],string)",
+                msg.sender,
+                proposalId,
+                options,
+                metadata
+            )
+        );
+        
+        require(callSuccess, "Weighted vote failed");
+        success = abi.decode(result, (bool));
+        require(success, "Weighted vote was rejected");
+        
+        emit WeightedVoteCast(msg.sender, proposalId, options);
+        return success;
+    }
+    
+    // Helper function to create a split vote (e.g., 70% Yes, 30% Abstain)
+    function voteSplit(
+        uint64 proposalId,
+        uint256 yesPercent,
+        uint256 abstainPercent
+    ) external returns (bool) {
+        require(yesPercent + abstainPercent == 100, "Percentages must sum to 100");
+        
+        WeightedVoteOption[] memory options = new WeightedVoteOption[](2);
+        
+        // Convert percentages to decimal weights (e.g., 70% = "0.700000000000000000")
+        options[0] = WeightedVoteOption({
+            option: VoteOption.Yes,
+            weight: string(abi.encodePacked("0.", _padPercentage(yesPercent)))
+        });
+        
+        options[1] = WeightedVoteOption({
+            option: VoteOption.Abstain,
+            weight: string(abi.encodePacked("0.", _padPercentage(abstainPercent)))
+        });
+        
+        return voteWeighted(proposalId, options, "Split vote");
+    }
+    
+    // Helper function to pad percentage to 18 decimal places
+    function _padPercentage(uint256 percent) internal pure returns (string memory) {
+        require(percent <= 100, "Percent cannot exceed 100");
+        
+        if (percent == 100) return "000000000000000000"; // Special case for 100%
+        
+        // This is a simplified version - in practice you'd want more robust decimal handling
+        string memory percentStr = _toString(percent);
+        if (percent < 10) {
+            return string(abi.encodePacked("0", percentStr, "0000000000000000"));
+        } else {
+            return string(abi.encodePacked(percentStr, "0000000000000000"));
+        }
+    }
+    
+    function _toString(uint256 value) internal pure returns (string memory) {
+        if (value == 0) return "0";
+        
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        return string(buffer);
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Weighted voting requires a signed transaction"
+```
+</CodeGroup>
+
 ### `deposit`
 Adds funds to a proposal's deposit during the deposit period.
 
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceExample {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    struct Coin {
+        string denom;
+        uint256 amount;
+    }
+    
+    event DepositMade(address indexed depositor, uint64 indexed proposalId, uint256 amount);
+    
+    function deposit(uint64 proposalId, Coin[] calldata amount) external payable {
+        require(proposalId > 0, "Invalid proposal ID");
+        require(amount.length > 0, "Deposit amount required");
+        
+        (bool success, bytes memory result) = GOVERNANCE_PRECOMPILE.call{value: msg.value}(
+            abi.encodeWithSignature(
+                "deposit(address,uint64,tuple(string,uint256)[])",
+                msg.sender,
+                proposalId,
+                amount
+            )
+        );
+        
+        require(success, "Deposit failed");
+        bool depositSuccess = abi.decode(result, (bool));
+        require(depositSuccess, "Deposit was rejected");
+        
+        // Calculate total deposited amount for event
+        uint256 totalAmount = 0;
+        for (uint i = 0; i < amount.length; i++) {
+            totalAmount += amount[i].amount;
+        }
+        
+        emit DepositMade(msg.sender, proposalId, totalAmount);
+    }
+    
+    // Convenience function to deposit native tokens
+    function depositNative(uint64 proposalId, uint256 amount, string memory denom) external payable {
+        require(msg.value >= amount, "Insufficient value sent");
+        
+        Coin[] memory coins = new Coin[](1);
+        coins[0] = Coin({denom: denom, amount: amount});
+        
+        this.deposit{value: amount}(proposalId, coins);
+    }
+}
+```
+</CodeGroup>
+
 ### `cancelProposal`
 Cancels a proposal that is still in its deposit period.
+
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceCancelProposal {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    event ProposalCanceled(address indexed proposer, uint64 indexed proposalId, bool success);
+    
+    function cancelProposal(uint64 proposalId) external returns (bool success) {
+        require(proposalId > 0, "Invalid proposal ID");
+        
+        (bool callSuccess, bytes memory result) = GOVERNANCE_PRECOMPILE.call(
+            abi.encodeWithSignature("cancelProposal(address,uint64)", msg.sender, proposalId)
+        );
+        
+        require(callSuccess, "Cancel proposal call failed");
+        success = abi.decode(result, (bool));
+        
+        emit ProposalCanceled(msg.sender, proposalId, success);
+        return success;
+    }
+    
+    // Function to safely cancel a proposal with additional checks
+    function safeCancelProposal(uint64 proposalId) external returns (bool success) {
+        // First, check if the proposal exists and can be canceled
+        // Note: In practice, you'd want to call getProposal first to verify status
+        
+        success = cancelProposal(proposalId);
+        require(success, "Proposal cancellation failed - check if you're the proposer and proposal is in deposit period");
+        
+        return success;
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Canceling proposals requires a signed transaction"
+```
+</CodeGroup>
 
 ## Query Methods
 
@@ -46,6 +362,60 @@ Cancels a proposal that is still in its deposit period.
 Retrieves detailed information about a specific proposal.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceQueries {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    struct ProposalData {
+        uint64 id;
+        string[] messages;
+        uint32 status;
+        TallyResultData finalTallyResult;
+        uint64 submitTime;
+        uint64 depositEndTime;
+        Coin[] totalDeposit;
+        uint64 votingStartTime;
+        uint64 votingEndTime;
+        string metadata;
+        string title;
+        string summary;
+        address proposer;
+    }
+    
+    struct TallyResultData {
+        string yes;
+        string abstain;
+        string no;
+        string noWithVeto;
+    }
+    
+    struct Coin {
+        string denom;
+        uint256 amount;
+    }
+    
+    function getProposal(uint64 proposalId) external view returns (ProposalData memory proposal) {
+        require(proposalId > 0, "Invalid proposal ID");
+        
+        (bool success, bytes memory result) = GOVERNANCE_PRECOMPILE.staticcall(
+            abi.encodeWithSignature("getProposal(uint64)", proposalId)
+        );
+        
+        require(success, "Failed to get proposal");
+        proposal = abi.decode(result, (ProposalData));
+        return proposal;
+    }
+    
+    // Helper function to check if proposal is in voting period
+    function isProposalInVotingPeriod(uint64 proposalId) external view returns (bool) {
+        ProposalData memory proposal = this.getProposal(proposalId);
+        return proposal.status == 2; // PROPOSAL_STATUS_VOTING_PERIOD
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -98,6 +468,97 @@ curl -X POST --data '{
 Retrieves a filtered and paginated list of proposals.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceProposalsList {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    struct PageRequest {
+        bytes key;
+        uint64 offset;
+        uint64 limit;
+        bool countTotal;
+        bool reverse;
+    }
+    
+    struct PageResponse {
+        bytes nextKey;
+        uint64 total;
+    }
+    
+    struct ProposalData {
+        uint64 id;
+        string[] messages;
+        uint32 status;
+        TallyResultData finalTallyResult;
+        uint64 submitTime;
+        uint64 depositEndTime;
+        Coin[] totalDeposit;
+        uint64 votingStartTime;
+        uint64 votingEndTime;
+        string metadata;
+        string title;
+        string summary;
+        address proposer;
+    }
+    
+    struct TallyResultData {
+        string yes;
+        string abstain;
+        string no;
+        string noWithVeto;
+    }
+    
+    struct Coin {
+        string denom;
+        uint256 amount;
+    }
+    
+    function getProposals(
+        uint32 proposalStatus,
+        address voter,
+        address depositor,
+        PageRequest memory pagination
+    ) external view returns (ProposalData[] memory proposals, PageResponse memory pageResponse) {
+        (bool success, bytes memory result) = GOVERNANCE_PRECOMPILE.staticcall(
+            abi.encodeWithSignature(
+                "getProposals(uint32,address,address,(bytes,uint64,uint64,bool,bool))",
+                proposalStatus,
+                voter,
+                depositor,
+                pagination
+            )
+        );
+        
+        require(success, "Failed to get proposals");
+        (proposals, pageResponse) = abi.decode(result, (ProposalData[], PageResponse));
+        return (proposals, pageResponse);
+    }
+    
+    // Helper function to get all active proposals (in voting period)
+    function getActiveProposals(uint64 limit) external view returns (ProposalData[] memory) {
+        PageRequest memory pagination = PageRequest({
+            key: "",
+            offset: 0,
+            limit: limit,
+            countTotal: true,
+            reverse: false
+        });
+        
+        uint32 votingStatus = 2; // PROPOSAL_STATUS_VOTING_PERIOD
+        (ProposalData[] memory proposals,) = this.getProposals(
+            votingStatus,
+            address(0),
+            address(0),
+            pagination
+        );
+        
+        return proposals;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -159,6 +620,42 @@ curl -X POST --data '{
 Retrieves the current or final vote tally for a proposal.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceTally {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    struct TallyResultData {
+        string yes;
+        string abstain;
+        string no;
+        string noWithVeto;
+    }
+    
+    function getTallyResult(uint64 proposalId) external view returns (TallyResultData memory tallyResult) {
+        require(proposalId > 0, "Invalid proposal ID");
+        
+        (bool success, bytes memory result) = GOVERNANCE_PRECOMPILE.staticcall(
+            abi.encodeWithSignature("getTallyResult(uint64)", proposalId)
+        );
+        
+        require(success, "Failed to get tally result");
+        tallyResult = abi.decode(result, (TallyResultData));
+        return tallyResult;
+    }
+    
+    // Helper function to check if proposal is passing
+    function isProposalPassing(uint64 proposalId) external view returns (bool) {
+        TallyResultData memory tally = this.getTallyResult(proposalId);
+        
+        // Convert string votes to numbers for comparison (simplified)
+        // In production, use proper decimal math libraries
+        return keccak256(bytes(tally.yes)) > keccak256(bytes(tally.no));
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -214,6 +711,56 @@ curl -X POST --data '{
 Retrieves the vote cast by a specific address on a proposal.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceVoteQuery {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    enum VoteOption {
+        Unspecified,
+        Yes,
+        Abstain,
+        No,
+        NoWithVeto
+    }
+    
+    struct WeightedVoteOption {
+        VoteOption option;
+        string weight;
+    }
+    
+    struct WeightedVote {
+        uint64 proposalId;
+        address voter;
+        WeightedVoteOption[] options;
+        string metadata;
+    }
+    
+    function getVote(uint64 proposalId, address voter) external view returns (WeightedVote memory vote) {
+        require(proposalId > 0, "Invalid proposal ID");
+        require(voter != address(0), "Invalid voter address");
+        
+        (bool success, bytes memory result) = GOVERNANCE_PRECOMPILE.staticcall(
+            abi.encodeWithSignature("getVote(uint64,address)", proposalId, voter)
+        );
+        
+        require(success, "Failed to get vote");
+        vote = abi.decode(result, (WeightedVote));
+        return vote;
+    }
+    
+    // Helper function to check if an address has voted
+    function hasVoted(uint64 proposalId, address voter) external view returns (bool) {
+        try this.getVote(proposalId, voter) returns (WeightedVote memory vote) {
+            return vote.options.length > 0;
+        } catch {
+            return false;
+        }
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -265,6 +812,96 @@ curl -X POST --data '{
 Retrieves all votes cast on a proposal, with pagination.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceVotesList {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    struct PageRequest {
+        bytes key;
+        uint64 offset;
+        uint64 limit;
+        bool countTotal;
+        bool reverse;
+    }
+    
+    struct PageResponse {
+        bytes nextKey;
+        uint64 total;
+    }
+    
+    enum VoteOption {
+        Unspecified,
+        Yes,
+        Abstain,
+        No,
+        NoWithVeto
+    }
+    
+    struct WeightedVoteOption {
+        VoteOption option;
+        string weight;
+    }
+    
+    struct WeightedVote {
+        uint64 proposalId;
+        address voter;
+        WeightedVoteOption[] options;
+        string metadata;
+    }
+    
+    function getVotes(
+        uint64 proposalId,
+        PageRequest memory pagination
+    ) external view returns (WeightedVote[] memory votes, PageResponse memory pageResponse) {
+        require(proposalId > 0, "Invalid proposal ID");
+        
+        (bool success, bytes memory result) = GOVERNANCE_PRECOMPILE.staticcall(
+            abi.encodeWithSignature(
+                "getVotes(uint64,(bytes,uint64,uint64,bool,bool))",
+                proposalId,
+                pagination
+            )
+        );
+        
+        require(success, "Failed to get votes");
+        (votes, pageResponse) = abi.decode(result, (WeightedVote[], PageResponse));
+        return (votes, pageResponse);
+    }
+    
+    // Helper function to get all Yes votes
+    function getYesVoters(uint64 proposalId, uint64 limit) external view returns (address[] memory) {
+        PageRequest memory pagination = PageRequest({
+            key: "",
+            offset: 0,
+            limit: limit,
+            countTotal: false,
+            reverse: false
+        });
+        
+        (WeightedVote[] memory votes,) = this.getVotes(proposalId, pagination);
+        
+        uint256 yesCount = 0;
+        for (uint i = 0; i < votes.length; i++) {
+            if (votes[i].options.length > 0 && votes[i].options[0].option == VoteOption.Yes) {
+                yesCount++;
+            }
+        }
+        
+        address[] memory yesVoters = new address[](yesCount);
+        uint256 index = 0;
+        for (uint i = 0; i < votes.length; i++) {
+            if (votes[i].options.length > 0 && votes[i].options[0].option == VoteOption.Yes) {
+                yesVoters[index++] = votes[i].voter;
+            }
+        }
+        
+        return yesVoters;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -323,6 +960,51 @@ curl -X POST --data '{
 Retrieves deposit information for a specific depositor on a proposal.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceDepositQuery {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    struct Coin {
+        string denom;
+        uint256 amount;
+    }
+    
+    struct DepositData {
+        uint64 proposalId;
+        address depositor;
+        Coin[] amount;
+    }
+    
+    function getDeposit(uint64 proposalId, address depositor) external view returns (DepositData memory deposit) {
+        require(proposalId > 0, "Invalid proposal ID");
+        require(depositor != address(0), "Invalid depositor address");
+        
+        (bool success, bytes memory result) = GOVERNANCE_PRECOMPILE.staticcall(
+            abi.encodeWithSignature("getDeposit(uint64,address)", proposalId, depositor)
+        );
+        
+        require(success, "Failed to get deposit");
+        deposit = abi.decode(result, (DepositData));
+        return deposit;
+    }
+    
+    // Helper function to get total deposit amount for a specific denom
+    function getDepositAmount(uint64 proposalId, address depositor, string memory denom) external view returns (uint256) {
+        DepositData memory deposit = this.getDeposit(proposalId, depositor);
+        
+        for (uint i = 0; i < deposit.amount.length; i++) {
+            if (keccak256(bytes(deposit.amount[i].denom)) == keccak256(bytes(denom))) {
+                return deposit.amount[i].amount;
+            }
+        }
+        
+        return 0;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -374,6 +1056,77 @@ curl -X POST --data '{
 Retrieves all deposits made on a proposal, with pagination.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceDepositsList {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    struct PageRequest {
+        bytes key;
+        uint64 offset;
+        uint64 limit;
+        bool countTotal;
+        bool reverse;
+    }
+    
+    struct PageResponse {
+        bytes nextKey;
+        uint64 total;
+    }
+    
+    struct Coin {
+        string denom;
+        uint256 amount;
+    }
+    
+    struct DepositData {
+        uint64 proposalId;
+        address depositor;
+        Coin[] amount;
+    }
+    
+    function getDeposits(
+        uint64 proposalId,
+        PageRequest memory pagination
+    ) external view returns (DepositData[] memory deposits, PageResponse memory pageResponse) {
+        require(proposalId > 0, "Invalid proposal ID");
+        
+        (bool success, bytes memory result) = GOVERNANCE_PRECOMPILE.staticcall(
+            abi.encodeWithSignature(
+                "getDeposits(uint64,(bytes,uint64,uint64,bool,bool))",
+                proposalId,
+                pagination
+            )
+        );
+        
+        require(success, "Failed to get deposits");
+        (deposits, pageResponse) = abi.decode(result, (DepositData[], PageResponse));
+        return (deposits, pageResponse);
+    }
+    
+    // Helper function to get all depositors
+    function getDepositors(uint64 proposalId, uint64 limit) external view returns (address[] memory) {
+        PageRequest memory pagination = PageRequest({
+            key: "",
+            offset: 0,
+            limit: limit,
+            countTotal: false,
+            reverse: false
+        });
+        
+        (DepositData[] memory deposits,) = this.getDeposits(proposalId, pagination);
+        
+        address[] memory depositors = new address[](deposits.length);
+        for (uint i = 0; i < deposits.length; i++) {
+            depositors[i] = deposits[i].depositor;
+        }
+        
+        return depositors;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -432,6 +1185,67 @@ curl -X POST --data '{
 Retrieves current governance parameters.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceParams {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    struct Coin {
+        string denom;
+        uint256 amount;
+    }
+    
+    struct Params {
+        int64 votingPeriod;
+        Coin[] minDeposit;
+        int64 maxDepositPeriod;
+        string quorum;
+        string threshold;
+        string vetoThreshold;
+        string minInitialDepositRatio;
+        string proposalCancelRatio;
+        string proposalCancelDest;
+        int64 expeditedVotingPeriod;
+        string expeditedThreshold;
+        Coin[] expeditedMinDeposit;
+        bool burnVoteQuorum;
+        bool burnProposalDepositPrevote;
+        bool burnVoteVeto;
+        string minDepositRatio;
+    }
+    
+    function getParams() external view returns (Params memory params) {
+        (bool success, bytes memory result) = GOVERNANCE_PRECOMPILE.staticcall(
+            abi.encodeWithSignature("getParams()")
+        );
+        
+        require(success, "Failed to get params");
+        params = abi.decode(result, (Params));
+        return params;
+    }
+    
+    // Helper function to get minimum deposit amount for a specific denom
+    function getMinDepositForDenom(string memory denom) external view returns (uint256) {
+        Params memory params = this.getParams();
+        
+        for (uint i = 0; i < params.minDeposit.length; i++) {
+            if (keccak256(bytes(params.minDeposit[i].denom)) == keccak256(bytes(denom))) {
+                return params.minDeposit[i].amount;
+            }
+        }
+        
+        return 0;
+    }
+    
+    // Helper function to get voting period in seconds
+    function getVotingPeriodSeconds() external view returns (int64) {
+        Params memory params = this.getParams();
+        return params.votingPeriod;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -481,6 +1295,36 @@ curl -X POST --data '{
 Retrieves the current governance constitution.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GovernanceConstitution {
+    address constant GOVERNANCE_PRECOMPILE = 0x0000000000000000000000000000000000000805;
+    
+    function getConstitution() external view returns (string memory constitution) {
+        (bool success, bytes memory result) = GOVERNANCE_PRECOMPILE.staticcall(
+            abi.encodeWithSignature("getConstitution()")
+        );
+        
+        require(success, "Failed to get constitution");
+        constitution = abi.decode(result, (string));
+        return constitution;
+    }
+    
+    // Helper function to check if constitution is set
+    function hasConstitution() external view returns (bool) {
+        string memory constitution = this.getConstitution();
+        return bytes(constitution).length > 0;
+    }
+    
+    // Helper function to get constitution length
+    function getConstitutionLength() external view returns (uint256) {
+        string memory constitution = this.getConstitution();
+        return bytes(constitution).length;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 

--- a/docs/next/documentation/smart-contracts/precompiles/ics20.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/ics20.mdx
@@ -74,6 +74,96 @@ Initiates a cross-chain token transfer using the IBC protocol.
 </Warning>
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ICS20Example {
+    address constant ICS20_PRECOMPILE = 0x0000000000000000000000000000000000000802;
+    
+    struct Height {
+        uint64 revisionNumber;
+        uint64 revisionHeight;
+    }
+    
+    event IBCTransferInitiated(
+        address indexed sender, 
+        string indexed receiver, 
+        string sourceChannel,
+        string denom,
+        uint256 amount,
+        uint64 sequence
+    );
+    
+    function transfer(
+        string calldata sourceChannel,
+        string calldata denom,
+        uint256 amount,
+        string calldata receiver,
+        uint64 timeoutTimestamp,
+        string calldata memo
+    ) external payable returns (uint64 sequence) {
+        require(bytes(sourceChannel).length > 0, "Source channel required");
+        require(bytes(denom).length > 0, "Denom required");
+        require(amount > 0, "Amount must be greater than 0");
+        require(bytes(receiver).length > 0, "Receiver address required");
+        require(timeoutTimestamp > 0, "Timeout timestamp required");
+        
+        // Default port for ICS20 transfers
+        string memory sourcePort = "transfer";
+        
+        // Disable height-based timeout (using timestamp instead)
+        Height memory timeoutHeight = Height({
+            revisionNumber: 0,
+            revisionHeight: 0
+        });
+        
+        (bool success, bytes memory result) = ICS20_PRECOMPILE.call{value: msg.value}(
+            abi.encodeWithSignature(
+                "transfer(string,string,string,uint256,address,string,tuple(uint64,uint64),uint64,string)",
+                sourcePort,
+                sourceChannel,
+                denom,
+                amount,
+                msg.sender,
+                receiver,
+                timeoutHeight,
+                timeoutTimestamp,
+                memo
+            )
+        );
+        
+        require(success, "IBC transfer failed");
+        sequence = abi.decode(result, (uint64));
+        
+        emit IBCTransferInitiated(msg.sender, receiver, sourceChannel, denom, amount, sequence);
+        return sequence;
+    }
+    
+    // Helper function to calculate timeout (1 hour from now)
+    function calculateTimeout(uint256 durationSeconds) external view returns (uint64) {
+        return uint64((block.timestamp + durationSeconds) * 1e9); // Convert to nanoseconds
+    }
+    
+    // Quick transfer with 1-hour timeout
+    function quickTransfer(
+        string calldata sourceChannel,
+        string calldata denom,
+        uint256 amount,
+        string calldata receiver
+    ) external payable returns (uint64) {
+        uint64 timeoutTimestamp = this.calculateTimeout(3600); // 1 hour
+        return this.transfer{value: msg.value}(
+            sourceChannel,
+            denom,
+            amount,
+            receiver,
+            timeoutTimestamp,
+            ""
+        );
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -91,7 +181,7 @@ const contract = new ethers.Contract(precompileAddress, precompileAbi, signer);
 // Transfer parameters
 const sourcePort = "transfer";
 const sourceChannel = "channel-0";
-const denom = "uatom"; // Token denomination
+const denom = "test"; // Token denomination
 const amount = ethers.parseEther("1.0"); // Amount to transfer
 const sender = await signer.getAddress();
 const receiver = "cosmos1..."; // Destination address on target chain
@@ -137,6 +227,48 @@ echo "IBC transfer requires a signed transaction - use ethers.js or other Web3 l
 Queries denomination information for an IBC token by its hash.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ICS20DenomQuery {
+    address constant ICS20_PRECOMPILE = 0x0000000000000000000000000000000000000802;
+    
+    struct Hop {
+        string portId;
+        string channelId;
+    }
+    
+    struct Denom {
+        string base;
+        Hop[] trace;
+    }
+    
+    function getDenom(string memory hash) external view returns (Denom memory denom) {
+        require(bytes(hash).length > 0, "Hash cannot be empty");
+        
+        (bool success, bytes memory result) = ICS20_PRECOMPILE.staticcall(
+            abi.encodeWithSignature("denom(string)", hash)
+        );
+        
+        require(success, "Failed to get denom");
+        denom = abi.decode(result, (Denom));
+        return denom;
+    }
+    
+    // Helper function to check if a denom is native (no trace)
+    function isNativeDenom(string memory hash) external view returns (bool) {
+        Denom memory denom = this.getDenom(hash);
+        return denom.trace.length == 0;
+    }
+    
+    // Helper function to get the base denomination
+    function getBaseDenom(string memory hash) external view returns (string memory) {
+        Denom memory denom = this.getDenom(hash);
+        return denom.base;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -185,6 +317,86 @@ curl -X POST --data '{
 Retrieves a paginated list of all denomination traces registered on the chain.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ICS20DenomsList {
+    address constant ICS20_PRECOMPILE = 0x0000000000000000000000000000000000000802;
+    
+    struct PageRequest {
+        bytes key;
+        uint64 offset;
+        uint64 limit;
+        bool countTotal;
+        bool reverse;
+    }
+    
+    struct PageResponse {
+        bytes nextKey;
+        uint64 total;
+    }
+    
+    struct Hop {
+        string portId;
+        string channelId;
+    }
+    
+    struct Denom {
+        string base;
+        Hop[] trace;
+    }
+    
+    function getDenoms(PageRequest memory pageRequest) 
+        external 
+        view 
+        returns (Denom[] memory denoms, PageResponse memory pageResponse) 
+    {
+        (bool success, bytes memory result) = ICS20_PRECOMPILE.staticcall(
+            abi.encodeWithSignature(
+                "denoms((bytes,uint64,uint64,bool,bool))",
+                pageRequest
+            )
+        );
+        
+        require(success, "Failed to get denoms");
+        (denoms, pageResponse) = abi.decode(result, (Denom[], PageResponse));
+        return (denoms, pageResponse);
+    }
+    
+    // Helper function to get all IBC denoms (with trace)
+    function getIBCDenoms(uint64 limit) external view returns (Denom[] memory) {
+        PageRequest memory pageRequest = PageRequest({
+            key: "",
+            offset: 0,
+            limit: limit,
+            countTotal: false,
+            reverse: false
+        });
+        
+        (Denom[] memory allDenoms,) = this.getDenoms(pageRequest);
+        
+        // Count IBC denoms (those with trace)
+        uint256 ibcCount = 0;
+        for (uint i = 0; i < allDenoms.length; i++) {
+            if (allDenoms[i].trace.length > 0) {
+                ibcCount++;
+            }
+        }
+        
+        // Filter IBC denoms
+        Denom[] memory ibcDenoms = new Denom[](ibcCount);
+        uint256 index = 0;
+        for (uint i = 0; i < allDenoms.length; i++) {
+            if (allDenoms[i].trace.length > 0) {
+                ibcDenoms[index++] = allDenoms[i];
+            }
+        }
+        
+        return ibcDenoms;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -241,6 +453,53 @@ curl -X POST --data '{
 Computes the hash of a denomination trace path.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ICS20DenomHash {
+    address constant ICS20_PRECOMPILE = 0x0000000000000000000000000000000000000802;
+    
+    function getDenomHash(string memory trace) external view returns (string memory hash) {
+        require(bytes(trace).length > 0, "Trace cannot be empty");
+        
+        (bool success, bytes memory result) = ICS20_PRECOMPILE.staticcall(
+            abi.encodeWithSignature("denomHash(string)", trace)
+        );
+        
+        require(success, "Failed to compute denom hash");
+        hash = abi.decode(result, (string));
+        return hash;
+    }
+    
+    // Helper function to build and hash a trace path
+    function buildAndHashTrace(
+        string memory portId,
+        string memory channelId,
+        string memory baseDenom
+    ) external view returns (string memory) {
+        // Build trace in format: "port/channel/denom"
+        string memory trace = string(abi.encodePacked(
+            portId,
+            "/",
+            channelId,
+            "/",
+            baseDenom
+        ));
+        
+        return this.getDenomHash(trace);
+    }
+    
+    // Helper function to verify if a hash matches a trace
+    function verifyDenomHash(
+        string memory trace,
+        string memory expectedHash
+    ) external view returns (bool) {
+        string memory actualHash = this.getDenomHash(trace);
+        return keccak256(bytes(actualHash)) == keccak256(bytes(expectedHash));
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -255,7 +514,7 @@ const precompileAddress = "0x0000000000000000000000000000000000000802";
 const contract = new ethers.Contract(precompileAddress, precompileAbi, provider);
 
 // Input: The trace path to hash
-const tracePath = "transfer/channel-0/uatom"; // Placeholder for actual trace path
+const tracePath = "transfer/channel-0/test"; // Placeholder for actual trace path
 
 async function getDenomHash() {
   try {

--- a/docs/next/documentation/smart-contracts/precompiles/index.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/index.mdx
@@ -4,36 +4,6 @@ description: "A hub for precompiled contracts that bridge EVM and Cosmos SDK mod
 keywords: ['precompiles', 'precompiled contracts', 'cosmos sdk', 'evm', 'smart contracts', 'hybrid applications', 'token decimals', 'native functionality', 'solidity interface', 'cosmos integration', 'chain precision', 'gas efficient']
 ---
 
-# Precompiled Contracts
-
-Precompiled contracts provide direct, gas-efficient access to native Cosmos SDK functionality from within the EVM. Build powerful hybrid applications that leverage the best of both worlds. This page provides an overview of the available precompiled contracts, each with detailed documentation on its usage, Solidity interface, and ABI.
-
-<Warning>
-  **Critical: Understanding Token Decimals in Precompiles**
-
-  All Cosmos EVM precompile contracts use the **native chain's decimal precision**, not Ethereum's standard 18 decimals (wei).
-
-  **Why this matters:**
-  - Cosmos chains typically use 6 decimals, while Ethereum uses 18
-  - Passing values while assuming conventional Ethereum exponents could cause significant miscalculations
-  - Example: On a 6-decimal chain, passing `1000000000000000000` (1 token in wei) will be interpreted as **1 trillion tokens**
-
-  **Before using any precompile:**
-  1. Check your chain's native token decimal precision
-  2. Convert amounts to match the native token's format
-  3. Never assume 18-decimal precision
-
-  ```solidity
-  // WRONG: Assuming Ethereum's 18 decimals
-  uint256 amount = 1 ether; // 1000000000000000000
-  staking.delegate(validator, amount); // Delegates 1 trillion tokens!
-
-  // CORRECT: Using chain's native 6 decimals
-  uint256 amount = 1000000; // 1 token with 6 decimals
-  staking.delegate(validator, amount); // Delegates 1 token
-  ```
-</Warning>
-
 ## Available Precompiles
 
 Access native Cosmos SDK features directly from Solidity:

--- a/docs/next/documentation/smart-contracts/precompiles/index.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/index.mdx
@@ -39,15 +39,15 @@ Precompiled contracts provide direct, gas-efficient access to native Cosmos SDK 
 Access native Cosmos SDK features directly from Solidity:
 
 <CardGroup cols={3}>
-  <Card title="Bank" icon="building-columns">
+  <Card title="Bank" icon="vault">
     Interface with native Cosmos SDK tokens for balance and supply queries.
     <a href="./bank">Explore Bank →</a>
   </Card>
-  <Card title="Bech32" icon="arrows-rotate">
+  <Card title="Bech32" icon="binary">
     Convert addresses between Ethereum hex and Cosmos bech32 formats.
     <a href="./bech32">Explore Bech32 →</a>
   </Card>
-  <Card title="Callbacks" icon="arrows-turn-right">
+  <Card title="Callbacks" icon="webhook">
     Handle IBC packet lifecycle callbacks in smart contracts.
     <a href="./callbacks">Explore Callbacks →</a>
   </Card>
@@ -55,19 +55,19 @@ Access native Cosmos SDK features directly from Solidity:
     Withdraw staking rewards and interact with the community pool.
     <a href="./distribution">Explore Distribution →</a>
   </Card>
-  <Card title="ERC20" icon="coins">
+  <Card title="ERC20" icon="refresh-cw">
     Utilize standard ERC20 token functionality for native Cosmos tokens.
     <a href="./erc20">Explore ERC20 →</a>
   </Card>
-  <Card title="Governance" icon="note">
+  <Card title="Governance" icon="scale">
     Participate in on-chain governance through proposals and voting.
     <a href="./governance">Explore Governance →</a>
   </Card>
-  <Card title="ICS20" icon="arrow-right-arrow-left">
+  <Card title="ICS20" icon="chevrons-left-right-ellipsis">
     Perform cross-chain token transfers via the IBC protocol.
     <a href="./ics20">Explore ICS20 →</a>
   </Card>
-  <Card title="P256" icon="key">
+  <Card title="P256" icon="shield-check">
     Execute P-256 elliptic curve cryptographic operations.
     <a href="./p256">Explore P256 →</a>
   </Card>
@@ -79,7 +79,7 @@ Access native Cosmos SDK features directly from Solidity:
     Perform validator operations, manage delegations, and handle staking.
     <a href="./staking">Explore Staking →</a>
   </Card>
-  <Card title="WERC20" icon="repeat">
+  <Card title="WERC20" icon="refresh-ccw">
     Wrap native tokens to provide ERC20-compatible functionality.
     <a href="./werc20">Explore WERC20 →</a>
   </Card>

--- a/docs/next/documentation/smart-contracts/precompiles/overview.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/overview.mdx
@@ -22,6 +22,34 @@ keywords: ['precompiles', 'precompiled contracts', 'cosmos sdk', 'evm', 'smart c
 
 ## Configuration
 
+Precompiled contracts provide direct, gas-efficient access to native Cosmos SDK functionality from within the EVM. Build powerful hybrid applications that leverage the best of both worlds. This page provides an overview of the available precompiled contracts, each with detailed documentation on its usage, Solidity interface, and ABI.
+
+<Warning>
+  **Critical: Understanding Token Decimals in Precompiles**
+
+  All Cosmos EVM precompile contracts use the **native chain's decimal precision**, not Ethereum's standard 18 decimals (wei).
+
+  **Why this matters:**
+  - Cosmos chains typically use 6 decimals, while Ethereum uses 18
+  - Passing values while assuming conventional Ethereum exponents could cause significant miscalculations
+  - Example: On a 6-decimal chain, passing `1000000000000000000` (1 token in wei) will be interpreted as **1 trillion tokens**
+
+  **Before using any precompile:**
+  1. Check your chain's native token decimal precision
+  2. Convert amounts to match the native token's format
+  3. Never assume 18-decimal precision
+
+  ```solidity
+  // WRONG: Assuming Ethereum's 18 decimals
+  uint256 amount = 1 ether; // 1000000000000000000
+  staking.delegate(validator, amount); // Delegates 1 trillion tokens!
+
+  // CORRECT: Using chain's native 6 decimals
+  uint256 amount = 1000000; // 1 token with 6 decimals
+  staking.delegate(validator, amount); // Delegates 1 token
+  ```
+</Warning>
+
 ### Genesis Configuration
 
 Precompiles must be enabled in the genesis file to be available on the network. The `active_static_precompiles` parameter controls which precompiles are activated at network launch.
@@ -33,7 +61,7 @@ Precompiles must be enabled in the genesis file to be available on the network. 
       "params": {
         "active_static_precompiles": [
           "0x0000000000000000000000000000000000000100",  // P256
-          "0x0000000000000000000000000000000000000400",  // Bech32  
+          "0x0000000000000000000000000000000000000400",  // Bech32
           "0x0000000000000000000000000000000000000800",  // Staking
           "0x0000000000000000000000000000000000000801",  // Distribution
           "0x0000000000000000000000000000000000000802",  // ICS20
@@ -67,7 +95,7 @@ All precompile constructors in v0.5.0 now require keeper interfaces instead of c
 // Concrete keeper types required
 bankPrecompile, err := bankprecompile.NewPrecompile(
     bankKeeper,      // bankkeeper.Keeper concrete type
-    stakingKeeper,   // stakingkeeper.Keeper concrete type  
+    stakingKeeper,   // stakingkeeper.Keeper concrete type
     // ... other keepers
 )
 ```
@@ -110,7 +138,7 @@ func NewCustomPrecompile(
     }, nil
 }
 
-// After (v0.5.0)  
+// After (v0.5.0)
 func NewCustomPrecompile(
     bankKeeper common.BankKeeper,        // Interface instead of concrete type
     stakingKeeper common.StakingKeeper,  // Interface instead of concrete type
@@ -134,7 +162,7 @@ func NewAvailableStaticPrecompiles(
     opts ...Option,
 ) map[common.Address]vm.PrecompiledContract {
     precompiles := make(map[common.Address]vm.PrecompiledContract)
-    
+
     // No casting needed - parameters are already interface types
     bankPrecompile, err := bankprecompile.NewPrecompile(bankKeeper, erc20Keeper)
     if err != nil {
@@ -177,11 +205,11 @@ import "./IStaking.sol";
 contract MyDApp {
     IBank constant bank = IBank(0x0000000000000000000000000000000000000804);
     IStaking constant staking = IStaking(0x0000000000000000000000000000000000000800);
-    
+
     function getBalance(string memory denom) external view returns (uint256) {
         return bank.balances(msg.sender, denom);
     }
-    
+
     function delegateTokens(string memory validatorAddr, uint256 amount) external {
         staking.delegate(msg.sender, validatorAddr, amount);
     }

--- a/docs/next/documentation/smart-contracts/precompiles/slashing.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/slashing.mdx
@@ -28,6 +28,98 @@ Gas costs are approximated and may vary based on chain settings.
 ### `unjail`
 Allows a validator to unjail themselves after being jailed for downtime.
 
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract SlashingExample {
+    address constant SLASHING_PRECOMPILE = 0x0000000000000000000000000000000000000806;
+    
+    struct SigningInfo {
+        address validatorAddress;
+        int64 startHeight;
+        int64 indexOffset;
+        int64 jailedUntil;
+        bool tombstoned;
+        int64 missedBlocksCounter;
+    }
+    
+    event ValidatorUnjailed(address indexed validator);
+    event ValidatorSlashingInfoQueried(address indexed validator, bool isJailed, bool isTombstoned);
+    
+    function unjailValidator(address validatorAddress) external returns (bool success) {
+        require(validatorAddress != address(0), "Invalid validator address");
+        
+        // Check signing info to prevent unjailing tombstoned validators
+        SigningInfo memory info = this.getValidatorSigningInfo(validatorAddress);
+        require(!info.tombstoned, "Tombstoned validators cannot be unjailed");
+        require(info.jailedUntil > int64(int256(block.timestamp)), "Validator is not jailed");
+        
+        (bool callSuccess, bytes memory result) = SLASHING_PRECOMPILE.call(
+            abi.encodeWithSignature("unjail(address)", validatorAddress)
+        );
+        
+        require(callSuccess, "Unjail call failed");
+        success = abi.decode(result, (bool));
+        require(success, "Unjail operation failed");
+        
+        emit ValidatorUnjailed(validatorAddress);
+        return success;
+    }
+    
+    function getValidatorSigningInfo(address consAddress) 
+        external 
+        view 
+        returns (SigningInfo memory signingInfo) 
+    {
+        (bool success, bytes memory result) = SLASHING_PRECOMPILE.staticcall(
+            abi.encodeWithSignature("getSigningInfo(address)", consAddress)
+        );
+        
+        require(success, "Signing info query failed");
+        signingInfo = abi.decode(result, (SigningInfo));
+        return signingInfo;
+    }
+    
+    function canValidatorBeUnjailed(address consAddress) 
+        external 
+        view 
+        returns (bool canUnjail, string memory reason) 
+    {
+        SigningInfo memory info = this.getValidatorSigningInfo(consAddress);
+        
+        // CRITICAL: Tombstoned validators can NEVER be unjailed
+        if (info.tombstoned) {
+            return (false, "PERMANENT_TOMBSTONE: Validator can never be unjailed due to severe infractions (e.g., double-signing)");
+        }
+        
+        if (info.jailedUntil <= int64(int256(block.timestamp))) {
+            return (false, "Validator is not currently jailed");
+        }
+        
+        return (true, "Validator can be unjailed");
+    }
+    
+    function getValidatorStatus(address consAddress) 
+        external 
+        view 
+        returns (bool isJailed, bool isTombstoned, int64 missedBlocks) 
+    {
+        SigningInfo memory info = this.getValidatorSigningInfo(consAddress);
+        
+        isJailed = info.jailedUntil > int64(int256(block.timestamp));
+        isTombstoned = info.tombstoned;
+        missedBlocks = info.missedBlocksCounter;
+        
+        emit ValidatorSlashingInfoQueried(consAddress, isJailed, isTombstoned);
+        
+        return (isJailed, isTombstoned, missedBlocks);
+    }
+}
+```
+</CodeGroup>
+
 ## Query Methods
 
 ### `getSigningInfo`

--- a/docs/next/documentation/smart-contracts/precompiles/staking.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/staking.mdx
@@ -28,13 +28,138 @@ Gas costs are approximated and may vary based on the complexity of the staking o
 ### `createValidator`
 Creates a new validator.
 
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract StakingExample {
+    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    
+    struct Description {
+        string moniker;
+        string identity;
+        string website;
+        string securityContact;
+        string details;
+    }
+    
+    struct CommissionRates {
+        uint256 rate;
+        uint256 maxRate;
+        uint256 maxChangeRate;
+    }
+    
+    event ValidatorCreated(address indexed validatorAddress, string moniker, uint256 value);
+    
+    function createNewValidator(
+        Description calldata description,
+        CommissionRates calldata commissionRates,
+        uint256 minSelfDelegation,
+        string calldata pubkey,
+        uint256 value
+    ) external payable returns (bool success) {
+        require(msg.value >= value, "Insufficient value sent");
+        
+        (bool callSuccess, bytes memory result) = STAKING_PRECOMPILE.call{value: value}(
+            abi.encodeWithSignature(
+                "createValidator((string,string,string,string,string),(uint256,uint256,uint256),uint256,address,string,uint256)",
+                description, commissionRates, minSelfDelegation, msg.sender, pubkey, value
+            )
+        );
+        
+        require(callSuccess, "Create validator failed");
+        success = abi.decode(result, (bool));
+        require(success, "Create validator returned false");
+        
+        emit ValidatorCreated(msg.sender, description.moniker, value);
+        return success;
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Validator creation requires a signed transaction"
+```
+</CodeGroup>
+
 ### `editValidator`
 Edits an existing validator's parameters.
+
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract StakingExample {
+    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    
+    struct Description {
+        string moniker;
+        string identity;
+        string website;
+        string securityContact;
+        string details;
+    }
+    
+    event ValidatorUpdated(address indexed validatorAddress, string moniker);
+    
+    function updateValidator(
+        Description calldata description,
+        int256 commissionRate,
+        int256 minSelfDelegation
+    ) external returns (bool success) {
+        (bool callSuccess, bytes memory result) = STAKING_PRECOMPILE.call(
+            abi.encodeWithSignature(
+                "editValidator((string,string,string,string,string),address,int256,int256)",
+                description, msg.sender, commissionRate, minSelfDelegation
+            )
+        );
+        
+        require(callSuccess, "Edit validator failed");
+        success = abi.decode(result, (bool));
+        require(success, "Edit validator returned false");
+        
+        emit ValidatorUpdated(msg.sender, description.moniker);
+        return success;
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Validator editing requires a signed transaction"
+```
+</CodeGroup>
 
 ### `delegate`
 Delegates tokens to a validator.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract StakingExample {
+    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    
+    event DelegationSuccess(address indexed delegator, string indexed validator, uint256 amount);
+    
+    function delegateTokens(string calldata validatorAddress, uint256 amount) external payable {
+        require(msg.value >= amount, "Insufficient value sent");
+        
+        // Call the staking precompile with correct signature
+        (bool success, bytes memory result) = STAKING_PRECOMPILE.call{value: amount}(
+            abi.encodeWithSignature("delegate(address,string,uint256)", msg.sender, validatorAddress, amount)
+        );
+        
+        require(success, "Delegation failed");
+        bool delegationSuccess = abi.decode(result, (bool));
+        require(delegationSuccess, "Delegation returned false");
+        
+        emit DelegationSuccess(msg.sender, validatorAddress, amount);
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -83,11 +208,143 @@ echo "Staking delegation requires a signed transaction - use ethers.js or other 
 ### `undelegate`
 Undelegates tokens from a validator.
 
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract StakingExample {
+    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    
+    event UndelegationStarted(address indexed delegator, string indexed validator, uint256 amount, int64 completionTime);
+    
+    function undelegateTokens(string calldata validatorAddress, uint256 amount) 
+        external returns (int64 completionTime) {
+        (bool success, bytes memory result) = STAKING_PRECOMPILE.call(
+            abi.encodeWithSignature("undelegate(address,string,uint256)", msg.sender, validatorAddress, amount)
+        );
+        
+        require(success, "Undelegation failed");
+        completionTime = abi.decode(result, (int64));
+        
+        emit UndelegationStarted(msg.sender, validatorAddress, amount, completionTime);
+        return completionTime;
+    }
+    
+    // Helper function to calculate days until completion
+    function getDaysUntilCompletion(int64 completionTime) external view returns (uint256 days) {
+        if (completionTime <= int64(block.timestamp)) {
+            return 0;
+        }
+        return uint256(uint64(completionTime - int64(block.timestamp))) / 86400;
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Undelegation requires a signed transaction"
+```
+</CodeGroup>
+
 ### `redelegate`
 Redelegates tokens from one validator to another.
 
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract StakingExample {
+    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    
+    event RedelegationStarted(
+        address indexed delegator, 
+        string indexed srcValidator, 
+        string indexed dstValidator, 
+        uint256 amount, 
+        int64 completionTime
+    );
+    
+    function redelegateTokens(
+        string calldata srcValidatorAddress,
+        string calldata dstValidatorAddress,
+        uint256 amount
+    ) external returns (int64 completionTime) {
+        require(bytes(srcValidatorAddress).length > 0, "Source validator cannot be empty");
+        require(bytes(dstValidatorAddress).length > 0, "Destination validator cannot be empty");
+        require(
+            keccak256(bytes(srcValidatorAddress)) != keccak256(bytes(dstValidatorAddress)), 
+            "Cannot redelegate to same validator"
+        );
+        
+        (bool success, bytes memory result) = STAKING_PRECOMPILE.call(
+            abi.encodeWithSignature(
+                "redelegate(address,string,string,uint256)", 
+                msg.sender, srcValidatorAddress, dstValidatorAddress, amount
+            )
+        );
+        
+        require(success, "Redelegation failed");
+        completionTime = abi.decode(result, (int64));
+        
+        emit RedelegationStarted(msg.sender, srcValidatorAddress, dstValidatorAddress, amount, completionTime);
+        return completionTime;
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Redelegation requires a signed transaction"
+```
+</CodeGroup>
+
 ### `cancelUnbondingDelegation`
 Cancels an unbonding delegation.
+
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract StakingExample {
+    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    
+    event UnbondingCancelled(
+        address indexed delegator, 
+        string indexed validator, 
+        uint256 amount, 
+        uint256 creationHeight
+    );
+    
+    function cancelUnbonding(
+        string calldata validatorAddress,
+        uint256 amount,
+        uint256 creationHeight
+    ) external returns (bool success) {
+        require(creationHeight > 0, "Creation height must be positive");
+        require(amount > 0, "Amount must be positive");
+        
+        (bool callSuccess, bytes memory result) = STAKING_PRECOMPILE.call(
+            abi.encodeWithSignature(
+                "cancelUnbondingDelegation(address,string,uint256,uint256)",
+                msg.sender, validatorAddress, amount, creationHeight
+            )
+        );
+        
+        require(callSuccess, "Cancel unbonding failed");
+        success = abi.decode(result, (bool));
+        require(success, "Cancel unbonding returned false");
+        
+        emit UnbondingCancelled(msg.sender, validatorAddress, amount, creationHeight);
+        return success;
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Transaction methods require signatures - use ethers.js or other Web3 library
+echo "Cancel unbonding requires a signed transaction"
+```
+</CodeGroup>
 
 ## Query Methods
 
@@ -95,6 +352,38 @@ Cancels an unbonding delegation.
 Queries information about a specific validator.
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract StakingExample {
+    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    
+    struct Validator {
+        string operatorAddress;
+        string consensusPubkey;
+        bool jailed;
+        uint8 status; // BondStatus enum
+        uint256 tokens;
+        uint256 delegatorShares;
+        string description;
+        int64 unbondingHeight;
+        int64 unbondingTime;
+        uint256 commission;
+        uint256 minSelfDelegation;
+    }
+    
+    function getValidator(address validatorAddress) external view returns (Validator memory validator) {
+        (bool success, bytes memory result) = STAKING_PRECOMPILE.staticcall(
+            abi.encodeWithSignature("validator(address)", validatorAddress)
+        );
+        
+        require(success, "Validator query failed");
+        validator = abi.decode(result, (Validator));
+        return validator;
+    }
+}
+```
 ```javascript Ethers.js expandable lines
 import { ethers } from "ethers";
 
@@ -108,13 +397,19 @@ const provider = new ethers.JsonRpcProvider("<RPC_URL>");
 const precompileAddress = "0x0000000000000000000000000000000000000800";
 const contract = new ethers.Contract(precompileAddress, precompileAbi, provider);
 
-// Input
-const validatorAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"; // Placeholder validator address
+// Input - use actual validator address from the network
+const validatorAddress = "0x7cB61D4117AE31a12E393a1Cfa3BaC666481D02E"; // Example validator address
 
 async function getValidator() {
   try {
     const validator = await contract.validator(validatorAddress);
-    console.log("Validator Info:", JSON.stringify(validator, null, 2));
+    console.log("Validator Info:", {
+      operatorAddress: validator.operatorAddress,
+      jailed: validator.jailed,
+      status: validator.status, // 0=Unspecified, 1=Unbonded, 2=Unbonding, 3=Bonded
+      tokens: ethers.formatEther(validator.tokens),
+      delegatorShares: ethers.formatEther(validator.delegatorShares)
+    });
   } catch (error) {
     console.error("Error fetching validator:", error);
   }
@@ -123,14 +418,15 @@ async function getValidator() {
 getValidator();
 ```
 ```bash cURL expandable lines
-# Note: Replace <RPC_URL> and the placeholder validator address with your actual data.
+# Note: Replace <RPC_URL> and the validator address with your actual data.
+# Data is ABI-encoded: validator(address) function selector + padded address parameter
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "eth_call",
     "params": [
         {
             "to": "0x0000000000000000000000000000000000000800",
-            "data": "0x3f33833b00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000031636f736d6f7376616c6f706572317179707178723732786b36706c63363637386c6c343265706871326c676c376c633732323577000000000000000000000000"
+            "data": "0x223b3b7a0000000000000000000000007cb61d4117ae31a12e393a1cfa3bac666481d02e"
         },
         "latest"
     ],
@@ -157,7 +453,7 @@ const precompileAddress = "0x0000000000000000000000000000000000000800";
 const contract = new ethers.Contract(precompileAddress, precompileAbi, provider);
 
 // Inputs
-const status = "Bonded";
+const status = "BOND_STATUS_BONDED";
 const pagination = {
   key: "0x",
   offset: 0,
@@ -187,7 +483,7 @@ curl -X POST --data '{
     "params": [
         {
             "to": "0x0000000000000000000000000000000000000800",
-            "data": "0x5374c43a00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000006426f6e6465640000000000000000000000000000000000000000000000000000"
+            "data": "0x186b2167000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000012424f4e445f5354415455535f424f4e444544000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
         },
         "latest"
     ],
@@ -214,8 +510,8 @@ const precompileAddress = "0x0000000000000000000000000000000000000800";
 const contract = new ethers.Contract(precompileAddress, precompileAbi, provider);
 
 // Inputs
-const delegatorAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"; // Placeholder
-const validatorAddress = "cosmosvaloper1qypqxr72xk6plc6678ll42ephq2lgl7lc7225w"; // Placeholder
+const delegatorAddress = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"; // Example delegator
+const validatorAddress = "cosmosvaloper10jmp6sgh4cc6zt3e8gw05wavvejgr5pw4xyrql"; // Example validator
 
 async function getDelegation() {
   try {
@@ -237,7 +533,7 @@ curl -X POST --data '{
     "params": [
         {
             "to": "0x0000000000000000000000000000000000000800",
-            "data": "0x41f33f63000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000031636f736d6f7376616c6f706572317179707178723732786b36706c63363637386c6c343265706871326c676c376c633732323577000000000000000000000000"
+            "data": "0x241774e6000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000346636f736d6f7376616c6f70657231306a6d7036736768346363367a743365386777303577617676656a677235707734787972716c00000000000000000000000000"
         },
         "latest"
     ],
@@ -264,8 +560,8 @@ const precompileAddress = "0x0000000000000000000000000000000000000800";
 const contract = new ethers.Contract(precompileAddress, precompileAbi, provider);
 
 // Inputs
-const delegatorAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"; // Placeholder
-const validatorAddress = "cosmosvaloper1qypqxr72xk6plc6678ll42ephq2lgl7lc7225w"; // Placeholder
+const delegatorAddress = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"; // Example delegator
+const validatorAddress = "cosmosvaloper10jmp6sgh4cc6zt3e8gw05wavvejgr5pw4xyrql"; // Example validator
 
 async function getUnbondingDelegation() {
   try {
@@ -286,7 +582,7 @@ curl -X POST --data '{
     "params": [
         {
             "to": "0x0000000000000000000000000000000000000800",
-            "data": "0x813b2933000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000031636f736d6f7376616c6f706572317179707178723732786b36706c63363637386c6c343265706871326c676c376c633732323577000000000000000000000000"
+            "data": "0xa03ffee1000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000346636f736d6f7376616c6f70657231306a6d7036736768346363367a743365386777303577617676656a677235707734787972716c00000000000000000000000000"
         },
         "latest"
     ],
@@ -297,6 +593,73 @@ curl -X POST --data '{
 
 ### `redelegation`
 Queries a specific redelegation.
+
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract StakingExample {
+    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    
+    struct RedelegationEntry {
+        int64 creationHeight;
+        int64 completionTime;
+        uint256 initialBalance;
+        uint256 sharesDst;
+    }
+    
+    struct RedelegationOutput {
+        string delegatorAddress;
+        string validatorSrcAddress;
+        string validatorDstAddress;
+        RedelegationEntry[] entries;
+    }
+    
+    function getRedelegation(
+        address delegatorAddress,
+        string calldata srcValidatorAddress,
+        string calldata dstValidatorAddress
+    ) external view returns (RedelegationOutput memory redelegation) {
+        (bool success, bytes memory result) = STAKING_PRECOMPILE.staticcall(
+            abi.encodeWithSignature(
+                "redelegation(address,string,string)",
+                delegatorAddress, srcValidatorAddress, dstValidatorAddress
+            )
+        );
+        
+        require(success, "Redelegation query failed");
+        redelegation = abi.decode(result, (RedelegationOutput));
+        return redelegation;
+    }
+    
+    // Check if redelegation is complete
+    function isRedelegationComplete(RedelegationOutput memory redelegation) external view returns (bool) {
+        for (uint i = 0; i < redelegation.entries.length; i++) {
+            if (redelegation.entries[i].completionTime > int64(block.timestamp)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+```
+```bash cURL expandable lines
+# Note: Replace addresses with your actual data
+curl -X POST --data '{
+    "jsonrpc": "2.0",
+    "method": "eth_call",
+    "params": [
+        {
+            "to": "0x0000000000000000000000000000000000000800",
+            "data": "0x..."  # ABI-encoded redelegation(address,string,string) call
+        },
+        "latest"
+    ],
+    "id": 1
+}' -H "Content-Type: application/json" <RPC_URL>
+```
+</CodeGroup>
 
 ### `redelegations`
 Queries redelegations with optional filters.
@@ -316,7 +679,7 @@ const precompileAddress = "0x0000000000000000000000000000000000000800";
 const contract = new ethers.Contract(precompileAddress, precompileAbi, provider);
 
 // Inputs
-const delegatorAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"; // Placeholder
+const delegatorAddress = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"; // Example delegator
 const srcValidatorAddress = ""; // Empty string for all
 const dstValidatorAddress = ""; // Empty string for all
 const pagination = {
@@ -348,7 +711,7 @@ curl -X POST --data '{
     "params": [
         {
             "to": "0x0000000000000000000000000000000000000800",
-            "data": "0x289e728a000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            "data": "0x10a2851c000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000064000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
         },
         "latest"
     ],
@@ -392,9 +755,9 @@ struct Description {
 
 // CommissionRates defines the initial commission rates to be used for a validator
 struct CommissionRates {
-    string rate;
-    string maxRate;
-    string maxChangeRate;
+    uint256 rate;
+    uint256 maxRate;
+    uint256 maxChangeRate;
 }
 
 // Commission defines a commission parameters for a given validator.
@@ -408,13 +771,13 @@ struct Validator {
     string operatorAddress;
     string consensusPubkey;
     bool jailed;
-    uint32 status;
+    uint8 status; // BondStatus enum: 0=Unspecified, 1=Unbonded, 2=Unbonding, 3=Bonded
     uint256 tokens;
-    string delegatorShares;
-    Description description;
+    uint256 delegatorShares;
+    string description;
     int64 unbondingHeight;
-    uint256 unbondingTime;
-    Commission commission;
+    int64 unbondingTime;
+    uint256 commission;
     uint256 minSelfDelegation;
 }
 
@@ -514,19 +877,19 @@ interface StakingI {
     // Transactions
     function createValidator(
         Description calldata description,
-        CommissionRates calldata commission,
+        CommissionRates calldata commissionRates,
         uint256 minSelfDelegation,
-        string calldata validatorAddress,
+        address validatorAddress,
         string calldata pubkey,
-        address value
-    ) external payable returns (bool);
+        uint256 value
+    ) external returns (bool success);
 
     function editValidator(
         Description calldata description,
-        string calldata validatorAddress,
-        uint256 commissionRate,
-        uint256 minSelfDelegation
-    ) external returns (bool);
+        address validatorAddress,
+        int256 commissionRate,
+        int256 minSelfDelegation
+    ) external returns (bool success);
 
     function delegate(
         address delegatorAddress,
@@ -556,7 +919,7 @@ interface StakingI {
 
     // Queries
     function validator(
-        string calldata validatorAddress
+        address validatorAddress
     ) external view returns (Validator memory);
 
     function validators(
@@ -567,7 +930,7 @@ interface StakingI {
     function delegation(
         address delegatorAddress,
         string calldata validatorAddress
-    ) external view returns (uint256);
+    ) external view returns (uint256 shares, Coin memory balance);
 
     function unbondingDelegation(
         address delegatorAddress,

--- a/docs/next/documentation/smart-contracts/precompiles/staking.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/staking.mdx
@@ -33,9 +33,8 @@ Creates a new validator.
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-contract StakingExample {
-    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
-    
+// Interface for the Staking precompile
+interface IStaking {
     struct Description {
         string moniker;
         string identity;
@@ -50,30 +49,55 @@ contract StakingExample {
         uint256 maxChangeRate;
     }
     
+    function createValidator(
+        Description memory description,
+        CommissionRates memory commissionRates,
+        uint256 minSelfDelegation,
+        address validatorAddress,
+        string memory pubkey,
+        uint256 value
+    ) external returns (bool success);
+}
+
+contract StakingExample {
+    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    IStaking public immutable staking;
+    
     event ValidatorCreated(address indexed validatorAddress, string moniker, uint256 value);
     
+    error InvalidInput();
+    error InsufficientValue();
+    error StakingOperationFailed();
+    
+    constructor() {
+        staking = IStaking(STAKING_PRECOMPILE);
+    }
+    
     function createNewValidator(
-        Description calldata description,
-        CommissionRates calldata commissionRates,
+        IStaking.Description calldata description,
+        IStaking.CommissionRates calldata commissionRates,
         uint256 minSelfDelegation,
         string calldata pubkey,
         uint256 value
     ) external payable returns (bool success) {
-        require(msg.value >= value, "Insufficient value sent");
+        if (msg.value < value) revert InsufficientValue();
+        if (bytes(description.moniker).length == 0) revert InvalidInput();
+        if (bytes(pubkey).length == 0) revert InvalidInput();
         
-        (bool callSuccess, bytes memory result) = STAKING_PRECOMPILE.call{value: value}(
-            abi.encodeWithSignature(
-                "createValidator((string,string,string,string,string),(uint256,uint256,uint256),uint256,address,string,uint256)",
-                description, commissionRates, minSelfDelegation, msg.sender, pubkey, value
-            )
-        );
-        
-        require(callSuccess, "Create validator failed");
-        success = abi.decode(result, (bool));
-        require(success, "Create validator returned false");
-        
-        emit ValidatorCreated(msg.sender, description.moniker, value);
-        return success;
+        try staking.createValidator(
+            description, 
+            commissionRates, 
+            minSelfDelegation, 
+            msg.sender, 
+            pubkey, 
+            value
+        ) returns (bool result) {
+            if (!result) revert StakingOperationFailed();
+            emit ValidatorCreated(msg.sender, description.moniker, value);
+            return result;
+        } catch {
+            revert StakingOperationFailed();
+        }
     }
 }
 ```
@@ -91,9 +115,8 @@ Edits an existing validator's parameters.
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-contract StakingExample {
-    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
-    
+// Interface for the Staking precompile
+interface IStaking {
     struct Description {
         string moniker;
         string identity;
@@ -102,26 +125,40 @@ contract StakingExample {
         string details;
     }
     
+    function editValidator(
+        Description memory description,
+        uint256 commissionRate,
+        uint256 minSelfDelegation
+    ) external returns (bool success);
+}
+
+contract StakingExample {
+    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    IStaking public immutable staking;
+    
     event ValidatorUpdated(address indexed validatorAddress, string moniker);
     
+    error InvalidInput();
+    error StakingOperationFailed();
+    
+    constructor() {
+        staking = IStaking(STAKING_PRECOMPILE);
+    }
+    
     function updateValidator(
-        Description calldata description,
-        int256 commissionRate,
-        int256 minSelfDelegation
+        IStaking.Description calldata description,
+        uint256 commissionRate,
+        uint256 minSelfDelegation
     ) external returns (bool success) {
-        (bool callSuccess, bytes memory result) = STAKING_PRECOMPILE.call(
-            abi.encodeWithSignature(
-                "editValidator((string,string,string,string,string),address,int256,int256)",
-                description, msg.sender, commissionRate, minSelfDelegation
-            )
-        );
+        if (bytes(description.moniker).length == 0) revert InvalidInput();
         
-        require(callSuccess, "Edit validator failed");
-        success = abi.decode(result, (bool));
-        require(success, "Edit validator returned false");
-        
-        emit ValidatorUpdated(msg.sender, description.moniker);
-        return success;
+        try staking.editValidator(description, commissionRate, minSelfDelegation) returns (bool result) {
+            if (!result) revert StakingOperationFailed();
+            emit ValidatorUpdated(msg.sender, description.moniker);
+            return result;
+        } catch {
+            revert StakingOperationFailed();
+        }
     }
 }
 ```
@@ -139,24 +176,37 @@ Delegates tokens to a validator.
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Interface for the Staking precompile
+interface IStaking {
+    function delegate(address delegatorAddress, string memory validatorAddress, uint256 amount) external returns (bool success);
+}
+
 contract StakingExample {
     address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    IStaking public immutable staking;
     
     event DelegationSuccess(address indexed delegator, string indexed validator, uint256 amount);
     
+    error InvalidAmount();
+    error InvalidValidator();
+    error StakingOperationFailed();
+    error InsufficientBalance();
+    
+    constructor() {
+        staking = IStaking(STAKING_PRECOMPILE);
+    }
+    
     function delegateTokens(string calldata validatorAddress, uint256 amount) external payable {
-        require(msg.value >= amount, "Insufficient value sent");
+        if (amount == 0) revert InvalidAmount();
+        if (msg.value != amount) revert InsufficientBalance();
+        if (bytes(validatorAddress).length == 0) revert InvalidValidator();
         
-        // Call the staking precompile with correct signature
-        (bool success, bytes memory result) = STAKING_PRECOMPILE.call{value: amount}(
-            abi.encodeWithSignature("delegate(address,string,uint256)", msg.sender, validatorAddress, amount)
-        );
-        
-        require(success, "Delegation failed");
-        bool delegationSuccess = abi.decode(result, (bool));
-        require(delegationSuccess, "Delegation returned false");
-        
-        emit DelegationSuccess(msg.sender, validatorAddress, amount);
+        try staking.delegate(msg.sender, validatorAddress, amount) returns (bool success) {
+            if (!success) revert StakingOperationFailed();
+            emit DelegationSuccess(msg.sender, validatorAddress, amount);
+        } catch {
+            revert StakingOperationFailed();
+        }
     }
 }
 ```
@@ -213,22 +263,37 @@ Undelegates tokens from a validator.
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Interface for the Staking precompile
+interface IStaking {
+    function beginUnbonding(address delegatorAddress, string memory validatorAddress, uint256 amount) external returns (int64 completionTime);
+}
+
 contract StakingExample {
     address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    IStaking public immutable staking;
     
     event UndelegationStarted(address indexed delegator, string indexed validator, uint256 amount, int64 completionTime);
     
+    error InvalidAmount();
+    error InvalidValidator();
+    error StakingOperationFailed();
+    
+    constructor() {
+        staking = IStaking(STAKING_PRECOMPILE);
+    }
+    
     function undelegateTokens(string calldata validatorAddress, uint256 amount) 
         external returns (int64 completionTime) {
-        (bool success, bytes memory result) = STAKING_PRECOMPILE.call(
-            abi.encodeWithSignature("undelegate(address,string,uint256)", msg.sender, validatorAddress, amount)
-        );
+        if (amount == 0) revert InvalidAmount();
+        if (bytes(validatorAddress).length == 0) revert InvalidValidator();
         
-        require(success, "Undelegation failed");
-        completionTime = abi.decode(result, (int64));
-        
-        emit UndelegationStarted(msg.sender, validatorAddress, amount, completionTime);
-        return completionTime;
+        try staking.beginUnbonding(msg.sender, validatorAddress, amount) returns (int64 completion) {
+            completionTime = completion;
+            emit UndelegationStarted(msg.sender, validatorAddress, amount, completionTime);
+            return completionTime;
+        } catch {
+            revert StakingOperationFailed();
+        }
     }
     
     // Helper function to calculate days until completion
@@ -254,8 +319,19 @@ Redelegates tokens from one validator to another.
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Interface for the Staking precompile
+interface IStaking {
+    function beginRedelegate(
+        address delegatorAddress,
+        string memory validatorSrcAddress,
+        string memory validatorDstAddress,
+        uint256 amount
+    ) external returns (int64 completionTime);
+}
+
 contract StakingExample {
     address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    IStaking public immutable staking;
     
     event RedelegationStarted(
         address indexed delegator, 
@@ -265,30 +341,35 @@ contract StakingExample {
         int64 completionTime
     );
     
+    error InvalidValidator();
+    error InvalidAmount();
+    error SameValidator();
+    error StakingOperationFailed();
+    
+    constructor() {
+        staking = IStaking(STAKING_PRECOMPILE);
+    }
+    
     function redelegateTokens(
         string calldata srcValidatorAddress,
         string calldata dstValidatorAddress,
         uint256 amount
     ) external returns (int64 completionTime) {
-        require(bytes(srcValidatorAddress).length > 0, "Source validator cannot be empty");
-        require(bytes(dstValidatorAddress).length > 0, "Destination validator cannot be empty");
-        require(
-            keccak256(bytes(srcValidatorAddress)) != keccak256(bytes(dstValidatorAddress)), 
-            "Cannot redelegate to same validator"
-        );
+        if (bytes(srcValidatorAddress).length == 0) revert InvalidValidator();
+        if (bytes(dstValidatorAddress).length == 0) revert InvalidValidator();
+        if (amount == 0) revert InvalidAmount();
+        if (keccak256(bytes(srcValidatorAddress)) == keccak256(bytes(dstValidatorAddress))) {
+            revert SameValidator();
+        }
         
-        (bool success, bytes memory result) = STAKING_PRECOMPILE.call(
-            abi.encodeWithSignature(
-                "redelegate(address,string,string,uint256)", 
-                msg.sender, srcValidatorAddress, dstValidatorAddress, amount
-            )
-        );
-        
-        require(success, "Redelegation failed");
-        completionTime = abi.decode(result, (int64));
-        
-        emit RedelegationStarted(msg.sender, srcValidatorAddress, dstValidatorAddress, amount, completionTime);
-        return completionTime;
+        try staking.beginRedelegate(msg.sender, srcValidatorAddress, dstValidatorAddress, amount) 
+            returns (int64 completion) {
+            completionTime = completion;
+            emit RedelegationStarted(msg.sender, srcValidatorAddress, dstValidatorAddress, amount, completionTime);
+            return completionTime;
+        } catch {
+            revert StakingOperationFailed();
+        }
     }
 }
 ```
@@ -306,37 +387,53 @@ Cancels an unbonding delegation.
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Interface for the Staking precompile
+interface IStaking {
+    function cancelUnbondingDelegation(
+        address delegatorAddress,
+        string memory validatorAddress,
+        uint256 amount,
+        int64 creationHeight
+    ) external returns (bool success);
+}
+
 contract StakingExample {
     address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    IStaking public immutable staking;
     
     event UnbondingCancelled(
         address indexed delegator, 
         string indexed validator, 
         uint256 amount, 
-        uint256 creationHeight
+        int64 creationHeight
     );
+    
+    error InvalidHeight();
+    error InvalidAmount();
+    error InvalidValidator();
+    error StakingOperationFailed();
+    
+    constructor() {
+        staking = IStaking(STAKING_PRECOMPILE);
+    }
     
     function cancelUnbonding(
         string calldata validatorAddress,
         uint256 amount,
-        uint256 creationHeight
+        int64 creationHeight
     ) external returns (bool success) {
-        require(creationHeight > 0, "Creation height must be positive");
-        require(amount > 0, "Amount must be positive");
+        if (creationHeight <= 0) revert InvalidHeight();
+        if (amount == 0) revert InvalidAmount();
+        if (bytes(validatorAddress).length == 0) revert InvalidValidator();
         
-        (bool callSuccess, bytes memory result) = STAKING_PRECOMPILE.call(
-            abi.encodeWithSignature(
-                "cancelUnbondingDelegation(address,string,uint256,uint256)",
-                msg.sender, validatorAddress, amount, creationHeight
-            )
-        );
-        
-        require(callSuccess, "Cancel unbonding failed");
-        success = abi.decode(result, (bool));
-        require(success, "Cancel unbonding returned false");
-        
-        emit UnbondingCancelled(msg.sender, validatorAddress, amount, creationHeight);
-        return success;
+        try staking.cancelUnbondingDelegation(msg.sender, validatorAddress, amount, creationHeight) 
+            returns (bool result) {
+            if (!result) revert StakingOperationFailed();
+            emit UnbondingCancelled(msg.sender, validatorAddress, amount, creationHeight);
+            return result;
+        } catch {
+            revert StakingOperationFailed();
+        }
     }
 }
 ```
@@ -356,31 +453,50 @@ Queries information about a specific validator.
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-contract StakingExample {
-    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
-    
+// Interface for the Staking precompile (matches ~/repos/evm ABI)
+interface IStaking {
     struct Validator {
         string operatorAddress;
         string consensusPubkey;
         bool jailed;
-        uint8 status; // BondStatus enum
+        uint8 status;                // BondStatus enum as uint8
         uint256 tokens;
-        uint256 delegatorShares;
-        string description;
+        uint256 delegatorShares;      // uint256
+        string description;           // string, not a nested struct
         int64 unbondingHeight;
-        int64 unbondingTime;
-        uint256 commission;
+        int64 unbondingTime;          // int64
+        uint256 commission;           // uint256
         uint256 minSelfDelegation;
     }
+
+    function validator(address validatorAddress) external view returns (Validator memory);
+}
+
+contract StakingExample {
+    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    IStaking public immutable staking;
     
-    function getValidator(address validatorAddress) external view returns (Validator memory validator) {
-        (bool success, bytes memory result) = STAKING_PRECOMPILE.staticcall(
-            abi.encodeWithSignature("validator(address)", validatorAddress)
-        );
-        
-        require(success, "Validator query failed");
-        validator = abi.decode(result, (Validator));
+    event ValidatorQueried(address indexed validatorAddress, string operatorAddress, uint256 tokens);
+    
+    constructor() {
+        staking = IStaking(STAKING_PRECOMPILE);
+    }
+    
+    function getValidator(address validatorAddress) external view returns (IStaking.Validator memory validator) {
+        validator = staking.validator(validatorAddress);
         return validator;
+    }
+    
+    function getValidatorInfo(address validatorAddress) 
+        external 
+        returns (string memory operatorAddress, uint256 tokens, bool jailed) {
+        IStaking.Validator memory validator = staking.validator(validatorAddress);
+        operatorAddress = validator.operatorAddress;
+        tokens = validator.tokens;
+        jailed = validator.jailed;
+        
+        emit ValidatorQueried(validatorAddress, operatorAddress, tokens);
+        return (operatorAddress, tokens, jailed);
     }
 }
 ```
@@ -551,7 +667,7 @@ import { ethers } from "ethers";
 
 // ABI definition for the function
 const precompileAbi = [
-  "function unbondingDelegation(address delegatorAddress, string memory validatorAddress) view returns (tuple(address delegatorAddress, string validatorAddress, tuple(uint256 creationHeight, uint256 completionTime, string initialBalance, string balance)[] entries) unbondingDelegation)"
+  "function unbondingDelegation(address delegatorAddress, string validatorAddress) view returns (tuple(string delegatorAddress, string validatorAddress, tuple(int64 creationHeight, int64 completionTime, uint256 initialBalance, uint256 balance, uint64 unbondingId, int64 unbondingOnHoldRefCount)[] entries) unbondingDelegation)"
 ];
 
 // Provider and contract setup
@@ -599,38 +715,79 @@ Queries a specific redelegation.
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-contract StakingExample {
-    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
-    
+// Interface for the Staking precompile
+interface IStaking {
     struct RedelegationEntry {
         int64 creationHeight;
         int64 completionTime;
         uint256 initialBalance;
         uint256 sharesDst;
+        uint64 unbondingId;
+        int64 unbondingOnHoldRefCount;
     }
     
-    struct RedelegationOutput {
+    struct Redelegation {
         string delegatorAddress;
         string validatorSrcAddress;
         string validatorDstAddress;
         RedelegationEntry[] entries;
     }
     
+    function redelegation(
+        address delegatorAddress,
+        string memory validatorSrcAddress,
+        string memory validatorDstAddress
+    ) external view returns (Redelegation memory);
+}
+
+contract StakingExample {
+    address constant STAKING_PRECOMPILE = 0x0000000000000000000000000000000000000800;
+    IStaking public immutable staking;
+    
+    event RedelegationQueried(
+        address indexed delegator,
+        string srcValidator,
+        string dstValidator,
+        uint256 entriesCount
+    );
+    
+    constructor() {
+        staking = IStaking(STAKING_PRECOMPILE);
+    }
+    
     function getRedelegation(
         address delegatorAddress,
         string calldata srcValidatorAddress,
         string calldata dstValidatorAddress
-    ) external view returns (RedelegationOutput memory redelegation) {
-        (bool success, bytes memory result) = STAKING_PRECOMPILE.staticcall(
-            abi.encodeWithSignature(
-                "redelegation(address,string,string)",
-                delegatorAddress, srcValidatorAddress, dstValidatorAddress
-            )
+    ) external view returns (IStaking.Redelegation memory redelegation) {
+        redelegation = staking.redelegation(delegatorAddress, srcValidatorAddress, dstValidatorAddress);
+        return redelegation;
+    }
+    
+    function getRedelegationInfo(
+        address delegatorAddress,
+        string calldata srcValidatorAddress,
+        string calldata dstValidatorAddress
+    ) external returns (uint256 entriesCount, bool hasActiveRedelegations) {
+        IStaking.Redelegation memory redelegation = staking.redelegation(
+            delegatorAddress, 
+            srcValidatorAddress, 
+            dstValidatorAddress
         );
         
-        require(success, "Redelegation query failed");
-        redelegation = abi.decode(result, (RedelegationOutput));
-        return redelegation;
+        entriesCount = redelegation.entries.length;
+        hasActiveRedelegations = entriesCount > 0;
+        
+        // Check if any redelegations are still active
+        for (uint256 i = 0; i < redelegation.entries.length; i++) {
+            if (redelegation.entries[i].completionTime > int64(int256(block.timestamp))) {
+                hasActiveRedelegations = true;
+                break;
+            }
+        }
+        
+        emit RedelegationQueried(delegatorAddress, srcValidatorAddress, dstValidatorAddress, entriesCount);
+        return (entriesCount, hasActiveRedelegations);
     }
     
     // Check if redelegation is complete
@@ -670,7 +827,7 @@ import { ethers } from "ethers";
 
 // ABI definition for the function
 const precompileAbi = [
-  "function redelegations(address delegatorAddress, string memory srcValidatorAddress, string memory dstValidatorAddress, tuple(bytes key, uint64 offset, uint64 limit, bool countTotal, bool reverse) pageRequest) view returns (tuple(tuple(address delegatorAddress, string validatorSrcAddress, string validatorDstAddress, tuple(uint256 creationHeight, uint256 completionTime, string initialBalance, string sharesDst)[] entries) redelegation, tuple(tuple(uint256 creationHeight, uint256 completionTime, string initialBalance, string sharesDst) redelegationEntry, string balance)[] entries)[] redelegations, tuple(bytes nextKey, uint64 total) pageResponse)"
+  "function redelegations(address delegatorAddress, string srcValidatorAddress, string dstValidatorAddress, tuple(bytes key, uint64 offset, uint64 limit, bool countTotal, bool reverse) pageRequest) view returns (tuple(tuple(string delegatorAddress, string validatorSrcAddress, string validatorDstAddress, tuple(int64 creationHeight, int64 completionTime, uint256 initialBalance, uint256 sharesDst)[] entries) redelegation, tuple(tuple(int64 creationHeight, int64 completionTime, uint256 initialBalance, uint256 sharesDst) redelegationEntry, uint256 balance)[] entries)[] redelegations, tuple(bytes nextKey, uint64 total) pageResponse)"
 ];
 
 // Provider and contract setup

--- a/docs/next/documentation/smart-contracts/precompiles/werc20.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/werc20.mdx
@@ -433,17 +433,18 @@ This function receives msg.value and immediately sends the coins back to the cal
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Interface for WERC20 precompile
+interface IWERC20 {
+    event Deposit(address indexed dst, uint256 wad);
+    event Withdrawal(address indexed src, uint256 wad);
+    
+    function deposit() external payable;
+    function withdraw(uint256 wad) external;
+    function balanceOf(address account) external view returns (uint256);
+}
+
 contract WERC20Example {
     address constant WTEST = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-    
-    interface IWERC20 {
-        event Deposit(address indexed dst, uint256 wad);
-        event Withdrawal(address indexed src, uint256 wad);
-        
-        function deposit() external payable;
-        function withdraw(uint256 wad) external;
-        function balanceOf(address account) external view returns (uint256);
-    }
     
     IWERC20 public immutable wtest;
     

--- a/docs/next/documentation/smart-contracts/precompiles/werc20.mdx
+++ b/docs/next/documentation/smart-contracts/precompiles/werc20.mdx
@@ -2,7 +2,7 @@
 title: "WERC20"
 description: "Single token representation: An ERC20 interface for any token"
 icon: "refresh-ccw"
-keywords: ['werc20', 'wrapped token', 'erc20', 'single token representation', 'precompile', 'watom', 'native token', 'bank module', 'cosmos sdk', 'token bridge', 'unified token', 'ibc tokens', 'no-op deposit', 'no-op withdraw']
+keywords: ['werc20', 'wrapped token', 'erc20', 'single token representation', 'precompile', 'wtest', 'native token', 'bank module', 'cosmos sdk', 'token bridge', 'unified token', 'ibc tokens', 'no-op deposit', 'no-op withdraw']
 ---
 
 ## Overview
@@ -10,13 +10,13 @@ keywords: ['werc20', 'wrapped token', 'erc20', 'single token representation', 'p
 The WERC20 precompile provides a standard ERC20 interface to native Cosmos tokens through Cosmos EVM's **[Single Token Representation](/docs/next/documentation/concepts/single-token-representation)** architecture.
 Unlike traditional wrapped tokens that are functionally two separate tokens with unique individual properties and behaviors, Cosmos EVM's WERC20 logic gives smart contracts direct access to native bank module balances through familiar ERC20 methods.
 
-**Key Concept**: ATOM and WATOM are not separate tokens—they are two different interfaces to the same token stored in the bank module.
-Native Cosmos tokens (including ATOM and all IBC tokens) exist in both wrapped and unwrapped states at all times, allowing developers to choose the interaction method that best fits their use case:
+**Key Concept**: TEST and WTEST are not separate tokens—they are two different interfaces to the same token stored in the bank module.
+Native Cosmos tokens (including TEST and all IBC tokens) exist in both wrapped and unwrapped states at all times, allowing developers to choose the interaction method that best fits their use case:
 - Use it normally through Cosmos bank send (unwrapped state)
 - Use it like you would normally use ether or 'wei' on the EVM (native value transfers)
-- Use it as ERC20 WATOM with the contract address below (wrapped state)
+- Use it as ERC20 WTEST with the contract address below (wrapped state)
 
-**WATOM Contract Address**: `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`
+**WTEST Contract Address**: `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`
 **Precompile Type**: Dynamic (unique address per wrapped token)
 **Related Module**: x/bank (via ERC20 module integration)
 
@@ -72,7 +72,7 @@ func (k Keeper) ERC20BalanceOf(account common.Address) *big.Int {
 
 ### Deposit/Withdraw Implementation Details
 
-Since ATOM and WATOM provide different interfaces to the same bank module token, deposit/withdraw functions exist for WETH interface compatibility:
+Since TEST and WTEST provide different interfaces to the same bank module token, deposit/withdraw functions exist for WETH interface compatibility:
 
 ```solidity
 // These functions exist for WETH interface compatibility
@@ -103,22 +103,22 @@ This is why `deposit()` and `withdraw()` are no-ops - there's no separate wrappe
 ### Real-World Example
 
 ```javascript
-// User starts with 100 ATOM in bank module
-const atomBalance = await bankPrecompile.balances(userAddress);
-// Returns: [{denom: "uatom", amount: "100000000"}] // 100 ATOM (6 decimals)
+// User starts with 100 TEST in bank module
+const testBalance = await bankPrecompile.balances(userAddress);
+// Returns: [{denom: "atest", amount: "100000000000000000000"}] // 100 TEST (18 decimals)
 
-const watomBalance = await watom.balanceOf(userAddress);
-// Returns: "100000000" // Same 100 ATOM, accessed via ERC20 interface
+const wtestBalance = await wtest.balanceOf(userAddress);
+// Returns: "100000000000000000000" // Same 100 TEST, accessed via ERC20 interface
 
-// User transfers 50 WATOM via ERC20
-await watom.transfer(recipientAddress, "50000000");
+// User transfers 50 WTEST via ERC20
+await wtest.transfer(recipientAddress, "50000000000000000000");
 
 // Check balances again
-const newAtomBalance = await bankPrecompile.balances(userAddress);
-// Returns: [{denom: "uatom", amount: "50000000"}] // 50 ATOM remaining
+const newTestBalance = await bankPrecompile.balances(userAddress);
+// Returns: [{denom: "atest", amount: "50000000000000000000"}] // 50 TEST (18 decimals) remaining
 
-const newWatomBalance = await watom.balanceOf(userAddress);
-// Returns: "50000000" // Same 50 ATOM, both queries return identical values
+const newWtestBalance = await wtest.balanceOf(userAddress);
+// Returns: "50000000000000000000" // Same 50 TEST, both queries return identical values
 ```
 
 ## Methods
@@ -135,16 +135,16 @@ Returns the native token balance for a specific account (same as bank module bal
 import { ethers } from "ethers";
 
 const provider = new ethers.JsonRpcProvider("<RPC_URL>");
-const watomAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const wtestAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const werc20Abi = ["function balanceOf(address account) view returns (uint256)"];
 
-const watom = new ethers.Contract(watomAddress, werc20Abi, provider);
+const wtest = new ethers.Contract(wtestAddress, werc20Abi, provider);
 
 async function getBalance() {
   try {
     const userAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
-    const balance = await watom.balanceOf(userAddress);
-    console.log("Balance (both ATOM and WATOM):", balance.toString());
+    const balance = await wtest.balanceOf(userAddress);
+    console.log("Balance (both TEST and WTEST):", balance.toString());
   } catch (error) {
     console.error("Error:", error);
   }
@@ -173,22 +173,74 @@ curl -X POST <RPC_URL> \
 Transfers tokens using the bank module (identical to native Cosmos transfer).
 
 <CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract WERC20Example {
+    // WTEST contract address
+    address constant WTEST = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    IERC20 public immutable wtest;
+    
+    event TokensTransferred(address indexed from, address indexed to, uint256 amount);
+    
+    constructor() {
+        wtest = IERC20(WTEST);
+    }
+    
+    function transferWTEST(address to, uint256 amount) external returns (bool) {
+        require(to != address(0), "Invalid recipient");
+        require(amount > 0, "Amount must be greater than 0");
+        
+        // This directly moves tokens in the bank module
+        // No wrapping/unwrapping - same underlying token balance
+        bool success = wtest.transfer(to, amount);
+        require(success, "Transfer failed");
+        
+        emit TokensTransferred(msg.sender, to, amount);
+        return true;
+    }
+    
+    function transferFromWTEST(address from, address to, uint256 amount) external returns (bool) {
+        require(from != address(0) && to != address(0), "Invalid addresses");
+        require(amount > 0, "Amount must be greater than 0");
+        
+        bool success = wtest.transferFrom(from, to, amount);
+        require(success, "Transfer from failed");
+        
+        emit TokensTransferred(from, to, amount);
+        return true;
+    }
+    
+    // Batch transfer example
+    function batchTransfer(address[] calldata recipients, uint256[] calldata amounts) external {
+        require(recipients.length == amounts.length, "Arrays length mismatch");
+        
+        for (uint256 i = 0; i < recipients.length; i++) {
+            wtest.transferFrom(msg.sender, recipients[i], amounts[i]);
+            emit TokensTransferred(msg.sender, recipients[i], amounts[i]);
+        }
+    }
+}
+```
 ```javascript Ethers.js
 import { ethers } from "ethers";
 
 const provider = new ethers.JsonRpcProvider("<RPC_URL>");
 const signer = new ethers.Wallet("<PRIVATE_KEY>", provider);
-const watomAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const wtestAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const werc20Abi = ["function transfer(address to, uint256 amount) returns (bool)"];
 
-const watom = new ethers.Contract(watomAddress, werc20Abi, signer);
+const wtest = new ethers.Contract(wtestAddress, werc20Abi, signer);
 
 async function transferTokens() {
   try {
     const recipientAddress = "0x742d35Cc6634C0532925a3b844Bc9e7595f5b899";
-    const amount = ethers.parseUnits("10.0", 6); // 10 ATOM (6 decimals)
+    const amount = ethers.parseUnits("10.0", 18); // 10 TEST (18 decimals)
 
-    const tx = await watom.transfer(recipientAddress, amount);
+    const tx = await wtest.transfer(recipientAddress, amount);
     const receipt = await tx.wait();
 
     console.log("Transfer successful:", receipt.hash);
@@ -219,14 +271,14 @@ Returns the total supply from the bank module.
 import { ethers } from "ethers";
 
 const provider = new ethers.JsonRpcProvider("<RPC_URL>");
-const watomAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const wtestAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const werc20Abi = ["function totalSupply() view returns (uint256)"];
 
-const watom = new ethers.Contract(watomAddress, werc20Abi, provider);
+const wtest = new ethers.Contract(wtestAddress, werc20Abi, provider);
 
 async function getTotalSupply() {
   try {
-    const supply = await watom.totalSupply();
+    const supply = await wtest.totalSupply();
     console.log("Total Supply:", supply.toString());
   } catch (error) {
     console.error("Error:", error);
@@ -261,30 +313,30 @@ import { ethers } from "ethers";
 
 const provider = new ethers.JsonRpcProvider("<RPC_URL>");
 const signer = new ethers.Wallet("<PRIVATE_KEY>", provider);
-const watomAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const wtestAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const werc20Abi = [
   "function approve(address spender, uint256 amount) returns (bool)",
   "function allowance(address owner, address spender) view returns (uint256)",
   "function transferFrom(address from, address to, uint256 amount) returns (bool)"
 ];
 
-const watom = new ethers.Contract(watomAddress, werc20Abi, signer);
+const wtest = new ethers.Contract(wtestAddress, werc20Abi, signer);
 
 async function approveAndTransfer() {
   try {
     const spenderAddress = "0x742d35Cc6634C0532925a3b844Bc9e7595f5b899";
-    const amount = ethers.parseUnits("50.0", 6); // 50 ATOM
+    const amount = ethers.parseUnits("50.0", 18); // 50 TEST (18 decimals)
 
     // Approve spending
-    const approveTx = await watom.approve(spenderAddress, amount);
+    const approveTx = await wtest.approve(spenderAddress, amount);
     await approveTx.wait();
 
     // Check allowance
-    const allowance = await watom.allowance(signer.address, spenderAddress);
+    const allowance = await wtest.allowance(signer.address, spenderAddress);
     console.log("Allowance:", allowance.toString());
 
     // Transfer from (would be called by spender)
-    // const transferTx = await watom.transferFrom(ownerAddress, recipientAddress, amount);
+    // const transferTx = await wtest.transferFrom(ownerAddress, recipientAddress, amount);
   } catch (error) {
     console.error("Error:", error);
   }
@@ -293,28 +345,28 @@ async function approveAndTransfer() {
 </CodeGroup>
 
 ### `name` / `symbol` / `decimals`
-Token metadata (e.g., "Wrapped ATOM", "WATOM", 6).
+Token metadata (e.g., "Wrapped Test", "WTEST", 18).
 
 <CodeGroup>
 ```javascript Ethers.js
 import { ethers } from "ethers";
 
 const provider = new ethers.JsonRpcProvider("<RPC_URL>");
-const watomAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const wtestAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const werc20Abi = [
   "function name() view returns (string)",
   "function symbol() view returns (string)",
   "function decimals() view returns (uint8)"
 ];
 
-const watom = new ethers.Contract(watomAddress, werc20Abi, provider);
+const wtest = new ethers.Contract(wtestAddress, werc20Abi, provider);
 
 async function getTokenInfo() {
   try {
     const [name, symbol, decimals] = await Promise.all([
-      watom.name(),
-      watom.symbol(),
-      watom.decimals()
+      wtest.name(),
+      wtest.symbol(),
+      wtest.decimals()
     ]);
     console.log(`Token: ${name} (${symbol}) - ${decimals} decimals`);
   } catch (error) {
@@ -373,14 +425,95 @@ These methods exist for WETH interface compatibility:
 **WETH compatibility function** - Handles payable deposits for interface compatibility.
 
 <Info>
-This function receives msg.value and immediately sends the coins back to the caller via the bank module, then emits a Deposit event. Since WATOM and ATOM are the same underlying bank module token, no actual wrapping occurs - your balance is simply accessible through both native and ERC20 interfaces.
+This function receives msg.value and immediately sends the coins back to the caller via the bank module, then emits a Deposit event. Since WTEST and TEST are the same underlying bank module token, no actual wrapping occurs - your balance is simply accessible through both native and ERC20 interfaces.
 </Info>
+
+<CodeGroup>
+```solidity Solidity expandable lines
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract WERC20Example {
+    address constant WTEST = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    
+    interface IWERC20 {
+        event Deposit(address indexed dst, uint256 wad);
+        event Withdrawal(address indexed src, uint256 wad);
+        
+        function deposit() external payable;
+        function withdraw(uint256 wad) external;
+        function balanceOf(address account) external view returns (uint256);
+    }
+    
+    IWERC20 public immutable wtest;
+    
+    constructor() {
+        wtest = IWERC20(WTEST);
+    }
+    
+    function depositToWTEST() external payable {
+        require(msg.value > 0, "Must send tokens to deposit");
+        
+        // Get balance before deposit
+        uint256 balanceBefore = wtest.balanceOf(msg.sender);
+        
+        // WERC20 deposit is a no-op for compatibility
+        // Your native token balance is immediately accessible as WTEST
+        wtest.deposit{value: msg.value}();
+        
+        // Verify balance is now accessible via WTEST interface
+        uint256 balanceAfter = wtest.balanceOf(msg.sender);
+        
+        // Both TEST and WTEST balances reflect the same bank module amount
+        // No actual wrapping occurred - same token, different interface
+        require(balanceAfter >= balanceBefore, "Deposit processed");
+    }
+    
+    function withdrawFromWTEST(uint256 amount) external {
+        require(amount > 0, "Amount must be greater than 0");
+        require(wtest.balanceOf(msg.sender) >= amount, "Insufficient balance");
+        
+        // WERC20 withdraw is a no-op that emits event for compatibility
+        // Your bank balance remains accessible as both native TEST and WTEST
+        wtest.withdraw(amount);
+        
+        // Tokens are still in bank module and accessible both ways
+    }
+    
+    // Helper function to demonstrate balance consistency
+    function checkBalanceConsistency(address user) external view returns (
+        uint256 wtestBalance,
+        string memory explanation
+    ) {
+        wtestBalance = wtest.balanceOf(user);
+        explanation = "This WTEST balance equals the user's native TEST balance in bank module";
+        
+        return (wtestBalance, explanation);
+    }
+    
+    // Example DeFi integration showing no wrapping needed
+    function addLiquidityWithDeposit() external payable {
+        require(msg.value > 0, "Must send tokens");
+        
+        // Deposit via WERC20 interface (compatibility no-op)
+        wtest.deposit{value: msg.value}();
+        
+        // Your tokens are now accessible as WTEST for DeFi protocols
+        // No additional steps needed - same token, ERC20 interface available
+        uint256 availableForDeFi = wtest.balanceOf(msg.sender);
+        
+        // Use in DeFi protocols immediately
+        // wtest.transfer(defiProtocolAddress, availableForDeFi);
+    }
+}
+```
+</CodeGroup>
 
 ### `withdraw`
 **No-op function** - Included for interface compatibility with WETH contracts.
 
 <Info>
-This function only emits a Withdrawal event but performs no actual token movement. Since WATOM and ATOM are the same underlying bank module token, your native token balance is always directly accessible without any unwrapping process.
+This function only emits a Withdrawal event but performs no actual token movement. Since WTEST and TEST are the same underlying bank module token, your native token balance is always directly accessible without any unwrapping process.
 </Info>
 
 ## Usage Examples
@@ -388,15 +521,15 @@ This function only emits a Withdrawal event but performs no actual token movemen
 ### DeFi Integration Example
 ```solidity
 contract LiquidityPool {
-    IERC20 public immutable WATOM;
+    IERC20 public immutable WTEST;
 
-    constructor(address _watom) {
-        WATOM = IERC20(_watom);
+    constructor(address _wtest) {
+        WTEST = IERC20(_wtest);
     }
 
     function addLiquidity(uint256 amount) external {
         // This transfers from the user's bank balance
-        WATOM.transferFrom(msg.sender, address(this), amount);
+        WTEST.transferFrom(msg.sender, address(this), amount);
 
         // Pool now has tokens in its bank balance
         // No wrapping/unwrapping needed - it's all the same token!
@@ -404,10 +537,10 @@ contract LiquidityPool {
 
     function removeLiquidity(uint256 amount) external {
         // This transfers back to user's bank balance
-        WATOM.transfer(msg.sender, amount);
+        WTEST.transfer(msg.sender, amount);
 
-        // User can now use these tokens as native ATOM
-        // or continue using WATOM interface - both access same balance
+        // User can now use these tokens as native TEST
+        // or continue using WTEST interface - both access same balance
     }
 }
 ```
@@ -418,14 +551,14 @@ contract LiquidityPool {
 async function verifyBalanceConsistency(userAddress) {
     // Query via bank precompile (native interface)
     const bankBalance = await bankContract.balances(userAddress);
-    const atomAmount = bankBalance.find(b => b.denom === "uatom")?.amount || "0";
+    const testAmount = bankBalance.find(b => b.denom === "test")?.amount || "0";
 
     // Query via WERC20 precompile (ERC20 interface)
-    const watomAmount = await watom.balanceOf(userAddress);
+    const wtestAmount = await wtest.balanceOf(userAddress);
 
     // These will always be equal since the ERC20 balance is just
     // an abstracted bank module balance query
-    console.log(`Consistent balance: ${atomAmount} (both ATOM and WATOM)`);
+    console.log(`Consistent balance: ${testAmount} (both TEST and WTEST)`);
 }
 ```
 

--- a/docs/v0.4.x/api-reference/ethereum-json-rpc/index.mdx
+++ b/docs/v0.4.x/api-reference/ethereum-json-rpc/index.mdx
@@ -83,7 +83,7 @@ rpc-evm-timeout = "10s"
 Alternatively, enable JSON-RPC when starting the node:
 
 ```bash
-appd start \
+evmd start \
   --json-rpc.enable \
   --json-rpc.address="0.0.0.0:8545" \
   --json-rpc.ws-address="0.0.0.0:8546" \
@@ -164,7 +164,7 @@ Since Cosmos EVM is built with the Cosmos SDK framework and uses CometBFT as it'
 You can start a connection with the Ethereum websocket using the `--json-rpc.ws-address` flag when starting the node (default `"0.0.0.0:8546"`):
 
 ```
-appd start --json-rpc.address="0.0.0.0:8545" --json-rpc.ws-address="0.0.0.0:8546" --json-rpc.api="eth,web3,net,txpool,debug" --json-rpc.enable
+evmd start --json-rpc.address="0.0.0.0:8545" --json-rpc.ws-address="0.0.0.0:8546" --json-rpc.api="eth,web3,net,txpool,debug" --json-rpc.enable
 ```
 
 Then, start a websocket subscription with [`ws`](https://github.com/hashrocket/ws)

--- a/docs/v0.4.x/api-reference/ethereum-json-rpc/methods.mdx
+++ b/docs/v0.4.x/api-reference/ethereum-json-rpc/methods.mdx
@@ -35,15 +35,15 @@ The following namespaces are not implemented in Cosmos EVM but may be present in
   </Accordion>
 
   <Accordion title="miner - Mining Operations (Not Applicable)">
-    The `miner` namespace controls Proof of Work mining operations. Cosmos EVM uses Tendermint Byzantine Fault Tolerant consensus instead of mining.
+    The `miner` namespace controls Proof of Work mining operations. Cosmos EVM uses 'CometBFT' Byzantine Fault Tolerant consensus instead of mining.
   </Accordion>
 
   <Accordion title="engine - Post-Merge Engine API (Not Applicable)">
-    The `engine` namespace implements Ethereum's post-merge Engine API for communication with the consensus layer. Cosmos EVM uses Tendermint consensus instead of the beacon chain.
+    The `engine` namespace implements Ethereum's post-merge Engine API for communication with the consensus layer. Cosmos EVM uses 'CometBFT' consensus instead of the beacon chain.
   </Accordion>
 
   <Accordion title="clique - Proof of Authority (Not Applicable)">
-    The `clique` namespace implements Proof of Authority consensus for private networks. Cosmos EVM uses Tendermint consensus.
+    The `clique` namespace implements Proof of Authority consensus for private networks. Cosmos EVM uses 'CometBFT' consensus.
   </Accordion>
 
   <Accordion title="les - Light Client Protocol (Not Supported)">
@@ -282,10 +282,10 @@ Block Number can be entered as a Hex string, `"earliest"`, `"latest"` or `"pendi
 <Info>
 **EIP-1559 Support**: Cosmos EVM supports EIP-1559 transaction types with `eth_maxPriorityFeePerGas`, though `eth_feeHistory` is not yet implemented.
 
-**Consensus Differences**: Due to using Tendermint BFT consensus instead of Proof of Work/Stake:
+**Consensus Differences**: Due to using 'CometBFT' BFT consensus instead of Proof of Work/Stake:
 * Uncle-related methods always return 0 or null
 * Block reorganizations are not possible
-* Engine API (`engine_*`) is not applicable - Tendermint handles consensus
+* Engine API (`engine_*`) is not applicable - 'CometBFT' handles consensus
 
 **Methods Not Implemented**:
 * `eth_createAccessList` (EIP-2930) - Access list transactions
@@ -298,7 +298,7 @@ Block Number can be entered as a Hex string, `"earliest"`, `"latest"` or `"pendi
 * `debug_getRaw*` methods - Raw data access methods
 * `debug_printBlock` - Block printing utility
 * `trace_*` methods - Advanced tracing features
-* `engine_*` methods - Post-merge Engine API (uses Tendermint instead)
+* `engine_*` methods - Post-merge Engine API (uses 'CometBFT' instead)
 * `admin_*` methods - Node administration
 * `les_*` methods - Light Ethereum Subprotocol
 * `clique_*` methods - Proof of Authority consensus
@@ -947,7 +947,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_coinbase","params":[],"id":1
 Returns whether the client is actively mining new blocks.
 
 <Info>
-Always returns `false` as Cosmos EVM uses Tendermint consensus instead of mining.
+Always returns `false` as Cosmos EVM uses 'CometBFT' consensus instead of mining.
 </Info>
 
 ```shell
@@ -962,7 +962,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_mining","params":[],"id":1}'
 Returns the number of hashes per second that the node is mining with.
 
 <Info>
-Always returns `0x0` as Cosmos EVM uses Tendermint consensus instead of mining.
+Always returns `0x0` as Cosmos EVM uses 'CometBFT' consensus instead of mining.
 </Info>
 
 ```shell
@@ -988,7 +988,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}
 Returns the number of uncles in a block matching the given block hash.
 
 <Info>
-Always returns `0x0` as Cosmos EVM does not have uncles due to using Tendermint consensus.
+Always returns `0x0` as Cosmos EVM does not have uncles due to using 'CometBFT' consensus.
 </Info>
 
 #### Parameters
@@ -1007,7 +1007,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockHash","p
 Returns the number of uncles in a block matching the given block number.
 
 <Info>
-Always returns `0x0` as Cosmos EVM does not have uncles due to using Tendermint consensus.
+Always returns `0x0` as Cosmos EVM does not have uncles due to using 'CometBFT' consensus.
 </Info>
 
 #### Parameters
@@ -1026,7 +1026,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockNumber",
 Returns information about an uncle by block hash and uncle index position.
 
 <Info>
-Always returns `null` as Cosmos EVM does not have uncles due to using Tendermint consensus.
+Always returns `null` as Cosmos EVM does not have uncles due to using 'CometBFT' consensus.
 </Info>
 
 #### Parameters
@@ -1046,7 +1046,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getUncleByBlockHashAndIndex"
 Returns information about an uncle by block number and uncle index position.
 
 <Info>
-Always returns `null` as Cosmos EVM does not have uncles due to using Tendermint consensus.
+Always returns `null` as Cosmos EVM does not have uncles due to using 'CometBFT' consensus.
 </Info>
 
 #### Parameters

--- a/docs/v0.4.x/devnet_ARCHIVED/connect-to-the-network.mdx
+++ b/docs/v0.4.x/devnet_ARCHIVED/connect-to-the-network.mdx
@@ -13,7 +13,7 @@ import { footnote } from '/snippets/footnote.mdx'
 | **EVM Chain ID** | `4231` | Network identifier for EVM tooling |
 | **EVM Version** | `Prague` | EVM hard fork compatibility version |
 | **Native Token** | `ATOM` | Staking / gas token |
-| **Denom Exponent** | `6` | Native token has 6 decimal places (`uatom`) |
+| **Denom Exponent** | `6` | Native token has 6 decimal places (`test`) |
 
 ## Public Endpoints
 
@@ -21,7 +21,7 @@ import { footnote } from '/snippets/footnote.mdx'
 |-------------------|----------------------|---------|
 | **EVM JSON-RPC** | `<evm_rpc_url>` | Ethereum-compatible tools (MetaMask, Hardhat, ethers.js) |
 | **EVM RPC WS**   | `wss://devnet-1-evmws.ib.skip.build`   | Streaming real-time, selective data for applications |
-| **Cosmos RPC** | `https://devnet-1-rpc.ib.skip.build` | Tendermint-level interactions (blocks, consensus state) |
+| **Cosmos RPC** | `https://devnet-1-rpc.ib.skip.build` | 'CometBFT'-level interactions (blocks, consensus state) |
 | **Cosmos REST API** | `https://devnet-1-lcd.ib.skip.build` | Query Cosmos SDK modules (bank, staking, etc.) |
 | **gRPC** | `devnet-1-grpc.ib.skip.build:443` | High-performance Protobuf endpoint for back-ends |
 
@@ -145,10 +145,10 @@ evmd keys add recovered --recover --key-type eth_secp256k1
   <Accordion title="Broadcast a Transaction">
     <CodeGroup>
       ```bash Bank Send
-      evmd tx bank send cosmos1... cosmos1... 1000uatom \
+      evmd tx bank send cosmos1... cosmos1... 1000test \
         --node https://devnet-1-rpc.ib.skip.build:443 \
         --chain-id 4321 \
-        --gas auto --fees 500uatom \
+        --gas auto --fees 500test \
         --yes
       ```
 
@@ -156,7 +156,7 @@ evmd keys add recovered --recover --key-type eth_secp256k1
       evmd tx evm raw 0x02e20180010182520894de0b295669a9fd93d5f28d9ec85e40f4cb697bae8080c0808080 \
         --node https://devnet-1-rpc.ib.skip.build:443 \
         --chain-id 4231 \
-        --gas auto --fees 500uatom \
+        --gas auto --fees 500test \
         --yes
       ```
     </CodeGroup>
@@ -166,10 +166,10 @@ evmd keys add recovered --recover --key-type eth_secp256k1
     You can use the `--generate-only` flag to create transaction messages without broadcasting them. This can be useful for finding the correct syntax and creating reusable transaction templates.
 
     ```bash Generate Only Example
-    evmd tx bank send cosmos1... cosmos1... 1000uatom \
+    evmd tx bank send cosmos1... cosmos1... 1000test \
       --node https://devnet-1-rpc.ib.skip.build:443 \
       --chain-id 4321 \
-      --gas auto --fees 500uatom \
+      --gas auto --fees 500test \
       --generate-only | jq
     ```
   </Accordion>
@@ -191,7 +191,7 @@ Basic endpoints:
 
 ### Cosmos RPC
 
-> **For Tendermint-level interactions**
+> **For 'CometBFT'-level interactions**
 
 `https://devnet-1-rpc.ib.skip.build`
 

--- a/docs/v0.4.x/documentation/concepts/accounts.mdx
+++ b/docs/v0.4.x/documentation/concepts/accounts.mdx
@@ -111,12 +111,12 @@ cosmos1z3t55m0l9h0eupuz3dp5t5cypyv674jj7mz2jw
 
 ### Address conversion
 
-The `appd debug addr <address>` can be used to convert an address between hex and bech32 formats:
+The `evmd debug addr <address>` can be used to convert an address between hex and bech32 formats:
 
 <CodeGroup>
 
 ```bash Bech32 to Hex
-$ appd debug addr cosmos1z3t55m0l9h0eupuz3dp5t5cypyv674jj7mz2jw
+$ evmd debug addr cosmos1z3t55m0l9h0eupuz3dp5t5cypyv674jj7mz2jw
 
 Address: [20 87 74 109 255 45 223 158 7 130 139 67 69 211 4 9 25 175 86 82]
 Address (hex): 14574A6DFF2DDF9E07828B4345D3040919AF5652
@@ -125,7 +125,7 @@ Bech32 Val: cosmosvaloper1z3t55m0l9h0eupuz3dp5t5cypyv674jjn4d6nn
 ```
 
 ```bash Hex to Bech32
-$ appd debug addr 14574A6DFF2DDF9E07828B4345D3040919AF5652
+$ evmd debug addr 14574A6DFF2DDF9E07828B4345D3040919AF5652
 
 Address: [20 87 74 109 255 45 223 158 7 130 139 67 69 211 4 9 25 175 86 82]
 Address (hex): 14574A6DFF2DDF9E07828B4345D3040919AF5652
@@ -138,7 +138,7 @@ Bech32 Val: cosmosvaloper1z3t55m0l9h0eupuz3dp5t5cypyv674jjn4d6nn
 ### Key output
 
 <Check>
-  The Cosmos SDK Keyring output (i.e `appd keys`) only supports addresses and public keys in Bech32 format.
+  The Cosmos SDK Keyring output (i.e `evmd keys`) only supports addresses and public keys in Bech32 format.
 </Check>
 
 We can use the `keys show` command with the flag `--bech <type>` to obtain different address formats:
@@ -146,7 +146,7 @@ We can use the `keys show` command with the flag `--bech <type>` to obtain diffe
 <Tabs>
   <Tab title="Account (acc)">
     ```bash
-    $ appd keys show dev0 --bech acc
+    $ evmd keys show dev0 --bech acc
 
     - name: dev0
       type: local
@@ -158,7 +158,7 @@ We can use the `keys show` command with the flag `--bech <type>` to obtain diffe
 
   <Tab title="Validator (val)">
     ```bash
-    $ appd keys show dev0 --bech val
+    $ evmd keys show dev0 --bech val
 
     - name: dev0
       type: local
@@ -170,7 +170,7 @@ We can use the `keys show` command with the flag `--bech <type>` to obtain diffe
 
   <Tab title="Consensus (cons)">
     ```bash
-    $ appd keys show dev0 --bech cons
+    $ evmd keys show dev0 --bech cons
 
     - name: dev0
       type: local
@@ -189,7 +189,7 @@ You can query an account address using CLI, gRPC, REST, or JSON-RPC:
   <Tab title="CLI">
     ```bash
     # NOTE: the --output (-o) flag defines the output format
-    appd q auth account $(appd keys show dev0 -a) -o text
+    evmd q auth account $(evmd keys show dev0 -a) -o text
 
     '@type': /ethermint.types.v1.EthAccount
     base_account:

--- a/docs/v0.4.x/documentation/concepts/migrations.mdx
+++ b/docs/v0.4.x/documentation/concepts/migrations.mdx
@@ -9,19 +9,19 @@ icon: "git-branch"
 Export state with:
 
 ```
-appd export > new_genesis.json
+evmd export > new_genesis.json
 ```
 
 You can also export state from a particular height (at the end of processing the block of that height):
 
 ```
-appd export --height [height] > new_genesis.json
+evmd export --height [height] > new_genesis.json
 ```
 
 If you plan to start a new network for 0 height (i.e genesis) from the exported state, export with the `--for-zero-height` flag:
 
 ```
-appd export --height [height] --for-zero-height > new_genesis.json
+evmd export --height [height] --for-zero-height > new_genesis.json
 ```
 
 ## Manually Migrate State[​](#manually-migrate-state "Direct link to Manually Migrate State")
@@ -39,6 +39,6 @@ At this point, you might want to run a script to update the exported genesis int
 You can use the `migrate` command to migrate from a given version to the next one (eg: `v0.X.X` to `v1.X.X`):
 
 ```
-appd migrate TARGET_VERSION GENESIS_FILE --chain-id=<new_chain_id> --genesis-time=<yyyy-mm-ddThh:mm:ssZ>
+evmd migrate TARGET_VERSION GENESIS_FILE --chain-id=<new_chain_id> --genesis-time=<yyyy-mm-ddThh:mm:ssZ>
 ```
 

--- a/docs/v0.4.x/documentation/concepts/precision-handling.mdx
+++ b/docs/v0.4.x/documentation/concepts/precision-handling.mdx
@@ -8,7 +8,7 @@ icon: "calculator"
 
 Cosmos SDK and Ethereum use different decimal precisions for their native tokens:
 
-- **Cosmos SDK**: 6 decimals (1 ATOM = 10^6 uatom)
+- **Cosmos SDK**: 6 decimals (1 ATOM = 10^6 test)
 - **Ethereum**: 18 decimals (1 ETH = 10^18 wei)
 
 This 12-decimal difference creates challenges when bridging the two ecosystems. Simply scaling values would lose precision or create rounding errors.
@@ -30,22 +30,22 @@ a(n) = b(n) × C + f(n)
 ```
 
 Where:
-- `a(n)` = Total balance in 18-decimal units (aatom)
-- `b(n)` = Integer balance in 6-decimal units (uatom)
+- `a(n)` = Total balance in 18-decimal units (atest)
+- `b(n)` = Integer balance in 6-decimal units (test)
 - `f(n)` = Fractional balance (remainder)
 - `C` = Conversion factor (10^12)
 - Constraint: `0 ≤ f(n) < C`
 
 ### Example Decomposition
 
-Consider a balance of 1,234,567,890,123,456,789 aatom:
+Consider a balance of 1,234,567,890,123,456,789 atest:
 
 ```
 1,234,567,890,123,456,789 = 1,234,567 × 10^12 + 890,123,456,789
 
 Where:
-- b(n) = 1,234,567 uatom (stored in bank)
-- f(n) = 890,123,456,789 aatom (stored in precisebank)
+- b(n) = 1,234,567 test (stored in bank)
+- f(n) = 890,123,456,789 atest (stored in precisebank)
 - Total = 1.234567890123456789 ATOM
 ```
 
@@ -65,7 +65,7 @@ b(R) × C = Σf(n) + r
 ```
 
 Where:
-- `b(R)` = Reserve balance in uatom
+- `b(R)` = Reserve balance in test
 - `Σf(n)` = Sum of all account fractional balances
 - `r` = Remainder (fractional amount not in circulation)
 - Constraint: `0 ≤ r < C`
@@ -74,10 +74,10 @@ Where:
 
 This ensures the fundamental invariant:
 ```
-Total_aatom = Total_uatom × 10^12 - remainder
+Total_atest = Total_test × 10^12 - remainder
 ```
 
-The remainder represents sub-uatom amounts that exist in the system but aren't assigned to any specific account.
+The remainder represents sub-test amounts that exist in the system but aren't assigned to any specific account.
 
 ## Operation Algorithms
 
@@ -158,32 +158,32 @@ The system manages three precision levels:
 | Unit | Precision | Decimals | Usage |
 |------|-----------|----------|-------|
 | **ATOM** | 10^0 | 0 | Human display |
-| **uatom** | 10^-6 | 6 | Cosmos native |
-| **aatom** | 10^-18 | 18 | EVM native |
+| **test** | 10^-6 | 6 | Cosmos native |
+| **atest** | 10^-18 | 18 | EVM native |
 
 ### Conversion Examples
 
 ```
-1 ATOM = 1,000,000 uatom = 1,000,000,000,000,000,000 aatom
-0.000001 ATOM = 1 uatom = 1,000,000,000,000 aatom
-0.000000000000000001 ATOM = 0.000000000001 uatom = 1 aatom
+1 ATOM = 1,000,000 test = 1,000,000,000,000,000,000 atest
+0.000001 ATOM = 1 test = 1,000,000,000,000 atest
+0.000000000000000001 ATOM = 0.000000000001 test = 1 atest
 ```
 
 ## Edge Cases and Limits
 
 ### Minimum Transferable Amount
-- **In Cosmos**: 1 uatom (0.000001 ATOM)
-- **In EVM**: 1 aatom (0.000000000000000001 ATOM)
+- **In Cosmos**: 1 test (0.000001 ATOM)
+- **In EVM**: 1 atest (0.000000000000000001 ATOM)
 
 ### Maximum Precision
-- **Cosmos operations**: Limited to uatom granularity
-- **EVM operations**: Full aatom precision
+- **Cosmos operations**: Limited to test granularity
+- **EVM operations**: Full atest precision
 - **Cross-system**: Automatic precision handling
 
 ### Dust Amounts
-Amounts smaller than 1 uatom but larger than 0 aatom:
+Amounts smaller than 1 test but larger than 0 atest:
 - Tracked in fractional balances
-- Accumulate until reaching 1 uatom
+- Accumulate until reaching 1 test
 - Never lost or rounded away
 
 ## Implementation Strategy
@@ -212,7 +212,7 @@ This single multiplication and addition reconstructs the full 18-decimal balance
 ## Why This Matters
 
 ### For Users
-- **No precision loss**: Every aatom is accounted for
+- **No precision loss**: Every atest is accounted for
 - **Seamless experience**: Automatic handling across systems
 - **Fair transactions**: No rounding advantages or disadvantages
 
@@ -233,7 +233,7 @@ This single multiplication and addition reconstructs the full 18-decimal balance
 // Naive approach - loses precision
 evmAmount = cosmosAmount * 10^12
 ```
-**Problems**: Loses sub-uatom amounts, rounding errors accumulate
+**Problems**: Loses sub-test amounts, rounding errors accumulate
 
 ### Fixed-Point Arithmetic
 ```
@@ -245,8 +245,8 @@ amount = FixedPoint{mantissa: 123456, exponent: -18}
 ### Separate Balances
 ```
 // Maintain two separate balance systems
-cosmosBalance: 1000000 uatom
-evmBalance: 1000000000000000000 aatom
+cosmosBalance: 1000000 test
+evmBalance: 1000000000000000000 atest
 ```
 **Problems**: Synchronization issues, double accounting, complexity
 

--- a/docs/v0.4.x/documentation/concepts/single-token-representation.mdx
+++ b/docs/v0.4.x/documentation/concepts/single-token-representation.mdx
@@ -38,13 +38,13 @@ Unlike wrapped tokens that require contract calls, STRv2 tokens operate at nativ
 A TokenPair links a Cosmos denomination with an ERC20 contract address, establishing the canonical mapping:
 
 ```
-Cosmos Coin (uatom) ←→ TokenPair ←→ ERC20 Contract (0x...)
+Cosmos Coin (test) ←→ TokenPair ←→ ERC20 Contract (0x...)
 ```
 
 ### Origin Types
 
 **Native Cosmos Coins**
-- Start as Cosmos SDK coins (uatom, uosmo, etc.)
+- Start as Cosmos SDK coins (test, uosmo, etc.)
 - Module deploys an ERC20 contract representation
 - Contract owned by module (OWNER_MODULE)
 - Conversions use mint/burn mechanism

--- a/docs/v0.4.x/documentation/concepts/tokens.mdx
+++ b/docs/v0.4.x/documentation/concepts/tokens.mdx
@@ -7,7 +7,7 @@ icon: "coins"
 * Cosmos tokens issued by the `x/bank` module
 * Ethereum-typed tokens, e.g. ERC-20, issued by the EVM
 
-`1 stake = 10<sup>18</sup> astake`
+`1 stake = 10<sup>18</sup> atest`
 
 This matches Ethereum denomination of:
 

--- a/docs/v0.4.x/documentation/cosmos-sdk/cli.mdx
+++ b/docs/v0.4.x/documentation/cosmos-sdk/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Command Line Interface (CLI)"
-description: "The CLI tool ('appd') provides a full-feature interface for interacting with the blockchain. This includes commands for node operations, key management, querying blockchain state, submitting transactions, and more."
+description: "The CLI tool ('evmd') provides a full-feature interface for interacting with the blockchain. This includes commands for node operations, key management, querying blockchain state, submitting transactions, and more."
 ---
 
 import { footnote } from '/snippets/footnote.mdx'
@@ -8,10 +8,10 @@ import { footnote } from '/snippets/footnote.mdx'
 <Info>
 **Node Requirements**
 
-To use the `query` and `tx` commands, your `appd` node must either:
+To use the `query` and `tx` commands, your `evmd` node must either:
 
 - Be fully synced with the network you're interacting with, OR
-- Be configured to use an external RPC endpoint in `~/.appd/config/client.toml`
+- Be configured to use an external RPC endpoint in `~/.evmd/config/client.toml`
 
 Example client.toml configuration:
 
@@ -39,11 +39,11 @@ These flags are available for all commands:
 |------|-------------|---------|
 | `-b, --broadcast-mode` | Transaction broadcasting mode (sync\|async) | `sync` |
 | `--chain-id` | Specify Chain ID for sending Tx | |
-| `--fees` | Fees to pay along with transaction (e.g., 10ustake) | |
+| `--fees` | Fees to pay along with transaction (e.g., 10atest) | |
 | `--from` | Name or address of private key with which to sign | |
 | `--gas-adjustment` | Adjustment factor to multiply against the estimate returned by tx simulation | `1` |
-| `--gas-prices` | Gas prices to determine the transaction fee (e.g., 10ustake) | |
-| `--home` | Directory for config and data | `~/.appd` |
+| `--gas-prices` | Gas prices to determine the transaction fee (e.g., 10atest) | |
+| `--home` | Directory for config and data | `~/.evmd` |
 | `--keyring-backend` | Select keyring's backend | `os` |
 | `--log_format` | The logging format (json\|plain) | `plain` |
 | `--log_level` | The logging level | `info` |
@@ -60,7 +60,7 @@ These flags are available for all commands:
 Run the full node.
 
 ```bash
-appd start [flags]
+evmd start [flags]
 ```
 
 Key flags:
@@ -90,8 +90,8 @@ You should only expose the debug endpoint in non production settings as it could
 For more detailed information about specific commands, simply use the `--help` or `-h` flag:
 
 ```bash
-appd [command] --help
-appd [command] [subcommand] --help
+evmd [command] --help
+evmd [command] [subcommand] --help
 ```
 
 #### Initializing the client / Running a node
@@ -101,13 +101,13 @@ Creates validator consensus key, p2p address book file, genesis (replace with th
 # Initialize node
 
 ```bash
-appd init mynode --chain-id my-chain-1
+evmd init mynode --chain-id my-chain-1
 ```
 
 # Start node with JSON-RPC enabled
 
 ```bash
-appd start --json-rpc.enable --json-rpc.api eth,web3,net,txpool,debug
+evmd start --json-rpc.enable --json-rpc.api eth,web3,net,txpool,debug
 ```
 
 # Get node status
@@ -115,7 +115,7 @@ appd start --json-rpc.enable --json-rpc.api eth,web3,net,txpool,debug
 You must be either running the client as part of a netork (or alone, for testing) or have an external RPC configured in `client.toml` first.
 
 ```bash
-appd status
+evmd status
 ```
 
 Returns:
@@ -168,7 +168,7 @@ Returns:
 Index historical Ethereum transactions.
 
 ```bash
-appd index-eth-tx [backward|forward] [flags]
+evmd index-eth-tx [backward|forward] [flags]
 ```
 
 - `backward`: Index from first indexed block to earliest block
@@ -183,7 +183,7 @@ The `keys` command provides keyring management functionality for accounts.
 Add a new key or recover from mnemonic.
 
 ```bash
-appd keys add [name] [flags]
+evmd keys add [name] [flags]
 ```
 
 Flags:
@@ -197,7 +197,7 @@ Flags:
 List all keys in the keyring.
 
 ```bash
-appd keys list [flags]
+evmd keys list [flags]
 ```
 
 #### `keys list-key-types`
@@ -205,7 +205,7 @@ appd keys list [flags]
 List all supported key types.
 
 ```bash
-appd keys list-key-types [flags]
+evmd keys list-key-types [flags]
 ```
 
 #### `keys show`
@@ -213,7 +213,7 @@ appd keys list-key-types [flags]
 Display key information.
 
 ```bash
-appd keys show [name|address] [flags]
+evmd keys show [name|address] [flags]
 ```
 
 #### `keys export`
@@ -221,7 +221,7 @@ appd keys show [name|address] [flags]
 Export a private key.
 
 ```bash
-appd keys export [name] [flags]
+evmd keys export [name] [flags]
 ```
 
 #### `keys import`
@@ -229,7 +229,7 @@ appd keys export [name] [flags]
 Import a private key.
 
 ```bash
-appd keys import [name] [keyfile] [flags]
+evmd keys import [name] [keyfile] [flags]
 ```
 
 #### EVM-specific Key Commands
@@ -239,7 +239,7 @@ appd keys import [name] [keyfile] [flags]
 Export an Ethereum private key (**UNSAFE**).
 
 ```bash
-appd keys unsafe-export-eth-key [name] [flags]
+evmd keys unsafe-export-eth-key [name] [flags]
 ```
 
 ##### `keys unsafe-import-eth-key`
@@ -247,7 +247,7 @@ appd keys unsafe-export-eth-key [name] [flags]
 Import Ethereum private keys into the local keybase (**UNSAFE**).
 
 ```bash
-appd keys unsafe-import-eth-key [name] [pk] [flags]
+evmd keys unsafe-import-eth-key [name] [pk] [flags]
 ```
 
 ### Query Commands
@@ -261,7 +261,7 @@ The `query` (or `q`) command provides read-only access to blockchain data.
 Get account information for an address.
 
 ```bash
-appd query evm account [address] [flags]
+evmd query evm account [address] [flags]
 ```
 
 ##### `query evm balance-bank`
@@ -269,7 +269,7 @@ appd query evm account [address] [flags]
 Get bank balance for a 0x address.
 
 ```bash
-appd query evm balance-bank [0x-address] [denom] [flags]
+evmd query evm balance-bank [0x-address] [denom] [flags]
 ```
 
 ##### `query evm balance-erc20`
@@ -277,7 +277,7 @@ appd query evm balance-bank [0x-address] [denom] [flags]
 Get ERC20 token balance.
 
 ```bash
-appd query evm balance-erc20 [0x-address] [erc20-address] [flags]
+evmd query evm balance-erc20 [0x-address] [erc20-address] [flags]
 ```
 
 ##### `query evm code`
@@ -285,7 +285,7 @@ appd query evm balance-erc20 [0x-address] [erc20-address] [flags]
 Get smart contract code.
 
 ```bash
-appd query evm code [address] [flags]
+evmd query evm code [address] [flags]
 ```
 
 ##### `query evm storage`
@@ -293,7 +293,7 @@ appd query evm code [address] [flags]
 Get storage value at a specific key.
 
 ```bash
-appd query evm storage [address] [key] [flags]
+evmd query evm storage [address] [key] [flags]
 ```
 
 ##### `query evm config`
@@ -301,7 +301,7 @@ appd query evm storage [address] [key] [flags]
 Get EVM configuration values.
 
 ```bash
-appd query evm config [flags]
+evmd query evm config [flags]
 ```
 
 ##### `query evm params`
@@ -309,7 +309,7 @@ appd query evm config [flags]
 Get EVM module parameters.
 
 ```bash
-appd query evm params [flags]
+evmd query evm params [flags]
 ```
 
 ##### Address Conversion
@@ -318,10 +318,10 @@ Convert between Ethereum (0x) and Cosmos (bech32) addresses:
 
 ```bash
 # 0x to bech32
-appd query evm 0x-to-bech32 [0x-address] [flags]
+evmd query evm 0x-to-bech32 [0x-address] [flags]
 
 # bech32 to 0x
-appd query evm bech32-to-0x [bech32-address] [flags]
+evmd query evm bech32-to-0x [bech32-address] [flags]
 ```
 
 #### ERC20 Module Queries
@@ -331,7 +331,7 @@ appd query evm bech32-to-0x [bech32-address] [flags]
 Get all registered token pairs.
 
 ```bash
-appd query erc20 token-pairs [flags]
+evmd query erc20 token-pairs [flags]
 ```
 
 ##### `query erc20 token-pair`
@@ -339,7 +339,7 @@ appd query erc20 token-pairs [flags]
 Get a specific token pair.
 
 ```bash
-appd query erc20 token-pair [token-address-or-denom] [flags]
+evmd query erc20 token-pair [token-address-or-denom] [flags]
 ```
 
 ##### `query erc20 params`
@@ -347,7 +347,7 @@ appd query erc20 token-pair [token-address-or-denom] [flags]
 Get ERC20 module parameters.
 
 ```bash
-appd query erc20 params [flags]
+evmd query erc20 params [flags]
 ```
 
 #### Feemarket Module Queries
@@ -357,7 +357,7 @@ appd query erc20 params [flags]
 Get the base fee at a given height.
 
 ```bash
-appd query feemarket base-fee [flags]
+evmd query feemarket base-fee [flags]
 ```
 
 ##### `query feemarket block-gas`
@@ -365,7 +365,7 @@ appd query feemarket base-fee [flags]
 Get the block gas used at a given height.
 
 ```bash
-appd query feemarket block-gas [flags]
+evmd query feemarket block-gas [flags]
 ```
 
 ##### `query feemarket params`
@@ -373,7 +373,7 @@ appd query feemarket block-gas [flags]
 Get fee market parameters.
 
 ```bash
-appd query feemarket params [flags]
+evmd query feemarket params [flags]
 ```
 
 #### Precisebank Module Queries
@@ -383,7 +383,7 @@ appd query feemarket params [flags]
 Get the remainder amount in the precise bank module.
 
 ```bash
-appd query precisebank remainder [flags]
+evmd query precisebank remainder [flags]
 ```
 
 ##### `query precisebank fractional-balance`
@@ -391,7 +391,7 @@ appd query precisebank remainder [flags]
 Get the fractional balance of an account.
 
 ```bash
-appd query precisebank fractional-balance [address] [flags]
+evmd query precisebank fractional-balance [address] [flags]
 ```
 
 #### Standard Cosmos Queries
@@ -400,49 +400,49 @@ appd query precisebank fractional-balance [address] [flags]
 
 ```bash
 # Get account balances
-appd query bank balances [address] [flags]
+evmd query bank balances [address] [flags]
 
 # Get specific denom balance
-appd query bank balance [address] [denom] [flags]
+evmd query bank balance [address] [denom] [flags]
 
 # Get total supply
-appd query bank total [flags]
+evmd query bank total [flags]
 ```
 
 ##### Staking Module
 
 ```bash
 # Get all validators
-appd query staking validators [flags]
+evmd query staking validators [flags]
 
 # Get delegations for an address
-appd query staking delegations [delegator-address] [flags]
+evmd query staking delegations [delegator-address] [flags]
 
 # Get unbonding delegations
-appd query staking unbonding-delegations [delegator-address] [flags]
+evmd query staking unbonding-delegations [delegator-address] [flags]
 ```
 
 ##### Distribution Module
 
 ```bash
 # Get rewards
-appd query distribution rewards [delegator-address] [validator-address] [flags]
+evmd query distribution rewards [delegator-address] [validator-address] [flags]
 
 # Get commission
-appd query distribution commission [validator-address] [flags]
+evmd query distribution commission [validator-address] [flags]
 ```
 
 ##### Governance Module
 
 ```bash
 # List all proposals
-appd query gov proposals [flags]
+evmd query gov proposals [flags]
 
 # Get specific proposal
-appd query gov proposal [proposal-id] [flags]
+evmd query gov proposal [proposal-id] [flags]
 
 # Get votes on a proposal
-appd query gov votes [proposal-id] [flags]
+evmd query gov votes [proposal-id] [flags]
 ```
 
 ### Transaction Commands
@@ -456,7 +456,7 @@ The `tx` command is used to create and broadcast transactions.
 Send funds between accounts.
 
 ```bash
-appd tx evm send [from] [to] [amount] [flags]
+evmd tx evm send [from] [to] [amount] [flags]
 ```
 
 ##### `tx evm raw`
@@ -464,7 +464,7 @@ appd tx evm send [from] [to] [amount] [flags]
 Build a Cosmos transaction from a raw Ethereum transaction.
 
 ```bash
-appd tx evm raw [hex-encoded-tx] [flags]
+evmd tx evm raw [hex-encoded-tx] [flags]
 ```
 
 #### ERC20 Transactions
@@ -474,7 +474,7 @@ appd tx evm raw [hex-encoded-tx] [flags]
 Convert native Cosmos coins to ERC20 tokens.
 
 ```bash
-appd tx erc20 convert-coin [amount] [receiver] [flags]
+evmd tx erc20 convert-coin [amount] [receiver] [flags]
 ```
 
 ##### `tx erc20 convert-erc20`
@@ -482,7 +482,7 @@ appd tx erc20 convert-coin [amount] [receiver] [flags]
 Convert ERC20 tokens to native Cosmos coins.
 
 ```bash
-appd tx erc20 convert-erc20 [contract-address] [amount] [receiver] [flags]
+evmd tx erc20 convert-erc20 [contract-address] [amount] [receiver] [flags]
 ```
 
 ##### `tx erc20 register-erc20`
@@ -490,7 +490,7 @@ appd tx erc20 convert-erc20 [contract-address] [amount] [receiver] [flags]
 Register native ERC20 tokens (governance only).
 
 ```bash
-appd tx erc20 register-erc20 [contract-address...] [flags]
+evmd tx erc20 register-erc20 [contract-address...] [flags]
 ```
 
 ##### `tx erc20 toggle-conversion`
@@ -498,7 +498,7 @@ appd tx erc20 register-erc20 [contract-address...] [flags]
 Enable or disable token pair conversion (governance only).
 
 ```bash
-appd tx erc20 toggle-conversion [token] [flags]
+evmd tx erc20 toggle-conversion [token] [flags]
 ```
 
 #### Standard Cosmos Transactions
@@ -507,39 +507,39 @@ appd tx erc20 toggle-conversion [token] [flags]
 
 ```bash
 # Send coins
-appd tx bank send [from] [to] [amount] [flags]
+evmd tx bank send [from] [to] [amount] [flags]
 
 # Multi-send
-appd tx bank multi-send [from] [to1] [amount1] [to2] [amount2] ... [flags]
+evmd tx bank multi-send [from] [to1] [amount1] [to2] [amount2] ... [flags]
 ```
 
 ##### Staking Transactions
 
 ```bash
 # Create validator
-appd tx staking create-validator [flags]
+evmd tx staking create-validator [flags]
 
 # Delegate
-appd tx staking delegate [validator-address] [amount] [flags]
+evmd tx staking delegate [validator-address] [amount] [flags]
 
 # Unbond
-appd tx staking unbond [validator-address] [amount] [flags]
+evmd tx staking unbond [validator-address] [amount] [flags]
 
 # Redelegate
-appd tx staking redelegate [src-validator] [dst-validator] [amount] [flags]
+evmd tx staking redelegate [src-validator] [dst-validator] [amount] [flags]
 ```
 
 ##### Governance Transactions
 
 ```bash
 # Submit proposal
-appd tx gov submit-proposal [proposal-type] [flags]
+evmd tx gov submit-proposal [proposal-type] [flags]
 
 # Vote on proposal
-appd tx gov vote [proposal-id] [option] [flags]
+evmd tx gov vote [proposal-id] [option] [flags]
 
 # Deposit on proposal
-appd tx gov deposit [proposal-id] [amount] [flags]
+evmd tx gov deposit [proposal-id] [amount] [flags]
 ```
 
 ### Advanced Commands
@@ -550,13 +550,13 @@ Genesis file manipulation commands.
 
 ```bash
 # Add genesis account
-appd genesis add-genesis-account [address] [coins] [flags]
+evmd genesis add-genesis-account [address] [coins] [flags]
 
 # Collect genesis transactions
-appd genesis collect-gentxs [flags]
+evmd genesis collect-gentxs [flags]
 
 # Generate genesis transaction
-appd genesis gentx [key-name] [amount] [flags]
+evmd genesis gentx [key-name] [amount] [flags]
 ```
 
 #### `comet`
@@ -565,13 +565,13 @@ CometBFT-specific commands.
 
 ```bash
 # Show node ID
-appd comet show-node-id [flags]
+evmd comet show-node-id [flags]
 
 # Show validator info
-appd comet show-validator [flags]
+evmd comet show-validator [flags]
 
 # Reset blockchain state
-appd comet unsafe-reset-all [flags]
+evmd comet unsafe-reset-all [flags]
 ```
 
 #### `debug`
@@ -580,13 +580,13 @@ Debugging utilities.
 
 ```bash
 # Get raw bytes for address
-appd debug addr [address] [flags]
+evmd debug addr [address] [flags]
 
 # Decode raw hex bytes
-appd debug raw-bytes [hex] [flags]
+evmd debug raw-bytes [hex] [flags]
 
 # Convert public key
-appd debug pubkey [pubkey] [flags]
+evmd debug pubkey [pubkey] [flags]
 ```
 
 ## Examples
@@ -595,52 +595,52 @@ appd debug pubkey [pubkey] [flags]
 
 ```bash
 # Create a new account
-appd keys add myaccount
+evmd keys add myaccount
 
 # Import an Ethereum private key
-appd keys unsafe-import-eth-key myethaccount 0x...
+evmd keys unsafe-import-eth-key myethaccount 0x...
 
 # List all accounts
-appd keys list
+evmd keys list
 
 # Show account details
-appd keys show myaccount
+evmd keys show myaccount
 ```
 
 ### Querying blockchain state
 
 ```bash
 # Get account balance
-appd query bank balances cosmos1...
+evmd query bank balances cosmos1...
 
 # Get EVM account info
-appd query evm account 0x...
+evmd query evm account 0x...
 
 # Get ERC20 balance
-appd query evm balance-erc20 0xUserAddress 0xTokenAddress
+evmd query evm balance-erc20 0xUserAddress 0xTokenAddress
 
 # Get base fee
-appd query feemarket base-fee
+evmd query feemarket base-fee
 ```
 
 ### Sending transactions
 
 ```bash
 # Send native tokens
-appd tx bank send myaccount cosmos1... 100ustake --gas-prices 10ustake
+evmd tx bank send myaccount cosmos1... 100atest --gas-prices 10atest
 
 # Send native tokens using EVM message
-appd tx evm send myaccount 0x... 100ustake --gas-prices 10ustake
+evmd tx evm send myaccount 0x... 100atest --gas-prices 10atest
 
 # Convert coins to ERC20
-appd tx erc20 convert-coin 100ustake 0x... --from myaccount
+evmd tx erc20 convert-coin 100atest 0x... --from myaccount
 ```
 
 ## Configuration
 
-- Configuration directory: `~/.appd/`
+- Configuration directory: `~/.evmd/`
 - Key storage: Managed by the keyring backend (os, file, test)
-- Node configuration: `~/.appd/config/config.toml`
-- App configuration: `~/.appd/config/app.toml`
+- Node configuration: `~/.evmd/config/config.toml`
+- App configuration: `~/.evmd/config/app.toml`
 
 <Info>If you use the `--home` flag upon initializing the light client, the root/config directory will be generated there</Info>

--- a/docs/v0.4.x/documentation/cosmos-sdk/modules/erc20.mdx
+++ b/docs/v0.4.x/documentation/cosmos-sdk/modules/erc20.mdx
@@ -318,13 +318,13 @@ evmd query erc20 params
 evmd query erc20 token-pairs
 
 # Query specific token pair
-evmd query erc20 token-pair uatom
+evmd query erc20 token-pair test
 evmd query erc20 token-pair 0x80b5a32e4f032b2a058b4f29ec95eefeeb87adcd
 ```
 
 ```bash Convert-Tokens
 # Convert Cosmos coin to ERC20
-evmd tx erc20 convert-coin 100uatom 0xReceiverAddress --from mykey
+evmd tx erc20 convert-coin 100test 0xReceiverAddress --from mykey
 
 # Convert ERC20 to Cosmos coin
 evmd tx erc20 convert-erc20 0xTokenAddress 100000000000000000000 cosmos1receiver --from mykey
@@ -364,7 +364,7 @@ await dexRouter.swapExactTokensForTokens(...);
 const packet = {
     sender: "cosmos1...",
     receiver: "0x...",  // EVM address triggers conversion
-    token: { denom: "uatom", amount: "1000000" }
+    token: { denom: "test", amount: "1000000" }
 };
 // Token arrives as ERC20 in receiver's EVM account
 ```
@@ -377,7 +377,7 @@ await client.signAndBroadcast(address, [
     {
         typeUrl: "/cosmos.evm.erc20.v1.MsgConvertCoin",
         value: {
-            coin: { denom: "uatom", amount: "1000000" },
+            coin: { denom: "test", amount: "1000000" },
             receiver: "0xEthereumAddress",
             sender: "cosmos1..."
         }
@@ -439,7 +439,7 @@ await client.signAndBroadcast(address, [
 
 ```bash
 # Check if token is registered
-evmd query erc20 token-pair uatom
+evmd query erc20 token-pair test
 
 # Check module parameters
 evmd query erc20 params

--- a/docs/v0.4.x/documentation/cosmos-sdk/modules/precisebank.mdx
+++ b/docs/v0.4.x/documentation/cosmos-sdk/modules/precisebank.mdx
@@ -16,7 +16,7 @@ The module acts as a wrapper around `x/bank`, providing:
 - **18 decimal precision** for EVM (10^18 sub-atomic units)
 - **Backward compatibility** with 6 decimal Cosmos operations
 - **Transparent conversion** between precision levels
-- **Fractional balance tracking** for sub-uatom amounts
+- **Fractional balance tracking** for sub-test amounts
 
 <Note>
   Developed with contributions from the [Kava](https://www.kava.io/) team.
@@ -35,13 +35,13 @@ The module maintains fractional balances and remainder ([source](https://github.
 
 Full balance calculation:
 ```
-aatom_balance = uatom_balance × 10^12 + fractional_balance
+atest_balance = test_balance × 10^12 + fractional_balance
 ```
 
 Where:
-- `uatom_balance`: Stored in x/bank (6 decimals)
+- `test_balance`: Stored in x/bank (6 decimals)
 - `fractional_balance`: Stored in x/precisebank (0 to 10^12-1)
-- `aatom_balance`: Full 18-decimal precision
+- `atest_balance`: Full 18-decimal precision
 
 ## Keeper Interface
 
@@ -66,9 +66,9 @@ type Keeper interface {
 
 ### Extended Coin Support
 
-Automatic handling of "aatom" denomination:
-- Converts between uatom and aatom transparently
-- Maintains fractional balances for sub-uatom amounts
+Automatic handling of "atest" denomination:
+- Converts between test and atest transparently
+- Maintains fractional balances for sub-test amounts
 - Ensures consistency between x/bank and x/precisebank
 
 ## Operations
@@ -80,7 +80,7 @@ Handles both integer and fractional components:
 ```go
 // SendCoins automatically handles precision
 keeper.SendCoins(ctx, from, to, sdk.NewCoins(
-    sdk.NewCoin("aatom", sdk.NewInt(1500000000000)), // 0.0015 uatom
+    sdk.NewCoin("atest", sdk.NewInt(1500000000000)), // 0.0015 test
 ))
 ```
 
@@ -97,7 +97,7 @@ Creates new tokens with proper backing:
 ```go
 // MintCoins with extended precision
 keeper.MintCoins(ctx, moduleName, sdk.NewCoins(
-    sdk.NewCoin("aatom", sdk.NewInt(1000000000000000000)), // 1 uatom
+    sdk.NewCoin("atest", sdk.NewInt(1000000000000000000)), // 1 test
 ))
 ```
 
@@ -113,7 +113,7 @@ Removes tokens from circulation:
 ```go
 // BurnCoins with extended precision
 keeper.BurnCoins(ctx, moduleName, sdk.NewCoins(
-    sdk.NewCoin("aatom", sdk.NewInt(500000000000)),  // 0.0005 uatom
+    sdk.NewCoin("atest", sdk.NewInt(500000000000)),  // 0.0005 test
 ))
 ```
 
@@ -130,7 +130,7 @@ Standard bank events with extended precision amounts:
 
 | Event | Attributes | Description |
 |-------|------------|-------------|
-| `transfer` | `sender`, `recipient`, `amount` | Full aatom amount |
+| `transfer` | `sender`, `recipient`, `amount` | Full atest amount |
 | `coin_spent` | `spender`, `amount` | Extended precision |
 | `coin_received` | `receiver`, `amount` | Extended precision |
 
@@ -170,7 +170,7 @@ service Query {
 evmd query precisebank total-fractional-balances
 
 # Example output:
-# total: "2000000000000aatom"
+# total: "2000000000000atest"
 ```
 
 ```bash Query-Remainder
@@ -178,7 +178,7 @@ evmd query precisebank total-fractional-balances
 evmd query precisebank remainder
 
 # Example output:
-# remainder: "100aatom"
+# remainder: "100atest"
 ```
 
 ```bash Query-Balance
@@ -186,7 +186,7 @@ evmd query precisebank remainder
 evmd query precisebank fractional-balance cosmos1...
 
 # Example output:
-# fractional_balance: "10000aatom"
+# fractional_balance: "10000atest"
 ```
 
 </CodeGroup>
@@ -209,12 +209,12 @@ app.EvmKeeper = evmkeeper.NewKeeper(
 Query extended balances through standard interface:
 
 ```go
-// Automatically handles aatom denomination
-balance := keeper.GetBalance(ctx, addr, "aatom")
+// Automatically handles atest denomination
+balance := keeper.GetBalance(ctx, addr, "atest")
 
 // Transfer with 18 decimal precision
 err := keeper.SendCoins(ctx, from, to, 
-    sdk.NewCoins(sdk.NewCoin("aatom", amount)))
+    sdk.NewCoins(sdk.NewCoin("atest", amount)))
 ```
 
 ## Reserve Account
@@ -222,7 +222,7 @@ err := keeper.SendCoins(ctx, from, to,
 The reserve account maintains backing for fractional balances:
 
 ```
-Reserve_uatom × 10^12 = Σ(all fractional balances) + remainder
+Reserve_test × 10^12 = Σ(all fractional balances) + remainder
 ```
 
 ### Monitoring Reserve
@@ -242,10 +242,10 @@ Critical invariants maintained by the module:
 
 | Invariant | Formula | Description |
 |-----------|---------|-------------|
-| **Supply** | `Total_aatom = Total_uatom × 10^12 - remainder` | Total supply consistency |
+| **Supply** | `Total_atest = Total_test × 10^12 - remainder` | Total supply consistency |
 | **Fractional Range** | `0 ≤ f(n) < 10^12` | Valid fractional bounds |
 | **Reserve Backing** | `Reserve × 10^12 = Σf(n) + r` | Full backing guarantee |
-| **Conservation** | `Δ(Total_aatom) = Δ(Total_uatom × 10^12)` | No creation/destruction |
+| **Conservation** | `Δ(Total_atest) = Δ(Total_test × 10^12)` | No creation/destruction |
 
 ## Best Practices
 
@@ -278,7 +278,7 @@ Critical invariants maintained by the module:
 
 1. **Balance Queries**
    ```javascript
-   // Query in aatom (18 decimals)
+   // Query in atest (18 decimals)
    const balance = await queryClient.precisebank.fractionalBalance({
        address: "cosmos1..."
    });
@@ -287,8 +287,8 @@ Critical invariants maintained by the module:
 2. **Precision Handling**
    ```javascript
    // Convert between precisions
-   const uatomAmount = aatomAmount / BigInt(10**12);
-   const aatomAmount = uatomAmount * BigInt(10**12);
+   const testAmount = atestAmount / BigInt(10**12);
+   const atestAmount = testAmount * BigInt(10**12);
    ```
 
 ## Security Considerations
@@ -332,7 +332,7 @@ Critical invariants maintained by the module:
 | Issue | Cause | Solution |
 |-------|-------|----------|
 | "fractional overflow" | Fractional > 10^12 | Check calculation logic |
-| "insufficient balance" | Including fractional | Verify full aatom balance |
+| "insufficient balance" | Including fractional | Verify full atest balance |
 | "invariant violation" | Supply mismatch | Audit reserve and remainder |
 
 ### Validation Commands
@@ -343,7 +343,7 @@ evmd query precisebank total-fractional-balances
 evmd query precisebank remainder
 
 # Check specific account
-evmd query bank balances cosmos1... --denom uatom
+evmd query bank balances cosmos1... --denom test
 evmd query precisebank fractional-balance cosmos1...
 ```
 

--- a/docs/v0.4.x/documentation/cosmos-sdk/modules/vm.mdx
+++ b/docs/v0.4.x/documentation/cosmos-sdk/modules/vm.mdx
@@ -16,7 +16,7 @@ The module parameters control EVM behavior and access policies ([source](https:/
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `evm_denom` | string | `"aatom"` | Token denomination for EVM transactions (18 decimals) |
+| `evm_denom` | string | `"atest"` | Token denomination for EVM transactions (18 decimals) |
 | `extra_eips` | []int64 | `[]` | Additional EIPs to activate beyond hard fork defaults |
 | `allow_unprotected_txs` | bool | `false` | Allow non-EIP155 replay-protected transactions |
 | `active_static_precompiles` | []string | `[]` | Activated static precompile addresses |
@@ -30,7 +30,7 @@ Defines the token used for gas and value transfers in EVM:
 - Must be registered in bank module
 - Should have 18 decimal precision
 - Used for all EVM operations (gas, transfers, contracts)
-- Example: `"aatom"`, `"aevmos"`, `"wei"`
+- Example: `"atest"`, `"aevmos"`, `"wei"`
 </Expandable>
 
 <Expandable title="extra_eips">
@@ -69,7 +69,7 @@ type AccessControl struct {
   <Tab title="Ethereum Compatible">
     ```json
     {
-      "evm_denom": "aatom",
+      "evm_denom": "atest",
       "extra_eips": [3855],
       "allow_unprotected_txs": false,
       "active_static_precompiles": [
@@ -455,7 +455,7 @@ finalGasUsed = gasUsed - refund
 2. **Precompile Usage**
    ```solidity
    IBank bank = IBank(0x0000000000000000000000000000000000000804);
-   uint256 balance = bank.balances(msg.sender, "aatom");
+   uint256 balance = bank.balances(msg.sender, "atest");
    ```
 
 ### dApp Integration

--- a/docs/v0.4.x/documentation/evm-compatibility/overview.mdx
+++ b/docs/v0.4.x/documentation/evm-compatibility/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overview"
 mode: "wide"
-keywords: ['differences', 'ethereum', 'evm', 'cosmos', 'tendermint', 'consensus', 'finality', 'json-rpc', 'compatibility', 'precompiles', 'ibc', 'mev', 'gas', 'basefee', 'reorganization', 'bft', 'validator', 'staking']
+keywords: ['differences', 'ethereum', 'evm', 'cosmos', ''CometBFT'', 'consensus', 'finality', 'json-rpc', 'compatibility', 'precompiles', 'ibc', 'mev', 'gas', 'basefee', 'reorganization', 'bft', 'validator', 'staking']
 ---
 
 The EVM module provides **developer and end-user Ethereum compatibility** for Cosmos-SDK based chains. All standard / common Ethereum dApps, tools, and workflows work seamlessly while gaining the benefits of Cosmos consensus and interoperability.
@@ -40,7 +40,7 @@ Cosmos EVM maintains all critical EVM behaviors that developers expect. The tabl
 
 ### Faster & Final Transactions
 
-**Instant Finality:** Transactions are final after one block (~2 seconds) thanks to Tendermint BFT consensus. No waiting for confirmations, no reorganizations possible.
+**Instant Finality:** Transactions are final after one block (~2 seconds) thanks to 'CometBFT' BFT consensus. No waiting for confirmations, no reorganizations possible.
 
 **Validator Set:** Fixed validator set with stake-based voting power. Requires 2/3+ stake agreement for consensus.
 
@@ -113,7 +113,7 @@ These are completely independent values, not derived from each other.
 
 **Implementation notes:**
 - Some methods return stub values for compatibility (e.g., `eth_gasPrice` returns 0)
-- Mining-related methods are not applicable (Cosmos uses Tendermint consensus)
+- Mining-related methods are not applicable (Cosmos uses 'CometBFT' consensus)
 - `txpool` methods require experimental mempool configuration
 - Debug namespace includes functional tracing and profiling tools
 
@@ -178,7 +178,7 @@ Key breaking changes when migrating:
 -  **Production Ready:** Core EVM implementation is stable and deployed on multiple mainnets
 -  **Enhanced Security:** No reorganization attacks possible due to instant finality
 -  **Byzantine Fault Tolerant:** Requires 2/3+ validator stake for any state changes
--  **Proven Stack:** Built on Cosmos SDK and Tendermint, powering hundreds of chains
+-  **Proven Stack:** Built on Cosmos SDK and 'CometBFT', powering hundreds of chains
 
 ## Resources
 

--- a/docs/v0.4.x/documentation/integration/devnet/connect-to-the-network.mdx
+++ b/docs/v0.4.x/documentation/integration/devnet/connect-to-the-network.mdx
@@ -13,7 +13,7 @@ import { footnote } from '/snippets/footnote.mdx'
 | **EVM Chain ID** | `4231` | Network identifier for EVM tooling |
 | **EVM Version** | `Prague` | EVM hard fork compatibility version |
 | **Native Token** | `ATOM` | Staking / gas token |
-| **Denom Exponent** | `6` | Native token has 6 decimal places (`uatom`) |
+| **Denom Exponent** | `6` | Native token has 6 decimal places (`test`) |
 
 ## Public Endpoints
 
@@ -21,7 +21,7 @@ import { footnote } from '/snippets/footnote.mdx'
 |-------------------|----------------------|---------|
 | **EVM JSON-RPC** | `<evm_rpc_url>` | Ethereum-compatible tools (MetaMask, Hardhat, ethers.js) |
 | **EVM RPC WS**   | `wss://devnet-1-evmws.ib.skip.build`   | Streaming real-time, selective data for applications |
-| **Cosmos RPC** | `https://devnet-1-rpc.ib.skip.build` | Tendermint-level interactions (blocks, consensus state) |
+| **Cosmos RPC** | `https://devnet-1-rpc.ib.skip.build` | 'CometBFT'-level interactions (blocks, consensus state) |
 | **Cosmos REST API** | `https://devnet-1-lcd.ib.skip.build` | Query Cosmos SDK modules (bank, staking, etc.) |
 | **gRPC** | `devnet-1-grpc.ib.skip.build:443` | High-performance Protobuf endpoint for back-ends |
 
@@ -145,10 +145,10 @@ evmd keys add recovered --recover --key-type eth_secp256k1
   <Accordion title="Broadcast a Transaction">
     <CodeGroup>
       ```bash Bank Send
-      evmd tx bank send cosmos1... cosmos1... 1000uatom \
+      evmd tx bank send cosmos1... cosmos1... 1000test \
         --node https://devnet-1-rpc.ib.skip.build:443 \
         --chain-id 4321 \
-        --gas auto --fees 500uatom \
+        --gas auto --fees 500test \
         --yes
       ```
 
@@ -156,7 +156,7 @@ evmd keys add recovered --recover --key-type eth_secp256k1
       evmd tx evm raw 0x02e20180010182520894de0b295669a9fd93d5f28d9ec85e40f4cb697bae8080c0808080 \
         --node https://devnet-1-rpc.ib.skip.build:443 \
         --chain-id 4231 \
-        --gas auto --fees 500uatom \
+        --gas auto --fees 500test \
         --yes
       ```
     </CodeGroup>
@@ -166,10 +166,10 @@ evmd keys add recovered --recover --key-type eth_secp256k1
     You can use the `--generate-only` flag to create transaction messages without broadcasting them. This can be useful for finding the correct syntax and creating reusable transaction templates.
 
     ```bash Generate Only Example
-    evmd tx bank send cosmos1... cosmos1... 1000uatom \
+    evmd tx bank send cosmos1... cosmos1... 1000test \
       --node https://devnet-1-rpc.ib.skip.build:443 \
       --chain-id 4321 \
-      --gas auto --fees 500uatom \
+      --gas auto --fees 500test \
       --generate-only | jq
     ```
   </Accordion>
@@ -191,7 +191,7 @@ Basic endpoints:
 
 ### Cosmos RPC
 
-> **For Tendermint-level interactions**
+> **For 'CometBFT'-level interactions**
 
 `https://devnet-1-rpc.ib.skip.build`
 

--- a/docs/v0.4.x/documentation/integration/evm-module-integration.mdx
+++ b/docs/v0.4.x/documentation/integration/evm-module-integration.mdx
@@ -26,7 +26,7 @@ Contact [Interchain Labs](https://share-eu1.hsforms.com/2g6yO-PVaRoKj50rUgG4Pjg2
 - Basic knowledge of Go and Cosmos SDK
 
 <Note>
-Throughout this guide, `appd` refers to your chain's binary (e.g., `gaiad`, `dydxd`, etc.).
+Throughout this guide, `evmd` refers to your chain's binary (e.g., `gaiad`, `dydxd`, etc.).
 </Note>
 
 ## Version Compatibility
@@ -811,7 +811,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 
 ## Step 9: Update Command Files
 
-### Update cmd/appd/commands.go
+### Update cmd/evmd/commands.go
 
 ```go
 import (
@@ -866,7 +866,7 @@ func initRootCmd(...) {
 }
 ```
 
-### Update cmd/appd/root.go
+### Update cmd/evmd/root.go
 
 ```go
 import (
@@ -936,7 +936,7 @@ If your chain requires Sign Mode Textual support, ensure your ante handler and c
 make test-all
 
 # Run EVM-specific tests
-make test-appd
+make test-evmd
 
 # Run integration tests
 make test-integration
@@ -961,7 +961,7 @@ chmod +x local_node.sh
 ### Genesis Validation
 
 ```bash
-appd genesis validate-genesis
+evmd genesis validate-genesis
 ```
 
 ---

--- a/docs/v0.4.x/documentation/integration/mempool-integration.mdx
+++ b/docs/v0.4.x/documentation/integration/mempool-integration.mdx
@@ -137,7 +137,7 @@ priorityConfig := sdkmempool.PriorityNonceMempoolConfig[math.Int]{
             }
 
             // Get fee in bond denomination
-            bondDenom := "uatom" // or your chain's bond denom
+            bondDenom := "test" // or your chain's bond denom
             fee := feeTx.GetFee()
             found, coin := fee.Find(bondDenom)
             if !found {

--- a/docs/v0.4.x/documentation/overview.mdx
+++ b/docs/v0.4.x/documentation/overview.mdx
@@ -14,7 +14,7 @@ import { EthereumIcon, CosmosLogo } from '/snippets/icons.mdx'
     Access staking, governance, IBC, and other Cosmos SDK modules directly from smart contracts
   </Card>
   <Card title="Instant Finality" icon="zap" href="/docs/next/documentation/concepts/transactions">
-    1-2 second block times with instant finality via Tendermint consensus
+    1-2 second block times with instant finality via 'CometBFT' consensus
   </Card>
   <Card title="Cross-Chain Ready" icon="globe" href="/docs/next/documentation/concepts/ibc">
     Built-in IBC support for interoperability across a growing list of ecosystems

--- a/docs/v0.4.x/documentation/smart-contracts/precompiles/erc20.mdx
+++ b/docs/v0.4.x/documentation/smart-contracts/precompiles/erc20.mdx
@@ -36,7 +36,7 @@ Gas costs are approximated and may vary based on token complexity and chain sett
 
 The ERC20 precompile works through a token pair mapping system:
 
-1. **Native Cosmos Token**: Each Cosmos SDK denomination (e.g., `uatom`, `stake`) exists as a native token
+1. **Native Cosmos Token**: Each Cosmos SDK denomination (e.g., `test`, `stake`) exists as a native token
 2. **ERC20 Contract**: A corresponding ERC20 precompile contract is created at a unique address
 3. **Bidirectional Conversion**: Tokens can be converted between native and ERC20 representations
 4. **Dynamic Addresses**: Each token pair gets its own precompile address when registered
@@ -275,7 +275,7 @@ curl -X POST --data '{
 Returns the number of decimals used for the token.
 
 <Warning>
-**Decimal Handling**: The ERC20 precompile may need to handle complex decimal conversions between Cosmos native tokens and ERC20 representation. Some Cosmos tokens use 6 decimals (e.g., `uatom`) while ERC20 typically uses 18. Always verify the decimal count for accurate amount calculations.
+**Decimal Handling**: The ERC20 precompile may need to handle complex decimal conversions between Cosmos native tokens and ERC20 representation. Some Cosmos tokens use 6 decimals (e.g., `test`) while ERC20 typically uses 18. Always verify the decimal count for accurate amount calculations.
 </Warning>
 
 <CodeGroup>

--- a/docs/v0.4.x/documentation/smart-contracts/precompiles/ics20.mdx
+++ b/docs/v0.4.x/documentation/smart-contracts/precompiles/ics20.mdx
@@ -68,7 +68,7 @@ const contract = new ethers.Contract(precompileAddress, precompileAbi, signer);
 // Transfer parameters
 const sourcePort = "transfer";
 const sourceChannel = "channel-0";
-const token = "uatom"; // or ERC20 token address
+const token = "test"; // or ERC20 token address
 const sender = await signer.getAddress();
 const receiver = "cosmos1..."; // Destination address on target chain
 const timeoutHeight = 0; // 0 for no height timeout
@@ -231,7 +231,7 @@ const precompileAddress = "0x0000000000000000000000000000000000000802";
 const contract = new ethers.Contract(precompileAddress, precompileAbi, provider);
 
 // Input: The trace path to hash
-const tracePath = "transfer/channel-0/uatom"; // Placeholder for actual trace path
+const tracePath = "transfer/channel-0/test"; // Placeholder for actual trace path
 
 async function getDenomHash() {
   try {

--- a/docs/v0.4.x/documentation/smart-contracts/precompiles/werc20.mdx
+++ b/docs/v0.4.x/documentation/smart-contracts/precompiles/werc20.mdx
@@ -2,7 +2,7 @@
 title: "WERC20"
 description: "Single token representation: An ERC20 interface for any token"
 icon: "refresh-ccw"
-keywords: ['werc20', 'wrapped token', 'erc20', 'single token representation', 'precompile', 'watom', 'native token', 'bank module', 'cosmos sdk', 'token bridge', 'unified token', 'ibc tokens', 'no-op deposit', 'no-op withdraw']
+keywords: ['werc20', 'wrapped token', 'erc20', 'single token representation', 'precompile', 'wtest', 'native token', 'bank module', 'cosmos sdk', 'token bridge', 'unified token', 'ibc tokens', 'no-op deposit', 'no-op withdraw']
 ---
 
 ## Overview
@@ -103,19 +103,19 @@ This is why `deposit()` and `withdraw()` are no-ops - there's no separate wrappe
 ```javascript
 // User starts with 100 ATOM in bank module
 const atomBalance = await bankPrecompile.balances(userAddress);
-// Returns: [{denom: "uatom", amount: "100000000"}] // 100 ATOM (6 decimals)
+// Returns: [{denom: "test", amount: "100000000"}] // 100 ATOM (6 decimals)
 
-const watomBalance = await watom.balanceOf(userAddress);
+const wtestBalance = await wtest.balanceOf(userAddress);
 // Returns: "100000000" // Same 100 ATOM, accessed via ERC20 interface
 
 // User transfers 50 WATOM via ERC20
-await watom.transfer(recipientAddress, "50000000");
+await wtest.transfer(recipientAddress, "50000000");
 
 // Check balances again
 const newAtomBalance = await bankPrecompile.balances(userAddress);
-// Returns: [{denom: "uatom", amount: "50000000"}] // 50 ATOM remaining
+// Returns: [{denom: "test", amount: "50000000"}] // 50 ATOM remaining
 
-const newWatomBalance = await watom.balanceOf(userAddress);
+const newWatomBalance = await wtest.balanceOf(userAddress);
 // Returns: "50000000" // Same 50 ATOM, both queries return identical values
 ```
 
@@ -133,15 +133,15 @@ Returns the native token balance for a specific account (same as bank module bal
 import { ethers } from "ethers";
 
 const provider = new ethers.JsonRpcProvider("<RPC_URL>");
-const watomAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const wtestAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const werc20Abi = ["function balanceOf(address account) view returns (uint256)"];
 
-const watom = new ethers.Contract(watomAddress, werc20Abi, provider);
+const wtest = new ethers.Contract(wtestAddress, werc20Abi, provider);
 
 async function getBalance() {
   try {
     const userAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
-    const balance = await watom.balanceOf(userAddress);
+    const balance = await wtest.balanceOf(userAddress);
     console.log("Balance (both ATOM and WATOM):", balance.toString());
   } catch (error) {
     console.error("Error:", error);
@@ -176,17 +176,17 @@ import { ethers } from "ethers";
 
 const provider = new ethers.JsonRpcProvider("<RPC_URL>");
 const signer = new ethers.Wallet("<PRIVATE_KEY>", provider);
-const watomAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const wtestAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const werc20Abi = ["function transfer(address to, uint256 amount) returns (bool)"];
 
-const watom = new ethers.Contract(watomAddress, werc20Abi, signer);
+const wtest = new ethers.Contract(wtestAddress, werc20Abi, signer);
 
 async function transferTokens() {
   try {
     const recipientAddress = "0x742d35Cc6634C0532925a3b844Bc9e7595f5b899";
     const amount = ethers.parseUnits("10.0", 6); // 10 ATOM (6 decimals)
 
-    const tx = await watom.transfer(recipientAddress, amount);
+    const tx = await wtest.transfer(recipientAddress, amount);
     const receipt = await tx.wait();
 
     console.log("Transfer successful:", receipt.hash);
@@ -217,14 +217,14 @@ Returns the total supply from the bank module.
 import { ethers } from "ethers";
 
 const provider = new ethers.JsonRpcProvider("<RPC_URL>");
-const watomAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const wtestAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const werc20Abi = ["function totalSupply() view returns (uint256)"];
 
-const watom = new ethers.Contract(watomAddress, werc20Abi, provider);
+const wtest = new ethers.Contract(wtestAddress, werc20Abi, provider);
 
 async function getTotalSupply() {
   try {
-    const supply = await watom.totalSupply();
+    const supply = await wtest.totalSupply();
     console.log("Total Supply:", supply.toString());
   } catch (error) {
     console.error("Error:", error);
@@ -259,14 +259,14 @@ import { ethers } from "ethers";
 
 const provider = new ethers.JsonRpcProvider("<RPC_URL>");
 const signer = new ethers.Wallet("<PRIVATE_KEY>", provider);
-const watomAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const wtestAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const werc20Abi = [
   "function approve(address spender, uint256 amount) returns (bool)",
   "function allowance(address owner, address spender) view returns (uint256)",
   "function transferFrom(address from, address to, uint256 amount) returns (bool)"
 ];
 
-const watom = new ethers.Contract(watomAddress, werc20Abi, signer);
+const wtest = new ethers.Contract(wtestAddress, werc20Abi, signer);
 
 async function approveAndTransfer() {
   try {
@@ -274,15 +274,15 @@ async function approveAndTransfer() {
     const amount = ethers.parseUnits("50.0", 6); // 50 ATOM
 
     // Approve spending
-    const approveTx = await watom.approve(spenderAddress, amount);
+    const approveTx = await wtest.approve(spenderAddress, amount);
     await approveTx.wait();
 
     // Check allowance
-    const allowance = await watom.allowance(signer.address, spenderAddress);
+    const allowance = await wtest.allowance(signer.address, spenderAddress);
     console.log("Allowance:", allowance.toString());
 
     // Transfer from (would be called by spender)
-    // const transferTx = await watom.transferFrom(ownerAddress, recipientAddress, amount);
+    // const transferTx = await wtest.transferFrom(ownerAddress, recipientAddress, amount);
   } catch (error) {
     console.error("Error:", error);
   }
@@ -298,21 +298,21 @@ Token metadata (e.g., "Wrapped ATOM", "WATOM", 6).
 import { ethers } from "ethers";
 
 const provider = new ethers.JsonRpcProvider("<RPC_URL>");
-const watomAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const wtestAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const werc20Abi = [
   "function name() view returns (string)",
   "function symbol() view returns (string)",
   "function decimals() view returns (uint8)"
 ];
 
-const watom = new ethers.Contract(watomAddress, werc20Abi, provider);
+const wtest = new ethers.Contract(wtestAddress, werc20Abi, provider);
 
 async function getTokenInfo() {
   try {
     const [name, symbol, decimals] = await Promise.all([
-      watom.name(),
-      watom.symbol(),
-      watom.decimals()
+      wtest.name(),
+      wtest.symbol(),
+      wtest.decimals()
     ]);
     console.log(`Token: ${name} (${symbol}) - ${decimals} decimals`);
   } catch (error) {
@@ -388,8 +388,8 @@ This function does nothing because ATOM and WATOM are the same token. Your nativ
 contract LiquidityPool {
     IERC20 public immutable WATOM;
 
-    constructor(address _watom) {
-        WATOM = IERC20(_watom);
+    constructor(address _wtest) {
+        WATOM = IERC20(_wtest);
     }
 
     function addLiquidity(uint256 amount) external {
@@ -416,10 +416,10 @@ contract LiquidityPool {
 async function verifyBalanceConsistency(userAddress) {
     // Query via bank precompile (native interface)
     const bankBalance = await bankContract.balances(userAddress);
-    const atomAmount = bankBalance.find(b => b.denom === "uatom")?.amount || "0";
+    const atomAmount = bankBalance.find(b => b.denom === "test")?.amount || "0";
 
     // Query via WERC20 precompile (ERC20 interface)
-    const watomAmount = await watom.balanceOf(userAddress);
+    const wtestAmount = await wtest.balanceOf(userAddress);
 
     // These will always be equal since the ERC20 balance is just
     // an abstracted bank module balance query

--- a/snippets/rpc-methods-viewer.jsx
+++ b/snippets/rpc-methods-viewer.jsx
@@ -343,48 +343,48 @@ export default function RPCMethodsViewerVersionB() {
       name: "miner",
       color: "gray",
       methods: [
-        { name: "miner_start", status: "N", description: "Starts mining (not applicable - uses Tendermint)" },
-        { name: "miner_stop", status: "N", description: "Stops mining (not applicable - uses Tendermint)" },
-        { name: "miner_setEtherbase", status: "N", description: "Sets etherbase (not applicable - uses Tendermint)" },
-        { name: "miner_setExtra", status: "N", description: "Sets extra data (not applicable - uses Tendermint)" },
-        { name: "miner_setGasPrice", status: "N", description: "Sets gas price (not applicable - uses Tendermint)" },
-        { name: "miner_setGasLimit", status: "N", description: "Sets gas limit (not applicable - uses Tendermint)" },
-        { name: "miner_setRecommitInterval", status: "N", description: "Sets recommit interval (not applicable - uses Tendermint)" },
-        { name: "miner_getHashrate", status: "N", description: "Returns hashrate (not applicable - uses Tendermint)" }
+        { name: "miner_start", status: "N", description: "Starts mining (not applicable - uses 'CometBFT')" },
+        { name: "miner_stop", status: "N", description: "Stops mining (not applicable - uses 'CometBFT')" },
+        { name: "miner_setEtherbase", status: "N", description: "Sets etherbase (not applicable - uses 'CometBFT')" },
+        { name: "miner_setExtra", status: "N", description: "Sets extra data (not applicable - uses 'CometBFT')" },
+        { name: "miner_setGasPrice", status: "N", description: "Sets gas price (not applicable - uses 'CometBFT')" },
+        { name: "miner_setGasLimit", status: "N", description: "Sets gas limit (not applicable - uses 'CometBFT')" },
+        { name: "miner_setRecommitInterval", status: "N", description: "Sets recommit interval (not applicable - uses 'CometBFT')" },
+        { name: "miner_getHashrate", status: "N", description: "Returns hashrate (not applicable - uses 'CometBFT')" }
       ]
     },
     engine: {
       name: "engine",
       color: "pink",
       methods: [
-        { name: "engine_newPayloadV1", status: "N", description: "New payload V1 (not applicable - uses Tendermint)" },
-        { name: "engine_newPayloadV2", status: "N", description: "New payload V2 (not applicable - uses Tendermint)" },
-        { name: "engine_newPayloadV3", status: "N", description: "New payload V3 (not applicable - uses Tendermint)" },
-        { name: "engine_forkchoiceUpdatedV1", status: "N", description: "Fork choice updated V1 (not applicable - uses Tendermint)" },
-        { name: "engine_forkchoiceUpdatedV2", status: "N", description: "Fork choice updated V2 (not applicable - uses Tendermint)" },
-        { name: "engine_forkchoiceUpdatedV3", status: "N", description: "Fork choice updated V3 (not applicable - uses Tendermint)" },
-        { name: "engine_getPayloadV1", status: "N", description: "Get payload V1 (not applicable - uses Tendermint)" },
-        { name: "engine_getPayloadV2", status: "N", description: "Get payload V2 (not applicable - uses Tendermint)" },
-        { name: "engine_getPayloadV3", status: "N", description: "Get payload V3 (not applicable - uses Tendermint)" },
-        { name: "engine_getPayloadBodiesByHashV1", status: "N", description: "Get payload bodies by hash (not applicable - uses Tendermint)" },
-        { name: "engine_getPayloadBodiesByRangeV1", status: "N", description: "Get payload bodies by range (not applicable - uses Tendermint)" },
-        { name: "engine_exchangeTransitionConfigurationV1", status: "N", description: "Exchange transition configuration (not applicable - uses Tendermint)" },
-        { name: "engine_exchangeCapabilities", status: "N", description: "Exchange capabilities (not applicable - uses Tendermint)" },
-        { name: "engine_getBlobsV1", status: "N", description: "Get blobs V1 (not applicable - uses Tendermint)" }
+        { name: "engine_newPayloadV1", status: "N", description: "New payload V1 (not applicable - uses 'CometBFT')" },
+        { name: "engine_newPayloadV2", status: "N", description: "New payload V2 (not applicable - uses 'CometBFT')" },
+        { name: "engine_newPayloadV3", status: "N", description: "New payload V3 (not applicable - uses 'CometBFT')" },
+        { name: "engine_forkchoiceUpdatedV1", status: "N", description: "Fork choice updated V1 (not applicable - uses 'CometBFT')" },
+        { name: "engine_forkchoiceUpdatedV2", status: "N", description: "Fork choice updated V2 (not applicable - uses 'CometBFT')" },
+        { name: "engine_forkchoiceUpdatedV3", status: "N", description: "Fork choice updated V3 (not applicable - uses 'CometBFT')" },
+        { name: "engine_getPayloadV1", status: "N", description: "Get payload V1 (not applicable - uses 'CometBFT')" },
+        { name: "engine_getPayloadV2", status: "N", description: "Get payload V2 (not applicable - uses 'CometBFT')" },
+        { name: "engine_getPayloadV3", status: "N", description: "Get payload V3 (not applicable - uses 'CometBFT')" },
+        { name: "engine_getPayloadBodiesByHashV1", status: "N", description: "Get payload bodies by hash (not applicable - uses 'CometBFT')" },
+        { name: "engine_getPayloadBodiesByRangeV1", status: "N", description: "Get payload bodies by range (not applicable - uses 'CometBFT')" },
+        { name: "engine_exchangeTransitionConfigurationV1", status: "N", description: "Exchange transition configuration (not applicable - uses 'CometBFT')" },
+        { name: "engine_exchangeCapabilities", status: "N", description: "Exchange capabilities (not applicable - uses 'CometBFT')" },
+        { name: "engine_getBlobsV1", status: "N", description: "Get blobs V1 (not applicable - uses 'CometBFT')" }
       ]
     },
     clique: {
       name: "clique",
       color: "teal",
       methods: [
-        { name: "clique_getSnapshot", status: "N", description: "Get snapshot at block (not applicable - uses Tendermint)" },
-        { name: "clique_getSnapshotAtHash", status: "N", description: "Get snapshot at hash (not applicable - uses Tendermint)" },
-        { name: "clique_getSigners", status: "N", description: "Get authorized signers (not applicable - uses Tendermint)" },
-        { name: "clique_getSignersAtHash", status: "N", description: "Get signers at hash (not applicable - uses Tendermint)" },
-        { name: "clique_propose", status: "N", description: "Propose new signer (not applicable - uses Tendermint)" },
-        { name: "clique_discard", status: "N", description: "Discard signer proposal (not applicable - uses Tendermint)" },
-        { name: "clique_status", status: "N", description: "Get clique status (not applicable - uses Tendermint)" },
-        { name: "clique_getSigner", status: "N", description: "Get current signer (not applicable - uses Tendermint)" }
+        { name: "clique_getSnapshot", status: "N", description: "Get snapshot at block (not applicable - uses 'CometBFT')" },
+        { name: "clique_getSnapshotAtHash", status: "N", description: "Get snapshot at hash (not applicable - uses 'CometBFT')" },
+        { name: "clique_getSigners", status: "N", description: "Get authorized signers (not applicable - uses 'CometBFT')" },
+        { name: "clique_getSignersAtHash", status: "N", description: "Get signers at hash (not applicable - uses 'CometBFT')" },
+        { name: "clique_propose", status: "N", description: "Propose new signer (not applicable - uses 'CometBFT')" },
+        { name: "clique_discard", status: "N", description: "Discard signer proposal (not applicable - uses 'CometBFT')" },
+        { name: "clique_status", status: "N", description: "Get clique status (not applicable - uses 'CometBFT')" },
+        { name: "clique_getSigner", status: "N", description: "Get current signer (not applicable - uses 'CometBFT')" }
       ]
     },
     les: {


### PR DESCRIPTION
Replaced all references to 'simapp', 'simd', 'uatom', 'ustake', etc. to 'atest' and 'evmd' to reflect the actual example application in `cosmos/evm`.

Added solidity examples for all relevant methods in each precompile page.