### PR TITLE
Add navigation links to index page

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -12,6 +12,7 @@ import { TopicCard, TopicCardGrid } from '/snippets/topic-card-component.jsx';
         // Navigation management for index page
         const indexNavManager = {
           styleId: 'hide-nav-styles-index',
+          customNavId: 'custom-nav-links',
           intervalId: null,
 
           css: \`
@@ -29,6 +30,42 @@ import { TopicCard, TopicCardGrid } from '/snippets/topic-card-component.jsx';
               overflow: hidden !important;
               position: absolute !important;
               left: -9999px !important;
+            }
+
+            #custom-nav-links {
+              position: fixed !important;
+              top: 20px !important;
+              right: 100px !important;
+              display: flex !important;
+              gap: 24px !important;
+              align-items: center !important;
+              z-index: 1000 !important;
+            }
+
+            #custom-nav-links a {
+              font-size: 14px !important;
+              font-weight: 500 !important;
+              text-decoration: none !important;
+              transition: opacity 0.2s !important;
+            }
+
+            #custom-nav-links a:hover {
+              opacity: 0.7 !important;
+            }
+
+            [data-theme="dark"] #custom-nav-links a,
+            html:not([data-theme]) #custom-nav-links a {
+              color: #F1F1F1 !important;
+            }
+
+            [data-theme="light"] #custom-nav-links a {
+              color: #1A1A1A !important;
+            }
+
+            @media (max-width: 768px) {
+              #custom-nav-links {
+                display: none !important;
+              }
             }
           \`,
 
@@ -56,6 +93,46 @@ import { TopicCard, TopicCardGrid } from '/snippets/topic-card-component.jsx';
             }
           },
 
+          injectCustomNav() {
+            // Check if already injected
+            if (document.getElementById(this.customNavId)) return;
+
+            // Create custom navigation container
+            const navContainer = document.createElement('div');
+            navContainer.id = this.customNavId;
+
+            // Define navigation links
+            const links = [
+              { label: 'Cosmos SDK', href: '/sdk/' },
+              { label: 'Cosmos EVM', href: '/evm/' },
+              { label: 'IBC', href: '/ibc/' },
+              { label: 'CometBFT', href: 'https://docs.cometbft.com/v0.38/' },
+              { label: 'Hub', href: '/hub/' }
+            ];
+
+            // Create and append links
+            links.forEach(link => {
+              const anchor = document.createElement('a');
+              anchor.href = link.href;
+              anchor.textContent = link.label;
+              if (link.href.startsWith('http')) {
+                anchor.target = '_blank';
+                anchor.rel = 'noopener noreferrer';
+              }
+              navContainer.appendChild(anchor);
+            });
+
+            // Append directly to body (using fixed positioning)
+            document.body.appendChild(navContainer);
+          },
+
+          removeCustomNav() {
+            const existingNav = document.getElementById(this.customNavId);
+            if (existingNav) {
+              existingNav.remove();
+            }
+          },
+
           removeStyles() {
             const existingStyle = document.getElementById(this.styleId);
             if (existingStyle) {
@@ -66,6 +143,7 @@ import { TopicCard, TopicCardGrid } from '/snippets/topic-card-component.jsx';
           manageNavigation() {
             if (this.isIndexPage()) {
               this.injectStyles();
+              this.injectCustomNav();
               this.scrollToTop();
 
               // Start monitoring if not already
@@ -73,6 +151,7 @@ import { TopicCard, TopicCardGrid } from '/snippets/topic-card-component.jsx';
                 this.intervalId = setInterval(() => {
                   if (this.isIndexPage()) {
                     this.injectStyles();
+                    this.injectCustomNav();
                   } else {
                     this.cleanup();
                   }
@@ -85,6 +164,7 @@ import { TopicCard, TopicCardGrid } from '/snippets/topic-card-component.jsx';
 
           cleanup() {
             this.removeStyles();
+            this.removeCustomNav();
             if (this.intervalId) {
               clearInterval(this.intervalId);
               this.intervalId = null;


### PR DESCRIPTION
## Summary
- Added custom navigation links to the top navigation bar on the index page
- Links include: Cosmos SDK, Cosmos EVM, IBC, CometBFT, and Hub
- Navigation uses fixed positioning and is theme-aware
- Hidden on mobile devices

## Changes
- Modified index.mdx to inject navigation links dynamically
- Links match the main documentation sections from the card headings