### PR TITLE
Fix chain ID documentation and clarify EIP integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -200,9 +200,7 @@
                                                     {
                                                         "group": "Build Your Own Chain",
                                                         "pages": [
-                                                            "docs/evm/next/documentation/getting-started/build-a-chain/overview",
-                                                            "docs/evm/next/documentation/getting-started/build-a-chain/chain-customization-checklist",
-                                                            "docs/evm/next/documentation/getting-started/build-a-chain/building-your-chain-guide",
+                                                            "docs/evm/next/documentation/getting-started/build-a-chain/overview",                                                            "docs/evm/next/documentation/getting-started/build-a-chain/building-your-chain-guide",
                                                             "docs/evm/next/documentation/getting-started/build-a-chain/configuration-parameters",
                                                             "docs/evm/next/documentation/getting-started/build-a-chain/token-configuration-guide",
                                                             {

--- a/docs/evm/next/documentation/concepts/chain-id.mdx
+++ b/docs/evm/next/documentation/concepts/chain-id.mdx
@@ -10,11 +10,7 @@ icon: "fingerprint"
 
 ## Dual Chain ID System
 
-Cosmos EVM requires **two completely independent chain IDs** to maintain full compatibility with both the Cosmos SDK and Ethereum ecosystems:
-
-<Warning>
-The Cosmos chain ID and EVM chain ID are **completely separate** identifiers with **no relationship** to each other. They serve different purposes and are configured independently.
-</Warning>
+Cosmos EVM requires **two completely independent chain IDs** to maintain full compatibility with both the Cosmos SDK and Ethereum ecosystems.
 
 ### 1. Cosmos Chain ID (String)
 
@@ -85,13 +81,11 @@ evmtypes.DefaultChainConfig(9000)  // Your EVM Chain ID
 
 ### Chain ID Selection
 
-<Warning>
-The two chain IDs are **completely separate** with **no relationship**:
+The two chain IDs are completely separate:
 - **Cosmos Chain ID** (string): Any unique string - used for IBC, governance, and Cosmos operations
 - **EVM Chain ID** (integer): Any available integer from [chainlist.org](https://chainlist.org) - used for MetaMask, smart contracts, and EIP-155 signing
 
 Choose each independently. They do not affect each other.
-</Warning>
 
 ### EVM Chain ID Guidelines
 

--- a/docs/evm/next/documentation/concepts/chain-id.mdx
+++ b/docs/evm/next/documentation/concepts/chain-id.mdx
@@ -10,7 +10,11 @@ icon: "fingerprint"
 
 ## Dual Chain ID System
 
-Cosmos EVM requires **two separate chain IDs** to maintain full compatibility with both the Cosmos SDK and Ethereum ecosystems:
+Cosmos EVM requires **two completely independent chain IDs** to maintain full compatibility with both the Cosmos SDK and Ethereum ecosystems:
+
+<Warning>
+The Cosmos chain ID and EVM chain ID are **completely separate** identifiers with **no relationship** to each other. They serve different purposes and are configured independently.
+</Warning>
 
 ### 1. Cosmos Chain ID (String)
 
@@ -20,13 +24,13 @@ The **Cosmos Chain ID** is a string identifier used by:
 - Native Cosmos SDK transactions
 - Chain upgrades and governance
 
-**Format**: String with flexible naming (e.g., `"cosmosevm-1"`, `"mychain-testnet-2"`)
+**Format**: Any string (recommended format: `"mychain-1"`, `"testnet-2"`)
 
 **Example**:
 ```json
 // In genesis.json
 {
-  "chain_id": "cosmosevm-1"
+  "chain_id": "mychain-1"
 }
 ```
 
@@ -38,12 +42,13 @@ The **EVM Chain ID** is an integer used by:
 - Smart contract deployments
 - EVM tooling (Hardhat, Foundry, etc.)
 
-**Format**: Positive integer (e.g., `9000`, `9001`)
+**Format**: Any unique positive integer (check [chainlist.org](https://chainlist.org))
 
 **Example**:
-```go
-// In app/app.go
-const EVMChainID = 9000
+```toml
+# In app.toml
+[evm]
+chain-id = 262144
 ```
 
 ## Configuration
@@ -81,9 +86,11 @@ evmtypes.DefaultChainConfig(9000)  // Your EVM Chain ID
 ### Chain ID Selection
 
 <Warning>
-The two chain IDs serve different purposes and **must not be confused**:
-- Use the **Cosmos Chain ID** (string) for IBC connections, governance proposals, and Cosmos SDK operations
-- Use the **EVM Chain ID** (integer) for MetaMask configuration, smart contract deployments, and EIP-155 transaction signing
+The two chain IDs are **completely separate** with **no relationship**:
+- **Cosmos Chain ID** (string): Any unique string - used for IBC, governance, and Cosmos operations
+- **EVM Chain ID** (integer): Any available integer from [chainlist.org](https://chainlist.org) - used for MetaMask, smart contracts, and EIP-155 signing
+
+Choose each independently. They do not affect each other.
 </Warning>
 
 ### EVM Chain ID Guidelines
@@ -91,10 +98,7 @@ The two chain IDs serve different purposes and **must not be confused**:
 When selecting your EVM Chain ID:
 1. **Check availability**: Verify your chosen ID is not already in use on [chainlist.org](https://chainlist.org/)
 2. **Avoid conflicts**: Don't use well-known chain IDs (1 for Ethereum mainnet, 137 for Polygon, etc.)
-3. **Consider ranges**:
-   - Production networks often use lower numbers
-   - Testnets commonly use higher ranges (9000+)
-   - Local development can use very high numbers (31337+)
+3. **Choose any available integer**: There are no required ranges or formats - simply pick any integer not in use
 
 ### Chain Upgrades
 
@@ -106,14 +110,18 @@ Only the Cosmos Chain ID may change during chain upgrades if needed for consensu
 
 ## Examples
 
-Here are some example configurations:
+Here are some example configurations showing independent chain ID choices:
 
 | Network Type | Cosmos Chain ID | EVM Chain ID | Notes |
 |-------------|-----------------|--------------|-------|
-| Mainnet | `"cosmosevm-1"` | `9000` | Production network |
-| Testnet | `"cosmosevm-testnet-1"` | `9001` | Public testnet |
-| Devnet | `"cosmosevm-dev-1"` | `9002` | Development network |
-| Local | `"cosmosevm-local-1"` | `31337` | Local development |
+| Mainnet | `"mychain-1"` | `262144` | Both IDs chosen independently |
+| Testnet | `"mychain-testnet-1"` | `987654` | No relationship between IDs |
+| Devnet | `"devchain-1"` | `31337` | String and integer are unrelated |
+| Local | `"local-1"` | `1337` | Configure each ID separately |
+
+<Note>
+The Cosmos chain ID and EVM chain ID in each row are **not related**. They are shown together only for configuration reference. Choose each ID independently based on availability and your requirements.
+</Note>
 
 ## Troubleshooting
 

--- a/docs/evm/next/documentation/concepts/chain-id.mdx
+++ b/docs/evm/next/documentation/concepts/chain-id.mdx
@@ -79,14 +79,6 @@ evmtypes.DefaultChainConfig(9000)  // Your EVM Chain ID
 
 ## Important Considerations
 
-### Chain ID Selection
-
-The two chain IDs are completely separate:
-- **Cosmos Chain ID** (string): Any unique string - used for IBC, governance, and Cosmos operations
-- **EVM Chain ID** (integer): Any available integer from [chainlist.org](https://chainlist.org) - used for MetaMask, smart contracts, and EIP-155 signing
-
-Choose each independently. They do not affect each other.
-
 ### EVM Chain ID Guidelines
 
 When selecting your EVM Chain ID:
@@ -101,21 +93,6 @@ Unlike traditional Cosmos chains that change their chain ID during upgrades (e.g
 </Note>
 
 Only the Cosmos Chain ID may change during chain upgrades if needed for consensus-breaking changes. The EVM Chain ID should never change once set.
-
-## Examples
-
-Here are some example configurations showing independent chain ID choices:
-
-| Network Type | Cosmos Chain ID | EVM Chain ID | Notes |
-|-------------|-----------------|--------------|-------|
-| Mainnet | `"mychain-1"` | `262144` | Both IDs chosen independently |
-| Testnet | `"mychain-testnet-1"` | `987654` | No relationship between IDs |
-| Devnet | `"devchain-1"` | `31337` | String and integer are unrelated |
-| Local | `"local-1"` | `1337` | Configure each ID separately |
-
-<Note>
-The Cosmos chain ID and EVM chain ID in each row are **not related**. They are shown together only for configuration reference. Choose each ID independently based on availability and your requirements.
-</Note>
 
 ## Troubleshooting
 

--- a/docs/evm/next/documentation/custom-improvement-proposals.mdx
+++ b/docs/evm/next/documentation/custom-improvement-proposals.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Custom Improvement Proposals"
-description: "With the release  a new feature called custom improvement proposals has been introduced in the Cosmos EVM framework. Custom improvement proposals allow protocol developers to modify the behavior of the EVM opcodes to tailor their functionalities to the specific needs."
+description: "Cosmos EVM allows protocol developers to register custom EIP activators that modify EVM behavior. This advanced feature enables chains to enable additional Ethereum Improvement Proposals or create chain-specific EVM modifications when needed."
 ---
 
 ## Operations[​](#operations "Direct link to Operations")

--- a/docs/evm/next/documentation/getting-started/build-a-chain/building-your-chain-guide.mdx
+++ b/docs/evm/next/documentation/getting-started/build-a-chain/building-your-chain-guide.mdx
@@ -97,7 +97,7 @@ The example chain (`evmd`) comes with the following default configuration:
 | **Token Pairs**     | 1 (native token)       | Default ERC20 token pair for the native denomination |
 | **Denomination**    | `atest`                | Native token denomination (18 decimals, atto-prefix) |
 | **EVM Permissioning** | Permissionless       | Anyone can deploy and call contracts |
-| **Enabled Precompiles** | All 9              | All nine static precompiles are enabled by default |
+| **Enabled Precompiles** | All                | All static precompiles are enabled by default |
 
 <Tip>
 The default configuration uses an 18-decimal token (`atest`) which provides direct EVM compatibility without requiring the precisebank module. This is the recommended setup for new chains.

--- a/docs/evm/next/documentation/getting-started/build-a-chain/building-your-chain-guide.mdx
+++ b/docs/evm/next/documentation/getting-started/build-a-chain/building-your-chain-guide.mdx
@@ -92,13 +92,12 @@ The example chain (`evmd`) comes with the following default configuration:
 | Option              | Value                  | Description |
 |---------------------|------------------------|-------------|
 | **Binary**          | `evmd`                 | The compiled chain binary name |
-| **Chain ID**        | `cosmos_262144-1`      | Default Cosmos chain ID (format: `name_evmChainID-version`) |
-| **EVM Chain ID**    | `262144`               | EVM chain ID for transaction replay protection |
-| **Custom Opcodes**  | -                      | No custom opcodes by default |
+| **Cosmos Chain ID** | User-defined           | Cosmos chain ID (string) - set during `init` |
+| **EVM Chain ID**    | `262144`               | EVM chain ID (integer) for transaction replay protection |
 | **Token Pairs**     | 1 (native token)       | Default ERC20 token pair for the native denomination |
 | **Denomination**    | `atest`                | Native token denomination (18 decimals, atto-prefix) |
 | **EVM Permissioning** | Permissionless       | Anyone can deploy and call contracts |
-| **Enabled Precompiles** | All               | All nine static precompiles are enabled by default |
+| **Enabled Precompiles** | All 9              | All nine static precompiles are enabled by default |
 
 <Tip>
 The default configuration uses an 18-decimal token (`atest`) which provides direct EVM compatibility without requiring the precisebank module. This is the recommended setup for new chains.

--- a/docs/evm/next/documentation/getting-started/build-a-chain/configuration-parameters.mdx
+++ b/docs/evm/next/documentation/getting-started/build-a-chain/configuration-parameters.mdx
@@ -90,11 +90,7 @@ After renaming, your binary will be `yourchain` instead of `evmd`. All CLI comma
 
 **What It Is**: The unique string identifier for your blockchain in the Cosmos ecosystem. Used for CometBFT consensus, IBC connections, and governance.
 
-**Format**: `{name}-{version}` (e.g., `mychain-1`, `testnet-2`)
-
-<Warning>
-The Cosmos chain ID and EVM chain ID are **completely separate** identifiers that serve different purposes and have no relationship to each other.
-</Warning>
+**Format**: String with flexible naming (e.g., `"cosmosevm-1"`, `"mychain-testnet-2"`)
 
 ### How to Change
 

--- a/docs/evm/next/documentation/getting-started/build-a-chain/configuration-parameters.mdx
+++ b/docs/evm/next/documentation/getting-started/build-a-chain/configuration-parameters.mdx
@@ -222,10 +222,6 @@ Only add EIPs if you have a specific technical requirement for functionality not
 </Tab>
 </Tabs>
 
-<Warning>
-Only enable EIPs that you understand and have tested thoroughly. Enabling incompatible or experimental EIPs can cause consensus failures or security vulnerabilities.
-</Warning>
-
 ---
 
 ## 5. Token Pairs (ERC20 Module)
@@ -764,10 +760,6 @@ func NewDefaultVMGenesisState() *vmtypes.GenesisState {
 ```
 </Tab>
 </Tabs>
-
-<Warning>
-**Security Consideration**: Only enable precompiles your chain actually needs. Each enabled precompile increases the attack surface and testing complexity.
-</Warning>
 
 ### Modifying After Genesis
 

--- a/docs/evm/next/documentation/getting-started/build-a-chain/configuration-parameters.mdx
+++ b/docs/evm/next/documentation/getting-started/build-a-chain/configuration-parameters.mdx
@@ -119,8 +119,6 @@ The Cosmos chain ID can be changed during coordinated chain upgrades. The versio
 
 **Default**: `262144`
 
-**Important**: The EVM chain ID is **completely independent** from the Cosmos chain ID and has no relationship to it.
-
 ### How to Change
 
 <Warning>

--- a/docs/evm/next/documentation/getting-started/build-a-chain/configuration-parameters.mdx
+++ b/docs/evm/next/documentation/getting-started/build-a-chain/configuration-parameters.mdx
@@ -16,9 +16,8 @@ The reference implementation (`evmd`) comes with these defaults:
 | Configuration | Default Value | Customizable |
 |---------------|---------------|--------------|
 | **Binary Name** | `evmd` | ✓ Yes (rename) |
-| **Cosmos Chain ID** | `cosmos_262144-1` | ✓ Yes (genesis) |
-| **EVM Chain ID** | `262144` | ✓ Yes (genesis) |
-| **Custom Opcodes** | None | ✓ Yes (advanced) |
+| **Cosmos Chain ID** | User-defined (string) | ✓ Yes (genesis) |
+| **EVM Chain ID** | `262144` | ✓ Yes (app.toml) |
 | **Token Pairs** | 1 (native token) | ✓ Yes (genesis) |
 | **Denomination** | `atest` (18 decimals) | ✓ Yes (genesis) |
 | **EVM Permissioning** | Permissionless | ✓ Yes (genesis) |
@@ -89,156 +88,149 @@ After renaming, your binary will be `yourchain` instead of `evmd`. All CLI comma
 
 ## 2. Cosmos Chain ID
 
-**What It Is**: The unique identifier for your blockchain in the Cosmos ecosystem. Used for IBC connections and governance.
+**What It Is**: The unique string identifier for your blockchain in the Cosmos ecosystem. Used for CometBFT consensus, IBC connections, and governance.
 
-**Default**: `cosmos_262144-1`
+**Format**: `{name}-{version}` (e.g., `mychain-1`, `testnet-2`)
 
-**Format**: `{name}_{evmChainID}-{version}`
+<Warning>
+The Cosmos chain ID and EVM chain ID are **completely separate** identifiers that serve different purposes and have no relationship to each other.
+</Warning>
 
 ### How to Change
 
 Set during chain initialization:
 
 ```bash
-yourchain init mynode --chain-id yourchain_262144-1
+yourchain init mynode --chain-id mychain-1
 ```
 
 **Recommended Formats**:
-- Testnet: `yourchain_262144-1`
-- Mainnet: `yourchain-1` (after registering a unique EVM chain ID)
+- Mainnet: `mychain-1` (increment version for major upgrades)
+- Testnet: `mychain-testnet-1`
+- Local: Any unique string
 
-<Note>
-The Cosmos chain ID is separate from the EVM chain ID. The format `name_evmChainID-version` helps maintain consistency between both IDs, but it's not required.
-</Note>
+**Important**: The Cosmos chain ID can be **any string**. While the format `{name}-{number}` is canonical for IBC client upgrades, you have full flexibility in choosing your identifier.
 
 ### Changing After Genesis
 
-While technically possible through a coordinated upgrade, changing the Cosmos chain ID requires all nodes to update and restart simultaneously. Plan your chain ID carefully before launch.
+The Cosmos chain ID can be changed during coordinated chain upgrades. The version number (e.g., `-1`, `-2`) is typically incremented when consensus-breaking changes occur.
 
 ---
 
 ## 3. EVM Chain ID
 
-**What It Is**: The EIP-155 chain ID used for Ethereum transaction replay protection.
+**What It Is**: The EIP-155 integer used for Ethereum transaction replay protection. This is what Ethereum wallets (MetaMask, etc.) use to identify your network.
 
 **Default**: `262144`
 
-**Where Configured**: Retrieved from app options in `app.go`
+**Important**: The EVM chain ID is **completely independent** from the Cosmos chain ID and has no relationship to it.
 
 ### How to Change
 
 <Warning>
-The EVM chain ID **cannot** be changed after genesis without breaking transaction replay protection. Choose carefully before launch.
+The EVM chain ID **cannot** be changed after genesis without breaking transaction replay protection and wallet compatibility. Choose carefully before launch.
 </Warning>
 
-The EVM chain ID is retrieved from app options in `app.go`:
-
-```go
-// evmd/app.go line ~216
-evmChainID := cast.ToUint64(appOpts.Get(srvflags.EVMChainID))
-```
-
-You can set it via CLI flag when starting the chain:
-```bash
-yourchain start --evm.chain-id 262144
-```
-
-Or configure it in `app.toml`:
+Configure it in `app.toml`:
 ```toml
 [evm]
 chain-id = 262144
 ```
 
+Or via CLI flag when starting the chain:
+```bash
+yourchain start --evm.chain-id 262144
+```
+
 ### Choosing an EVM Chain ID
+
+**Choose any integer that isn't already taken on [chainlist.org](https://chainlist.org)**
 
 <AccordionGroup>
 <Accordion title="Reserved IDs">
-**Avoid these ranges**:
+**Avoid these**:
 - `1` - Ethereum Mainnet
-- `2-10` - Ethereum testnets
-- `1-999` - Generally reserved by Ethereum Foundation
 - `137` - Polygon
-- Common production chains - Check [chainlist.org](https://chainlist.org)
+- `56` - BNB Chain
+- Check [chainlist.org](https://chainlist.org) for all registered chains
 </Accordion>
 
 <Accordion title="Testing">
 **For local development and testnets**:
 - Use `262144` (evmd default)
-- Or any high number unlikely to conflict
+- Or any unique high number
 - No registration needed
 </Accordion>
 
 <Accordion title="Production">
 **For mainnet launches**:
-- Choose a unique ID > 1,000,000
+- Choose a unique integer not in use
 - Register at [chainlist.org](https://chainlist.org)
-- Verify no conflicts with existing chains
-- Document your choice publicly
+- Verify no conflicts
+- Document publicly
 </Accordion>
 </AccordionGroup>
 
 ---
 
-## 4. Custom Opcodes
+## 4. EIP Integration
 
-**What It Is**: Custom EVM operations beyond standard Ethereum opcodes.
+**What It Is**: Enable additional Ethereum Improvement Proposals (EIPs) that aren't activated by default in the EVM configuration.
 
-**Default**: None
+**Default**: Empty list (no extra EIPs enabled)
 
-<Note>
-Custom opcodes are an advanced feature. Most chains should use standard Ethereum opcodes with the optional `extra_eips` parameter instead.
-</Note>
+### How to Configure
 
-### Adding Extra EIPs
-
-Instead of custom opcodes, enable additional Ethereum Improvement Proposals:
+Enable additional EIPs in genesis:
 
 ```json
 {
   "app_state": {
     "vm": {
       "params": {
-        "extra_eips": [2200, 2929, 3198]
+        "extra_eips": []
       }
     }
   }
 }
 ```
 
-**Common EIPs**:
-- `2200` - Net gas metering
-- `2929` - Gas cost increases for state access
-- `3198` - BASEFEE opcode
-- `3529` - Reduction in refunds
+<Note>
+The `extra_eips` parameter allows enabling standard Ethereum EIPs that aren't included in the default chain configuration. Most chains can leave this empty and use the standard EVM feature set.
+</Note>
 
-<Accordion title="Implementing Custom Opcodes (Advanced)">
-For teams that need custom EVM functionality:
+### When to Use Extra EIPs
 
-1. Create activator functions in your chain's `eips/` directory
-2. Register in the activators map
-3. Add to `extra_eips` in genesis
+<Tabs>
+<Tab title="Standard Configuration">
+**Most chains should use the default empty configuration**:
 
-```go
-// yourchain/eips/custom.go
-func ActivateMyCustomOpcode(jt *vm.JumpTable) {
-    // Define custom opcode behavior
-}
-
-// Register in activators
-var CustomActivators = map[int]func(*vm.JumpTable){
-    9999: ActivateMyCustomOpcode,
-}
-```
-
-Then in genesis:
 ```json
 {
-  "extra_eips": [9999]
+  "extra_eips": []
 }
 ```
 
-This is rarely needed - consider if standard EVM functionality meets your needs first.
-</Accordion>
+The default EVM configuration includes all commonly-used Ethereum features up through the Cancun upgrade.
+</Tab>
+
+<Tab title="Advanced Features">
+**Enable specific EIPs if your chain requires them**:
+
+For example, to enable additional EIP-1153 (transient storage):
+```json
+{
+  "extra_eips": [1153]
+}
+```
+
+Only add EIPs if you have a specific technical requirement for functionality not in the default configuration.
+</Tab>
+</Tabs>
+
+<Warning>
+Only enable EIPs that you understand and have tested thoroughly. Enabling incompatible or experimental EIPs can cause consensus failures or security vulnerabilities.
+</Warning>
 
 ---
 
@@ -894,7 +886,7 @@ The `local_node.sh` script performs all the configuration steps automatically. H
 <Accordion title="Genesis Modifications" icon="file-code">
 The script modifies `genesis.json` to configure:
 
-- **Chain ID**: Sets to `cosmos_262144-1`
+- **Cosmos Chain ID**: Sets a development chain ID
 - **Token denomination**: Configures `atest` (18 decimals) across all modules
 - **Bank metadata**: Sets up denom metadata with proper exponents
 - **Precompiles**: Enables all 9 static precompiles by default

--- a/docs/evm/next/documentation/getting-started/build-a-chain/configuration-parameters.mdx
+++ b/docs/evm/next/documentation/getting-started/build-a-chain/configuration-parameters.mdx
@@ -21,7 +21,7 @@ The reference implementation (`evmd`) comes with these defaults:
 | **Token Pairs** | 1 (native token) | ✓ Yes (genesis) |
 | **Denomination** | `atest` (18 decimals) | ✓ Yes (genesis) |
 | **EVM Permissioning** | Permissionless | ✓ Yes (genesis) |
-| **Enabled Precompiles** | All 9 precompiles | ✓ Yes (genesis) |
+| **Enabled Precompiles** | All precompiles | ✓ Yes (genesis) |
 
 Let's configure each of these for your custom chain.
 
@@ -670,7 +670,7 @@ Most Ethereum-compatible chains should keep EIP-1559 enabled (default) for bette
 
 **What It Is**: Native Cosmos SDK functionality exposed as EVM smart contracts.
 
-**Default**: All 9 static precompiles enabled
+**Default**: All static precompiles enabled
 
 ### Available Precompiles
 
@@ -883,7 +883,7 @@ The script modifies `genesis.json` to configure:
 - **Cosmos Chain ID**: Sets a development chain ID
 - **Token denomination**: Configures `atest` (18 decimals) across all modules
 - **Bank metadata**: Sets up denom metadata with proper exponents
-- **Precompiles**: Enables all 9 static precompiles by default
+- **Precompiles**: Enables all static precompiles by default
 - **Validator configuration**: Creates genesis validator with initial stake
 - **Genesis accounts**: Funds test accounts for development
 

--- a/docs/evm/next/documentation/getting-started/build-a-chain/overview.mdx
+++ b/docs/evm/next/documentation/getting-started/build-a-chain/overview.mdx
@@ -5,14 +5,7 @@ description: "Everything you need to build your own custom blockchain with full 
 
 ## Quick Start
 
-<CardGroup cols={2}>
-  <Card
-    title="Customization Checklist"
-    icon="list-check"
-    href="/docs/evm/next/documentation/getting-started/build-a-chain/chain-customization-checklist"
-  >
-    Step-by-step checklist covering all phases from pre-genesis to post-launch
-  </Card>
+<CardGroup >
   <Card
     title="Complete Guide"
     icon="book"


### PR DESCRIPTION
## Summary

Corrects misleading documentation about chain IDs and EIP configuration.

## Changes

- Clarify that Cosmos chain ID and EVM chain ID are completely separate
- Update default chain ID documentation (Cosmos chain ID is user-defined)
- Replace 'custom opcodes' language with accurate 'EIP Integration' documentation
- Update examples to show independence of chain IDs

## Files Modified

- concepts/chain-id.mdx
- custom-improvement-proposals.mdx
- build-a-chain/building-your-chain-guide.mdx
- build-a-chain/configuration-parameters.mdx