### PR TITLE
Parse error fixes

### DIFF
--- a/cometbft/v0.38/spec/p2p/implementation/peer_manager.md
+++ b/cometbft/v0.38/spec/p2p/implementation/peer_manager.md
@@ -117,7 +117,7 @@ This is not done in the p2p package, but it is part of the procedure to set up a
 
 The picture below is a first attempt of illustrating the life cycle of an outbound peer:
 
-<img src="../images/p2p_state.png" width="50%" title="Outgoing peers lifecycle">
+<img src="../images/p2p_state.png" width="50%" title="Outgoing peers lifecycle"/>
 
 A peer can be in the following states:
 

--- a/cometbft/v0.38/spec/p2p/implementation/switch.md
+++ b/cometbft/v0.38/spec/p2p/implementation/switch.md
@@ -173,7 +173,7 @@ precisely, not providing to the switch any "reason" for that.
 In both cases the `Peer` instance is stopped, the peer is removed from all
 registered reactors, and finally from the list of connected peers.
 
-> Issue <https://github.com/tendermint/tendermint/issues/3338> is mentioned in
+> Issue [https://github.com/tendermint/tendermint/issues/3338](https://github.com/tendermint/tendermint/issues/3338]) is mentioned in
 > the internal `stopAndRemovePeer` method explaining why removing the peer from
 > the list of connected peers is the last action taken.
 

--- a/cometbft/v0.38/spec/p2p/implementation/transport.md
+++ b/cometbft/v0.38/spec/p2p/implementation/transport.md
@@ -70,8 +70,8 @@ during the version handshake,
 as well any error returned in this process are added to a queue of accepted connections.
 This queue is consumed by the `Accept` method.
 
-> Handling accepted connection asynchronously was introduced due to this issue:
-> <https://github.com/tendermint/tendermint/issues/2047>
+Handling accepted connection asynchronously was introduced due to this issue:
+[https://github.com/tendermint/tendermint/issues/2047](https://github.com/tendermint/tendermint/issues/2047)
 
 ## Connection Filtering
 


### PR DESCRIPTION
Fix parse errors on the docs build. Closed an image tag and removed angle brackets that were causing errors. 

I'm not sure why this is causing a link rot error and the older builds aren't. 