### PR TITLE
`/beginner` copy updates

### DIFF
--- a/sdk/v0.53/learn/beginner/accounts.mdx
+++ b/sdk/v0.53/learn/beginner/accounts.mdx
@@ -16,9 +16,9 @@ This document describes the in-built account and public key system of the Cosmos
 
 ## Account Definition
 
-In the Cosmos SDK, an *account* designates a pair of *public key* `PubKey` and *private key* `PrivKey`. The `PubKey` can be derived to generate various `Addresses`, which are used to identify users (among other parties) in the application. `Addresses` are also associated with [`message`s](/sdk/v0.53/build/building-modules/messages-and-queries#messages) to identify the sender of the `message`. The `PrivKey` is used to generate [digital signatures](#signatures) to prove that an `Address` associated with the `PrivKey` approved of a given `message`.
+In the Cosmos SDK, an *account* designates a pair of *public key* `PubKey` and *private key* `PrivKey`. The `PubKey` can be derived to generate various `Addresses`, which are used to identify users (among other parties) in the application. `Addresses` are also associated with [`messages`](/sdk/v0.53/build/building-modules/messages-and-queries#messages) to identify the sender of the `message`. The `PrivKey` is used to generate [digital signatures](#signatures) to prove that an `Address` associated with the `PrivKey` approved of a given `message`.
 
-For HD key derivation the Cosmos SDK uses a standard called [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki). The BIP32 allows users to create an HD wallet (as specified in [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)) - a set of accounts derived from an initial secret seed. A seed is usually created from a 12- or 24-word mnemonic. A single seed can derive any number of `PrivKey`s using a one-way cryptographic function. Then, a `PubKey` can be derived from the `PrivKey`. Naturally, the mnemonic is the most sensitive information, as private keys can always be re-generated if the mnemonic is preserved.
+For HD key derivation, the Cosmos SDK uses a standard called [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki). The BIP32 allows users to create an HD wallet (as specified in [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)) - a set of accounts derived from an initial secret seed. A seed is usually created from a 12- or 24-word mnemonic. A single seed can derive any number of `PrivKey`s using a one-way cryptographic function. Then, a `PubKey` can be derived from the `PrivKey`. Naturally, the mnemonic is the most sensitive information, as private keys can always be re-generated if the mnemonic is preserved.
 
 ```text expandable
      Account 0                         Account 1                         Account 2
@@ -71,7 +71,7 @@ In the node, all data is stored using Protocol Buffers serialization.
 The Cosmos SDK supports the following digital key schemes for creating digital signatures:
 
 * `secp256k1`, as implemented in the [Cosmos SDK's `crypto/keys/secp256k1` package](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0/crypto/keys/secp256k1/secp256k1.go).
-* `secp256r1`, as implemented in the [Cosmos SDK's `crypto/keys/secp256r1` package](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0/crypto/keys/secp256r1/pubkey.go),
+* `secp256r1`, as implemented in the [Cosmos SDK's `crypto/keys/secp256r1` package](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0/crypto/keys/secp256r1/pubkey.go).
 * `tm-ed25519`, as implemented in the [Cosmos SDK `crypto/keys/ed25519` package](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0/crypto/keys/ed25519/ed25519.go). This scheme is supported only for the consensus validation.
 
 |              | Address length in bytes | Public key length in bytes | Used for transaction authentication | Used for consensus (cometbft) |
@@ -82,9 +82,9 @@ The Cosmos SDK supports the following digital key schemes for creating digital s
 
 ## Addresses
 
-`Addresses` and `PubKey`s are both public information that identifies actors in the application. `Account` is used to store authentication information. The basic account implementation is provided by a `BaseAccount` object.
+`Addresses` and `PubKey`s are both public information that identify actors in the application. `Account` is used to store authentication information. The basic account implementation is provided by a `BaseAccount` object.
 
-Each account is identified using `Address` which is a sequence of bytes derived from a public key. In the Cosmos SDK, we define 3 types of addresses that specify a context where an account is used:
+Each account is identified using an `Address`, which is a sequence of bytes derived from a public key. In the Cosmos SDK, there are three defined types of addresses that specify a context where an account is used:
 
 * `AccAddress` identifies users (the sender of a `message`).
 * `ValAddress` identifies validator operators.
@@ -118,9 +118,9 @@ import (
 )
 
 const (
-	// Constants defined here are the defaults value for address.
+	// Constants defined here are the default values for address.
 	// You can use the specific values for your project.
-	// Add the follow lines to the `main()` of your server.
+	// Add the following lines to the `main()` of your server.
 	//
 	//	config := sdk.GetConfig()
 	//	config.SetBech32PrefixForAccount(yourBech32PrefixAccAddr, yourBech32PrefixAccPub)
@@ -879,7 +879,7 @@ return cacheBech32Addr(GetConfig().GetBech32ConsensusAddrPrefix(), ca, consAddrC
 }
 
 // Bech32ifyAddressBytes returns a bech32 representation of address bytes.
-// Returns an empty sting if the byte slice is 0-length. Returns an error if the bech32 conversion
+// Returns an empty string if the byte slice is 0-length. Returns an error if the bech32 conversion
 // fails or the prefix is empty.
 func Bech32ifyAddressBytes(prefix string, bs []byte) (string, error) {
     if len(bs) == 0 {
@@ -976,7 +976,7 @@ Here is the standard way to obtain an account address from a `pub` public key:
 sdk.AccAddress(pub.Address().Bytes())
 ```
 
-Of note, the `Marshal()` and `Bytes()` method both return the same raw `[]byte` form of the address. `Marshal()` is required for Protobuf compatibility.
+Of note, the `Marshal()` and `Bytes()` methods both return the same raw `[]byte` form of the address. `Marshal()` is required for Protobuf compatibility.
 
 For user interaction, addresses are formatted using [Bech32](https://en.bitcoin.it/wiki/Bech32) and implemented by the `String` method. The Bech32 method is the only supported format to use when interacting with a blockchain. The Bech32 human-readable part (Bech32 prefix) is used to denote an address type. Example:
 
@@ -1006,9 +1006,9 @@ import (
 )
 
 const (
-	// Constants defined here are the defaults value for address.
+	// Constants defined here are the default values for address.
 	// You can use the specific values for your project.
-	// Add the follow lines to the `main()` of your server.
+	// Add the following lines to the `main()` of your server.
 	//
 	//	config := sdk.GetConfig()
 	//	config.SetBech32PrefixForAccount(yourBech32PrefixAccAddr, yourBech32PrefixAccPub)
@@ -1767,7 +1767,7 @@ return cacheBech32Addr(GetConfig().GetBech32ConsensusAddrPrefix(), ca, consAddrC
 }
 
 // Bech32ifyAddressBytes returns a bech32 representation of address bytes.
-// Returns an empty sting if the byte slice is 0-length. Returns an error if the bech32 conversion
+// Returns an empty string if the byte slice is 0-length. Returns an error if the bech32 conversion
 // fails or the prefix is empty.
 func Bech32ifyAddressBytes(prefix string, bs []byte) (string, error) {
     if len(bs) == 0 {
@@ -1865,7 +1865,7 @@ return bech32Addr
 
 ### Public Keys
 
-Public keys in Cosmos SDK are defined by `cryptotypes.PubKey` interface. Since public keys are saved in a store, `cryptotypes.PubKey` extends the `proto.Message` interface:
+Public keys in Cosmos SDK are defined by the `cryptotypes.PubKey` interface. Since public keys are saved in a store, `cryptotypes.PubKey` extends the `proto.Message` interface:
 
 ```go expandable
 package types
@@ -1921,7 +1921,7 @@ string
 // and will be deprecated/removed once LEGACY_AMINO_JSON is removed.
 type LedgerPrivKeyAminoJSON interface {
     LedgerPrivKey
-	// SignLedgerAminoJSON signs a messages on the Ledger device using
+	// SignLedgerAminoJSON signs a message on the Ledger device using
 	// SIGN_MODE_LEGACY_AMINO_JSON.
 	SignLedgerAminoJSON(msg []byte) ([]byte, error)
 }
@@ -1962,7 +1962,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// Use protobuf interface marshaler rather then generic JSON
+// Use protobuf interface marshaler rather than generic JSON
 
 // KeyOutput defines a structure wrapping around an Info object used for output
 // functionality.
@@ -1996,7 +1996,7 @@ return KeyOutput{
 }, nil
 }
 
-// MkConsKeyOutput create a KeyOutput in with "cons" Bech32 prefixes.
+// MkConsKeyOutput creates a KeyOutput with "cons" Bech32 prefixes.
 func MkConsKeyOutput(k *keyring.Record) (KeyOutput, error) {
     pk, err := k.GetPubKey()
     if err != nil {
@@ -2008,7 +2008,7 @@ func MkConsKeyOutput(k *keyring.Record) (KeyOutput, error) {
 return NewKeyOutput(k.Name, k.GetType(), addr, pk)
 }
 
-// MkValKeyOutput create a KeyOutput in with "val" Bech32 prefixes.
+// MkValKeyOutput creates a KeyOutput with "val" Bech32 prefixes.
 func MkValKeyOutput(k *keyring.Record) (KeyOutput, error) {
     pk, err := k.GetPubKey()
     if err != nil {
@@ -2020,7 +2020,7 @@ func MkValKeyOutput(k *keyring.Record) (KeyOutput, error) {
 return NewKeyOutput(k.Name, k.GetType(), addr, pk)
 }
 
-// MkAccKeyOutput create a KeyOutput in with "acc" Bech32 prefixes. If the
+// MkAccKeyOutput creates a KeyOutput with "acc" Bech32 prefixes. If the
 // public key is a multisig public key, then the threshold and constituent
 // public keys will be added.
 func MkAccKeyOutput(k *keyring.Record) (KeyOutput, error) {
@@ -2036,7 +2036,7 @@ return NewKeyOutput(k.Name, k.GetType(), addr, pk)
 
 // MkAccKeysOutput returns a slice of KeyOutput objects, each with the "acc"
 // Bech32 prefixes, given a slice of Record objects. It returns an error if any
-// call to MkKeyOutput fails.
+// call to MkAccKeyOutput fails.
 func MkAccKeysOutput(records []*keyring.Record) ([]KeyOutput, error) {
     kos := make([]KeyOutput, len(records))
 
@@ -2165,9 +2165,7 @@ error
 	// SaveOfflineKey stores a public key and returns the persisted Info structure.
 	SaveOfflineKey(uid string, pubkey types.PubKey) (*Record, error)
 
-	// SaveMultisig stores and returns a new multsig (offline)
-
-key reference.
+	// SaveMultisig stores and returns a new multisig (offline) key reference.
 	SaveMultisig(uid string, pubkey types.PubKey) (*Record, error)
 
 Signer
@@ -2189,10 +2187,10 @@ keyring.Keyring
 
 // Signer is implemented by key stores that want to provide signing capabilities.
 type Signer interface {
-	// Sign sign byte messages with a user key.
+	// Sign signs byte messages with a user key.
 	Sign(uid string, msg []byte, signMode signing.SignMode) ([]byte, types.PubKey, error)
 
-	// SignByAddress sign byte messages with a user key providing the address.
+	// SignByAddress signs byte messages with a user key providing the address.
 	SignByAddress(address sdk.Address, msg []byte, signMode signing.SignMode) ([]byte, types.PubKey, error)
 }
 
@@ -2219,7 +2217,7 @@ type Migrator interface {
 
 // Exporter is implemented by key stores that support export of public and private keys.
 type Exporter interface {
-	// Export public key
+	// ExportPubKeyArmor exports a public key.
 	ExportPubKeyArmor(uid string) (string, error)
 
 ExportPubKeyArmorByAddress(address sdk.Address) (string, error)
@@ -2236,7 +2234,7 @@ type Option func(options *Options)
 
 // NewInMemory creates a transient keyring useful for testing
 // purposes and on-the-fly key generation.
-// Keybase options can be applied when generating this new Keybase.
+// Keyring options can be applied when generating this new keyring.
 func NewInMemory(cdc codec.Codec, opts ...Option)
 
 Keyring {
@@ -2763,7 +2761,7 @@ Key(uid string) (*Record, error) {
 return k, nil
 }
 
-// SupportedAlgorithms returns the keystore Options' supported signing algorithm.
+// SupportedAlgorithms returns the keystore Options' supported signing algorithms
 // for the keyring and Ledger.
 func (ks keystore)
 
@@ -3027,9 +3025,9 @@ return nil
 }
 
 // existsInDb returns (true, nil)
-    if either addr or name exist is in keystore DB.
+// if either addr or name exists in the keystore DB.
 // On the other hand, it returns (false, error)
-    if Get method returns error different from keyring.ErrKeyNotFound
+// if the Get method returns an error different from keyring.ErrKeyNotFound
 // In case of inconsistent keyring, it recovers it automatically.
 func (ks keystore)
 
@@ -3048,9 +3046,8 @@ else if !errors.Is(errInfo, keyring.ErrKeyNotFound) {
     return false, errInfo // received unexpected error - returns
 }
 
-	// looking for an issue, record with meta (getByAddress)
-
-exists, but record with public key itself does not
+		// looking for an issue: record with meta (getByAddress)
+		// exists, but record with public key itself does not
     if errAddr == nil && errors.Is(errInfo, keyring.ErrKeyNotFound) {
     fmt.Fprintf(os.Stderr, "address \"%s\" exists but pubkey itself does not\n", hex.EncodeToString(addr.Bytes()))
 
@@ -3078,7 +3075,7 @@ writeOfflineKey(name string, pk types.PubKey) (*Record, error) {
 return k, ks.writeRecord(k)
 }
 
-// writeMultisigKey investigate where thisf function is called maybe remove it
+// writeMultisigKey investigates where this function is called; maybe remove it
 func (ks keystore)
 
 writeMultisigKey(name string, pk types.PubKey) (*Record, error) {
@@ -3105,7 +3102,7 @@ sort.Strings(keys)
 
 var recs []*Record
     for _, key := range keys {
-		// The keyring items only with `.info` consists the key info.
+		// The keyring items only with `.info` consist of the key info.
     if !strings.HasSuffix(key, infoSuffix) {
     continue
 }
@@ -3124,10 +3121,8 @@ return recs, nil
 }
 
 // migrate converts keyring.Item from amino to proto serialization format.
-// the `key` argument can be a key uid (e.g. "alice")
-
-or with the '.info'
-// suffix (e.g. "alice.info").
+// The `key` argument can be a key uid (e.g. "alice")
+// or with the '.info' suffix (e.g. "alice.info").
 //
 // It operates as follows:
 // 1. retrieve any key
@@ -3274,7 +3269,7 @@ A few notes on the `Keyring` methods:
 
 ### Create New Key Type
 
-To create a new key type for using in keyring, `keyring.SignatureAlgo` interface must be fulfilled.
+To create a new key type for use in keyring, the `keyring.SignatureAlgo` interface must be fulfilled.
 
 ```go expandable
 package keyring
@@ -3314,7 +3309,7 @@ return nil, errors.Wrap(ErrUnsupportedSigningAlgo, str)
 // SigningAlgoList is a slice of signature algorithms
 type SigningAlgoList []SignatureAlgo
 
-// Contains returns true if the SigningAlgoList the given SignatureAlgo.
+// Contains returns true if the SigningAlgoList contains the given SignatureAlgo.
 func (sal SigningAlgoList)
 
 Contains(algo SignatureAlgo)
@@ -3345,7 +3340,7 @@ return strings.Join(names, ",")
 }
 ```
 
-The interface consists in three methods where `Name()` returns the name of the algorithm as a `hd.PubKeyType` and `Derive()` and `Generate()` must return the following functions respectively:
+The interface consists of three methods where `Name()` returns the name of the algorithm as a `hd.PubKeyType` and `Derive()` and `Generate()` must return the following functions respectively:
 
 ```go expandable
 package hd
@@ -3569,6 +3564,6 @@ keystore {
 ...
 ```
 
-Hereafter to create new keys using your algo, you must specify it with the flag `--algo` :
+To create new keys using your algo, you must specify it with the flag `--algo`:
 
 `simd keys add myKey --algo secp256r1`

--- a/sdk/v0.53/learn/beginner/gas-fees.mdx
+++ b/sdk/v0.53/learn/beginner/gas-fees.mdx
@@ -412,15 +412,15 @@ Gas consumption can be done manually, generally by the module developer in the [
 
 `ctx.BlockGasMeter()` is the gas meter used to track gas consumption per block and make sure it does not go above a certain limit.
 
-During the genesis phase, gas consumption is unlimited to accommodate initialisation transactions.
+During the genesis phase, gas consumption is unlimited to accommodate initialization transactions.
 
 ```go
 app.finalizeBlockState.SetContext(app.finalizeBlockState.Context().WithBlockGasMeter(storetypes.NewInfiniteGasMeter()))
 ```
 
-Following the genesis block, the block gas meter is set to a finite value by the SDK. This transition is facilitated by the consensus engine (e.g., CometBFT) calling the `RequestFinalizeBlock` function, which in turn triggers the SDK's `FinalizeBlock` method. Within `FinalizeBlock`, `internalFinalizeBlock` is executed, performing necessary state updates and function executions. The block gas meter, initialised each with a finite limit, is then incorporated into the context for transaction execution, ensuring gas consumption does not exceed the block's gas limit and is reset at the end of each block.
+Following the genesis block, the block gas meter is set to a finite value by the SDK. This transition is facilitated by the consensus engine (e.g., CometBFT) calling the `RequestFinalizeBlock` function, which in turn triggers the SDK's `FinalizeBlock` method. Within `FinalizeBlock`, `internalFinalizeBlock` is executed, performing necessary state updates and function executions. The block gas meter, initialized with a finite limit, is then incorporated into the context for transaction execution, ensuring gas consumption does not exceed the block's gas limit and is reset at the end of each block.
 
-Modules within the Cosmos SDK can consume block gas at any point during their execution by utilising the `ctx`. This gas consumption primarily occurs during state read/write operations and transaction processing. The block gas meter, accessible via `ctx.BlockGasMeter()`, monitors the total gas usage within a block, enforcing the gas limit to prevent excessive computation. This ensures that gas limits are adhered to on a per-block basis, starting from the first block post-genesis.
+Modules within the Cosmos SDK can consume block gas at any point during their execution by utilizing the `ctx`. This gas consumption primarily occurs during state read/write operations and transaction processing. The block gas meter, accessible via `ctx.BlockGasMeter()`, monitors the total gas usage within a block, enforcing the gas limit to prevent excessive computation. This ensures that gas limits are adhered to on a per-block basis, starting from the first block post-genesis.
 
 ```go
 gasMeter := app.getBlockGasMeter(app.finalizeBlockState.Context())
@@ -428,7 +428,7 @@ gasMeter := app.getBlockGasMeter(app.finalizeBlockState.Context())
 app.finalizeBlockState.SetContext(app.finalizeBlockState.Context().WithBlockGasMeter(gasMeter))
 ```
 
-The above shows the general mechanism for setting the block gas meter with a finite limit based on the block's consensus parameters.
+The above code shows the general mechanism for setting the block gas meter with a finite limit based on the block's consensus parameters.
 
 ## AnteHandler
 
@@ -469,7 +469,7 @@ type (
 		GetSigners() []AccAddress
 }
 
-	// Fee defines an interface for an application application-defined concrete
+	// Fee defines an interface for an application-defined concrete
 	// transaction type to be able to set and return the transaction fee.
 	Fee interface {
     GetGas()
@@ -480,7 +480,7 @@ uint64
 Coins
 }
 
-	// Signature defines an interface for an application application-defined
+	// Signature defines an interface for an application-defined
 	// concrete transaction type to be able to set and return transaction signatures.
 	Signature interface {
     GetPubKey()
@@ -621,4 +621,4 @@ This enables developers to play with various types for the transaction of their 
 * Verify that the sender of the transaction has enough funds to cover for the `fees`. When the end-user generates a transaction, they must indicate 2 of the 3 following parameters (the third one being implicit): `fees`, `gas` and `gas-prices`. This signals how much they are willing to pay for nodes to execute their transaction. The provided `gas` value is stored in a parameter called `GasWanted` for later use.
 * Set `newCtx.GasMeter` to 0, with a limit of `GasWanted`. **This step is crucial**, as it not only makes sure the transaction cannot consume infinite gas, but also that `ctx.GasMeter` is reset in-between each transaction (`ctx` is set to `newCtx` after `anteHandler` is run, and the `anteHandler` is run each time a transaction executes).
 
-As explained above, the `anteHandler` returns a maximum limit of `gas` the transaction can consume during execution called `GasWanted`. The actual amount consumed in the end is denominated `GasUsed`, and we must therefore have `GasUsed =< GasWanted`. Both `GasWanted` and `GasUsed` are relayed to the underlying consensus engine when [`FinalizeBlock`](/sdk/v0.53/learn/advanced/baseapp#finalizeblock) returns.
+As explained above, the `anteHandler` returns a maximum limit of `gas` the transaction can consume during execution called `GasWanted`. The actual amount consumed in the end is denominated `GasUsed`, and we must therefore have `GasUsed <= GasWanted`. Both `GasWanted` and `GasUsed` are relayed to the underlying consensus engine when [`FinalizeBlock`](/sdk/v0.53/learn/advanced/baseapp#finalizeblock) returns.

--- a/sdk/v0.53/learn/beginner/gas-fees.mdx
+++ b/sdk/v0.53/learn/beginner/gas-fees.mdx
@@ -16,10 +16,10 @@ This document describes the default strategies to handle gas and fees within a C
 
 ## Introduction to `Gas` and `Fees`
 
-In the Cosmos SDK, `gas` is a special unit that is used to track the consumption of resources during execution. `gas` is typically consumed whenever read and writes are made to the store, but it can also be consumed if expensive computation needs to be done. It serves two main purposes:
+In the Cosmos SDK, `gas` is a special unit that is used to track the consumption of resources during execution. `gas` is typically consumed whenever reads and writes are made to the store, but it can also be consumed if expensive computation needs to be done. It serves two main purposes:
 
 * Make sure blocks are not consuming too many resources and are finalized. This is implemented by default in the Cosmos SDK via the [block gas meter](#block-gas-meter).
-* Prevent spam and abuse from end-user. To this end, `gas` consumed during [`message`](/sdk/v0.53/build/building-modules/messages-and-queries#messages) execution is typically priced, resulting in a `fee` (`fees = gas * gas-prices`). `fees` generally have to be paid by the sender of the `message`. Note that the Cosmos SDK does not enforce `gas` pricing by default, as there may be other ways to prevent spam (e.g. bandwidth schemes). Still, most applications implement `fee` mechanisms to prevent spam by using the [`AnteHandler`](#antehandler).
+* Prevent spam and abuse from end-users. To this end, `gas` consumed during [`message`](/sdk/v0.53/build/building-modules/messages-and-queries#messages) execution is typically priced, resulting in a `fee` (`fees = gas * gas-prices`). `fees` generally have to be paid by the sender of the `message`. Note that the Cosmos SDK does not enforce `gas` pricing by default, as there may be other ways to prevent spam (e.g. bandwidth schemes). Still, most applications implement `fee` mechanisms to prevent spam by using the [`AnteHandler`](#antehandler).
 
 ## Gas Meter
 
@@ -60,7 +60,7 @@ type ErrorOutOfGas struct {
     Descriptor string
 }
 
-// ErrorGasOverflow defines an error thrown when an action results gas consumption
+// ErrorGasOverflow defines an error thrown when an action results in gas consumption
 // unsigned integer overflow.
 type ErrorGasOverflow struct {
     Descriptor string
@@ -299,7 +299,7 @@ ConsumeGas(amount Gas, descriptor string) {
 // RefundGas will deduct the given amount from the gas consumed. If the amount is greater than the
 // gas consumed, the function will panic.
 //
-// Use case: This functionality enables refunding gas to the trasaction or block gas pools so that
+// Use case: This functionality enables refunding gas to the transaction or block gas pools so that
 // EVM-compatible chains can fully support the go-ethereum StateDb interface.
 // See https://github.com/cosmos/cosmos-sdk/pull/9403 for reference.
 func (g *infiniteGasMeter)
@@ -400,7 +400,7 @@ The gas meter is generally held in [`ctx`](/sdk/v0.53/learn/advanced/context), a
 ctx.GasMeter().ConsumeGas(amount, "description")
 ```
 
-By default, the Cosmos SDK makes use of two different gas meters, the [main gas meter](#main-gas-metter) and the [block gas meter](#block-gas-meter).
+By default, the Cosmos SDK makes use of two different gas meters, the [main gas meter](#main-gas-meter) and the [block gas meter](#block-gas-meter).
 
 ### Main Gas Meter
 
@@ -428,7 +428,7 @@ gasMeter := app.getBlockGasMeter(app.finalizeBlockState.Context())
 app.finalizeBlockState.SetContext(app.finalizeBlockState.Context().WithBlockGasMeter(gasMeter))
 ```
 
-This above shows the general mechanism for setting the block gas meter with a finite limit based on the block's consensus parameters.
+The above shows the general mechanism for setting the block gas meter with a finite limit based on the block's consensus parameters.
 
 ## AnteHandler
 
@@ -491,7 +491,7 @@ cryptotypes.PubKey
 
 	// HasMsgs defines an interface a transaction must fulfill.
 	HasMsgs interface {
-		// GetMsgs gets the all the transaction's messages.
+		// GetMsgs gets all the transaction's messages.
 		GetMsgs() []Msg
 }
 
@@ -557,7 +557,7 @@ bool
 }
 
 	// HasValidateBasic defines a type that has a ValidateBasic method.
-	// ValidateBasic is deprecated and now facultative.
+	// ValidateBasic is deprecated and now optional.
 	// Prefer validating messages directly in the msg server.
 	HasValidateBasic interface {
 		// ValidateBasic does a simple validation check that
@@ -617,8 +617,8 @@ This enables developers to play with various types for the transaction of their 
 ```
 
 * Verify signatures for each [`message`](/sdk/v0.53/build/building-modules/messages-and-queries#messages) contained in the transaction. Each `message` should be signed by one or multiple sender(s), and these signatures must be verified in the `anteHandler`.
-* During `CheckTx`, verify that the gas prices provided with the transaction is greater than the local `min-gas-prices` (as a reminder, gas-prices can be deducted from the following equation: `fees = gas * gas-prices`). `min-gas-prices` is a parameter local to each full-node and used during `CheckTx` to discard transactions that do not provide a minimum amount of fees. This ensures that the mempool cannot be spammed with garbage transactions.
+* During `CheckTx`, verify that the gas prices provided with the transaction are greater than the local `min-gas-prices` (as a reminder, gas-prices can be derived from the following equation: `fees = gas * gas-prices`). `min-gas-prices` is a parameter local to each full-node and used during `CheckTx` to discard transactions that do not provide a minimum amount of fees. This ensures that the mempool cannot be spammed with garbage transactions.
 * Verify that the sender of the transaction has enough funds to cover for the `fees`. When the end-user generates a transaction, they must indicate 2 of the 3 following parameters (the third one being implicit): `fees`, `gas` and `gas-prices`. This signals how much they are willing to pay for nodes to execute their transaction. The provided `gas` value is stored in a parameter called `GasWanted` for later use.
-* Set `newCtx.GasMeter` to 0, with a limit of `GasWanted`. **This step is crucial**, as it not only makes sure the transaction cannot consume infinite gas, but also that `ctx.GasMeter` is reset in-between each transaction (`ctx` is set to `newCtx` after `anteHandler` is run, and the `anteHandler` is run each time a transactions executes).
+* Set `newCtx.GasMeter` to 0, with a limit of `GasWanted`. **This step is crucial**, as it not only makes sure the transaction cannot consume infinite gas, but also that `ctx.GasMeter` is reset in-between each transaction (`ctx` is set to `newCtx` after `anteHandler` is run, and the `anteHandler` is run each time a transaction executes).
 
 As explained above, the `anteHandler` returns a maximum limit of `gas` the transaction can consume during execution called `GasWanted`. The actual amount consumed in the end is denominated `GasUsed`, and we must therefore have `GasUsed =< GasWanted`. Both `GasWanted` and `GasUsed` are relayed to the underlying consensus engine when [`FinalizeBlock`](/sdk/v0.53/learn/advanced/baseapp#finalizeblock) returns.

--- a/sdk/v0.53/learn/beginner/query-lifecycle.mdx
+++ b/sdk/v0.53/learn/beginner/query-lifecycle.mdx
@@ -37,7 +37,7 @@ simd query [moduleName] [command] <arguments> --flag <flagArg>
 
 To provide values such as `--node` (the full-node the CLI connects to), the user can use the [`app.toml`](/sdk/v0.53/user/run-node/run-node#configuring-the-node-using-apptoml-and-configtoml) config file to set them or provide them as flags.
 
-The CLI understands a specific set of commands, defined in a hierarchical structure by the application developer: from the [root command](/sdk/v0.53/learn/advanced/cli#root-command) (`simd`), the type of command (`Myquery`), the module that contains the command (`staking`), and command itself (`delegations`). Thus, the CLI knows exactly which module handles this command and directly passes the call there.
+The CLI understands a specific set of commands, defined in a hierarchical structure by the application developer: from the [root command](/sdk/v0.53/learn/advanced/cli#root-command) (`simd`), the type of command (`query`), the module that contains the command (`staking`), and the command itself (`delegations`). Thus, the CLI knows exactly which module handles this command and directly passes the call there.
 
 ### gRPC
 
@@ -47,7 +47,7 @@ One such tool is [grpcurl](https://github.com/fullstorydev/grpcurl), and a gRPC 
 
 ```bash
 grpcurl \
-    -plaintext                                           # We want results in plain test
+    -plaintext                                           # We want results in plain text
     -import-path ./proto \                               # Import these .proto files
     -proto ./proto/cosmos/staking/v1beta1/query.proto \  # Look into this .proto file for the Query protobuf service
     -d '{"address":"$MY_DELEGATOR"}' \                   # Query arguments
@@ -76,7 +76,7 @@ The first thing that is created in the execution of a CLI command is a `client.C
 * **Codec**: The [encoder/decoder](/sdk/v0.53/learn/advanced/encoding) used by the application, used to marshal the parameters and query before making the CometBFT RPC request and unmarshal the returned response into a JSON object. The default codec used by the CLI is Protobuf.
 * **Account Decoder**: The account decoder from the [`auth`](/sdk/v0.53/build/modules/auth/auth) module, which translates `[]byte`s into accounts.
 * **RPC Client**: The CometBFT RPC Client, or node, to which requests are relayed.
-* **Keyring**: A \[Key Manager]../beginner/03-accounts.md#keyring) used to sign transactions and handle other operations with keys.
+* **Keyring**: A [Key Manager](/sdk/v0.53/learn/beginner/accounts#keyring) used to sign transactions and handle other operations with keys.
 * **Output Writer**: A [Writer](https://pkg.go.dev/io/#Writer) used to output the response.
 * **Configurations**: The flags configured by the user for this command, including `--height`, specifying the height of the blockchain to query, and `--indent`, which indicates to add an indent to the JSON response.
 
@@ -912,7 +912,7 @@ query(path string, key []byte) ([]byte, int64, error) {
 return resp.Value, resp.Height, nil
 }
 
-// queryStore performs a query to a CometBFT node with the provided a store
+// queryStore performs a query to a CometBFT node with the provided store
 // name and path. It returns the result and height of the query upon success
 // or an error if the query fails.
 func (ctx Context)
@@ -961,7 +961,7 @@ Once a result is received from the querier, `baseapp` begins the process of retu
 
 ## Response
 
-Since `Query()` is an ABCI function, `baseapp` returns the response as an [`abci.ResponseQuery`](https://docs.cometbft.com/master/spec/abci/abci.html#query-2) type. The `client.Context` `Query()` routine receives the response and.
+Since `Query()` is an ABCI function, `baseapp` returns the response as an [`abci.ResponseQuery`](https://docs.cometbft.com/master/spec/abci/abci.html#query-2) type. The `client.Context` `Query()` routine receives the response and processes it accordingly.
 
 ### CLI Response
 
@@ -1590,4 +1590,4 @@ return keyring.New(sdk.KeyringServiceName(), backend, ctx.KeyringDir, ctx.Input,
 }
 ```
 
-And that's a wrap! The result of the query is outputted to the console by the CLI.
+Finally, the result of the query is output to the console by the CLI, completing the query lifecycle.

--- a/sdk/v0.53/learn/beginner/tx-lifecycle.mdx
+++ b/sdk/v0.53/learn/beginner/tx-lifecycle.mdx
@@ -93,7 +93,7 @@ changes while in the process of verifying transactions, but still need a copy of
 state in order to answer queries - they should not respond using state with uncommitted changes.
 
 In order to verify a `Tx`, full-nodes call `CheckTx`, which includes both *stateless* and *stateful*
-checks. Further validation happens later in the [`DeliverTx`](#delivertx) stage. `CheckTx` goes
+checks. Further validation happens later in the [Transaction Execution](#transaction-execution) stage. `CheckTx` goes
 through several steps, beginning with decoding `Tx`.
 
 ### Decoding
@@ -113,7 +113,7 @@ Read [RFC 001](https://docs.cosmos.network/main/rfc/rfc-001-tx-validation) for m
 </Warning>
 
 <Note>
-`BaseApp` still calls `ValidateBasic` on messages that implements that method for backwards compatibility.
+`BaseApp` still calls `ValidateBasic` on messages that implement that method for backwards compatibility.
 </Note>
 
 #### Guideline
@@ -129,7 +129,7 @@ A copy of the cached context is provided to the `AnteHandler`, which performs li
 For example, the [`auth`](https://github.com/cosmos/cosmos-sdk/tree/main/x/auth/spec) module `AnteHandler` checks and increments sequence numbers, checks signatures and account numbers, and deducts fees from the first signer of the transaction - all state changes are made using the `checkState`.
 
 <Warning>
-Ante handlers only run on a transaction. If a transaction embed multiple messages (like some x/authz, x/gov transactions for instance), the ante handlers only have awareness of the outer message. Inner messages are mostly directly routed to the [message router](https://docs.cosmos.network/main/learn/advanced/baseapp#msg-service-router) and will skip the chain of ante handlers. Keep that in mind when designing your own ante handler.
+Ante handlers only run on a transaction. If a transaction embeds multiple messages (like some x/authz, x/gov transactions for instance), the ante handlers only have awareness of the outer message. Inner messages are mostly directly routed to the [message router](https://docs.cosmos.network/main/learn/advanced/baseapp#msg-service-router) and will skip the chain of ante handlers. Keep that in mind when designing your own ante handler.
 </Warning>
 
 ### Gas
@@ -246,7 +246,7 @@ Instead of using their `checkState`, full-nodes use `finalizeblock`:
 
 * **`Msg` service:** Protobuf `Msg` service is responsible for executing each message in the `Tx` and causes state transitions to persist in `finalizeBlockState`.
 
-* **PostHandlers:** [`PostHandler`](/sdk/v0.53/learn/advanced/baseapp#posthandler)s run after the execution of the message. If they fail, the state change of `runMsgs`, as well of `PostHandlers`, are both reverted.
+* **PostHandlers:** [`PostHandler`](/sdk/v0.53/learn/advanced/baseapp#posthandler)s run after the execution of the message. If they fail, the state change of `runMsgs`, as well as `PostHandlers`, are both reverted.
 
 * **Gas:** While a `Tx` is being delivered, a `GasMeter` is used to keep track of how much
   gas is being used; if execution completes, `GasUsed` is set and returned in the
@@ -268,7 +268,7 @@ not they should commit the state changes.
 When they receive enough validator votes (2/3+ *precommits* weighted by voting power), full nodes commit to a new block to be added to the blockchain and
 finalize the state transitions in the application layer. A new state root is generated to serve as
 a merkle proof for the state transitions. Applications use the [`Commit`](/sdk/v0.53/learn/advanced/baseapp#commit)
-ABCI method inherited from [Baseapp](/sdk/v0.53/learn/advanced/baseapp); it syncs all the state transitions by
+ABCI method inherited from [BaseApp](/sdk/v0.53/learn/advanced/baseapp); it syncs all the state transitions by
 writing the `deliverState` into the application's internal state. As soon as the state changes are
 committed, `checkState` starts afresh from the most recently committed state and `deliverState`
 resets to `nil` in order to be consistent and reflect the changes.

--- a/sdk/v0.53/learn/intro/sdk-design.mdx
+++ b/sdk/v0.53/learn/intro/sdk-design.mdx
@@ -1032,14 +1032,13 @@ return modAccAddrs
 
 The goal of `baseapp` is to provide a secure interface between the store and the extensible state machine while defining as little about the state machine as possible (staying true to the ABCI).
 
-For more on `baseapp`, please click [here](/sdk/v0.53/learn/advanced/baseapp).
+For more information on `baseapp`, please click [here](/sdk/v0.53/learn/advanced/baseapp).
 
 ## Multistore
 
-The Cosmos SDK provides a [`multistore`](/sdk/v0.53/learn/advanced/store#multistore) for persisting state. The multistore allows developers to declare any number of [`KVStores`](/sdk/v0.53/learn
-/advanced/store#base-layer-kvstores). These `KVStores` only accept the `[]byte` type as value and therefore any custom structure needs to be marshalled using [a codec](/sdk/v0.53/learn/advanced/encoding) before being stored.
+The Cosmos SDK provides a [`multistore`](/sdk/v0.53/learn/advanced/store#multistore) for persisting state. The multistore allows developers to declare any number of [`KVStores`](/sdk/v0.53/learn/advanced/store#base-layer-kvstores). These `KVStores` only accept the `[]byte` type as a value and therefore any custom structure needs to be marshalled using [a codec](/sdk/v0.53/learn/advanced/encoding) before being stored.
 
-The multistore abstraction is used to divide the state in distinct compartments, each managed by its own module. For more on the multistore, click [here](/sdk/v0.53/learn/advanced/store#multistore)
+The multistore abstraction is used to divide the state into distinct compartments, each managed by its own module. For more on the multistore, click [here](/sdk/v0.53/learn/advanced/store#multistore)
 
 ## Modules
 
@@ -1061,7 +1060,7 @@ Here is a simplified view of how a transaction is processed by the application o
     D4 -->|Handle message, Update state| E["Return result to CometBFT (0=Ok, 1=Err)"]
 ```
 
-Each module can be seen as a little state-machine. Developers need to define the subset of the state handled by the module, as well as custom message types that modify the state (*Note:* `messages` are extracted from `transactions` by `baseapp`). In general, each module declares its own `KVStore` in the `multistore` to persist the subset of the state it defines. Most developers will need to access other 3rd party modules when building their own modules. Given that the Cosmos SDK is an open framework, some of the modules may be malicious, which means there is a need for security principles to reason about inter-module interactions. These principles are based on [object-capabilities](/sdk/v0.53/learn/advanced/ocap). In practice, this means that instead of having each module keep an access control list for other modules, each module implements special objects called `keepers` that can be passed to other modules to grant a pre-defined set of capabilities.
+Each module can be seen as a mini state-machine. Developers need to define the subset of the state handled by the module, as well as custom message types that modify the state (*Note:* `messages` are extracted from `transactions` by `baseapp`). In general, each module declares its own `KVStore` in the `multistore` to persist the subset of the state it defines. Most developers will need to access other third-party modules when building their own modules. Given that the Cosmos SDK is an open framework, some of the modules may be malicious, which means there is a need for security principles to reason about inter-module interactions. These principles are based on [object-capabilities](/sdk/v0.53/learn/advanced/ocap). In practice, this means that instead of having each module keep an access control list for other modules, each module implements special objects called `keepers` that can be passed to other modules to grant a pre-defined set of capabilities.
 
 Cosmos SDK modules are defined in the `x/` folder of the Cosmos SDK. Some core modules include:
 
@@ -1069,4 +1068,4 @@ Cosmos SDK modules are defined in the `x/` folder of the Cosmos SDK. Some core m
 * `x/bank`: Used to enable tokens and token transfers.
 * `x/staking` + `x/slashing`: Used to build Proof-of-Stake blockchains.
 
-In addition to the already existing modules in `x/`, which anyone can use in their app, the Cosmos SDK lets you build your own custom modules. You can check an [example of that in the tutorial](https://tutorials.cosmos.network/).
+In addition to the already existing modules in `x/`, which anyone can use in their app, the Cosmos SDK lets you build your own custom modules. For more information on Cosmos mocules, visit the [module section](/sdk/v0.53/build/building-modules/intro). 


### PR DESCRIPTION
Update the copy of the `beginner` section of the sdk docs for basic grammar and link checks. 