### PR TITLE
[PROD-216]  Add release note sections to sdk/cometBFT

### DIFF
--- a/cometbft/v0.38/changelog/release-notes.mdx
+++ b/cometbft/v0.38/changelog/release-notes.mdx
@@ -1,0 +1,315 @@
+---
+title: "Release Notes"
+description: "Release history and changelog for Cosmos CometBFT"
+mode: "wide"
+---
+
+<Update label="Release" description="v0.38.18" tags={["CometBFT", "Release"]}>
+## IMPROVEMENTS
+
+- Adds metrics that emit precommit data; precommit quorum delay from proposal, and precommit vote count and stake weight within timeout commit period.
+</Update>
+
+<Update label="Release" description="v0.38.17" tags={["CometBFT", "Release"]}>
+## BUG FIXES
+
+- (blocksync) Ban peer if it reports height lower than what was previously reported
+- (types) Check that `Part.Index` equals `Part.Proof.Index`
+
+## DEPENDENCIES
+
+- (go/runtime) Bump minimum Go version to 1.22.11
+</Update>
+
+<Update label="Release" description="v0.38.16" tags={["CometBFT", "Release"]}>
+## CHANGES
+
+- fixes a bug that caused a node produce errors caused by the sending of next PEX requests too soon.
+- Adds a proper description of `ExtendedVoteInfo` and `VoteInfo` in the spec.
+
+## BUG FIXES
+
+- (mocks) Mockery `v2.49.0` broke the mocks. We had to add a `.mockery.yaml` to
+</Update>
+
+<Update label="Release" description="v0.38.14" tags={["CometBFT", "Release"]}>
+## BUG FIXES
+
+- (consensus) Do not panic if the validator index of a `Vote` message is out
+
+## DEPENDENCIES
+
+- Bump cometbft-db version to v0.15.0
+- (go/runtime) Bump Go version to 1.23
+
+## IMPROVEMENTS
+
+- (p2p) fix exponential backoff logic to increase reconnect retries close to 24 hours
+</Update>
+
+<Update label="Release" description="v0.38.13" tags={["CometBFT", "Release"]}>
+## BUG FIXES
+
+- (metrics) Call unused `rejected_txs` metric in mempool
+- (state/indexer) Fix the tx_search results not returning all results by changing the logic in the indexer to copy the key and values instead of reusing an iterator. This issue only arises when upgrading to cometbft-db v0.13 or later.
+
+## DEPENDENCIES
+
+- (go/runtime) Bump Go version to 1.22
+- Bump cometbft-db version to v0.14.1
+
+## FEATURES
+
+- [#4294](https://github.com/cometbft/cometbft/pull/4294) (crypto) use decred secp256k1 directly ()
+
+## IMPROVEMENTS
+
+- (metrics) Add `evicted_txs` metric to mempool
+- (log) Change "mempool is full" log to debug level
+</Update>
+
+<Update label="Release" description="v0.38.12" tags={["CometBFT", "Release"]}>
+## BUG FIXES
+
+- (light) Cross-check proposer priorities in retrieved validator sets
+- (privval) Ignore duplicate privval listen when already connected ([\#3828](https://github.com/cometbft/cometbft/issues/3828)
+
+## DEPENDENCIES
+
+- (crypto/secp256k1) Adjust to breaking interface changes in
+- pinned mockery's version to v2.49.2 to prevent potential
+
+## IMPROVEMENTS
+
+- (types) Check that proposer is one of the validators in `ValidateBasic`
+- (e2e) Add `log_level` option to manifest file
+- (e2e) Add `log_format` option to manifest file
+</Update>
+
+<Update label="Release" description="v0.38.11" tags={["CometBFT", "Release"]}>
+## BUG FIXES
+
+- (types) Only check IFF vote is a non-nil Precommit if extensionsEnabled
+
+## IMPROVEMENTS
+
+- (indexer) Fixed ineffective select break statements; they now
+</Update>
+
+<Update label="Release" description="v0.38.10" tags={["CometBFT", "Release"]}>
+## BUG FIXES
+
+- (p2p) Node respects configured `max_num_outbound_peers` limit when dialing
+- (rpc) Fix an issue where a legacy ABCI response, created on `v0.37` or before, is not returned properly in `v0.38` and up
+- (blocksync) Do not stay in blocksync if the node's validator voting power
+
+## IMPROVEMENTS
+
+- (p2p/conn) Update send monitor, used for sending rate limiting, once per batch of packets sent
+- (libs/pubsub) Allow dash (`-`) in event tags
+- (p2p/conn) Remove the usage of a synchronous pool of buffers in secret connection, storing instead the buffer in the connection struct. This reduces the synchronization primitive usage, speeding up the code.
+</Update>
+
+<Update label="Release" description="v0.38.9" tags={["CometBFT", "Release"]}>
+## BREAKING CHANGES
+
+- (mempool) Revert adding the method `PreUpdate()` to the `Mempool` interface, recently introduced
+
+## BUG FIXES
+
+- (rpc) Fix nil pointer error in `/tx` and `/tx_search` when block is
+</Update>
+
+<Update label="Release" description="v0.38.8" tags={["CometBFT", "Release"]}>
+## BREAKING CHANGES
+
+- (mempool) Add to the `Mempool` interface a new method `PreUpdate()`. This method should be
+
+## BUG FIXES
+
+- (blockstore) Added peer banning in blockstore
+- (blockstore) Send correct error message when vote extensions do not align with received packet
+- [`mempool`] Fix data race when rechecking with async ABCI client
+- (consensus) Fix a race condition in the consensus timeout ticker. Race is caused by two timeouts being scheduled at the same time.
+- (types) Do not batch verify a commit if the validator set keys have different
+
+## IMPROVEMENTS
+
+- (config) Added `recheck_timeout` mempool parameter to set how much time to wait for recheck
+- (rpc) Add a configurable maximum batch size for RPC requests.
+- (event-bus) Remove the debug logs in PublishEventTx, which were noticed production slowdowns.
+- (state/execution) Cache the block hash computation inside of the Block Type, so we only compute it once.
+- (consensus/state) Remove a redundant `VerifyBlock` call in `FinalizeCommit`
+- (p2p/channel) Speedup `ProtoIO` writer creation time, and thereby speedup channel writing by 5%.
+- (p2p/conn) Minor speedup (3%) to connection.WritePacketMsgTo, by removing MinInt calls.
+- (internal/bits) 10x speedup creating initialized bitArrays, which speedsup extendedCommit.BitArray(). This is used in consensus vote gossip.
+- (blockstore) Remove a redundant `Header.ValidateBasic` call in `LoadBlockMeta`, 75% reducing this time.
+- (p2p/conn) Speedup connection.WritePacketMsgTo, by reusing internal buffers rather than re-allocating.
+- [`blockstore`] Use LRU caches in blockstore, significiantly improving consensus gossip routine performance
+- [`consensus`] Improve performance of consensus metrics by lowering string operations
+- [`protoio`] Remove one allocation and new object call from `ReadMsg`,
+- (mempool) Before updating the mempool, consider it as full if rechecking is still in progress.
+</Update>
+
+<Update label="Release" description="v0.38.7" tags={["CometBFT", "Release"]}>
+## BUG FIXES
+
+- [`mempool`] Panic when a CheckTx request to the app returns an error
+- [`bits`] prevent `BitArray.UnmarshalJSON` from crashing on 0 bits
+
+## FEATURES
+
+- [`node`] Add `BootstrapStateWithGenProvider` to boostrap state using a custom
+
+## IMPROVEMENTS
+
+- (state/indexer) Lower the heap allocation of transaction searches
+- (internal/bits) 10x speedup and remove heap overhead of bitArray.PickRandom (used extensively in consensus gossip)
+- (libs/json) Lower the memory overhead of JSON encoding by using JSON encoders internally
+</Update>
+
+<Update label="Release" description="v0.38.6" tags={["CometBFT", "Release"]}>
+## BUG FIXES
+
+- (privval) Retry accepting a connection ([\#2047](https://github.com/cometbft/cometbft/pull/2047))
+- (state) Fix rollback to a specific height
+
+## FEATURES
+
+- (e2e) Add `block_max_bytes` option to the manifest file.
+
+## IMPROVEMENTS
+
+- (blocksync) Avoid double-calling `types.BlockFromProto` for performance
+- (e2e) Add manifest option `load_max_txs` to limit the number of transactions generated by the
+- [#2434](https://github.com/cometbft/cometbft/pull/2434) (jsonrpc) enable HTTP basic auth in websocket client ()
+- (blocksync) make the max number of downloaded blocks dynamic.
+- (blocksync) Request a block from peer B if we are approaching pool's height
+- (blocksync) Request the block N from peer B immediately after getting
+- (blocksync) Sort peers by download rate (the fastest peer is picked first)
+</Update>
+
+<Update label="Release" description="v0.38.5" tags={["CometBFT", "Release"]}>
+## IMPROVEMENTS
+
+- (consensus) Add `chain_size_bytes` metric for measuring the size of the blockchain in bytes
+</Update>
+
+<Update label="Release" description="v0.38.4" tags={["CometBFT", "Release"]}>
+## IMPROVEMENTS
+
+- (e2e) Add manifest option `VoteExtensionsUpdateHeight` to test
+</Update>
+
+<Update label="Release" description="v0.38.3" tags={["CometBFT", "Release"]}>
+## BUG FIXES
+
+- (consensus) Fix for "Validation of `VoteExtensionsEnableHeight` can cause chain halt"
+- (mempool) Fix data races in `CListMempool` by making atomic the types of `height`, `txsBytes`, and
+- (mempool) The calculation method of tx size returned by calling proxyapp should be consistent with that of mempool
+- (evidence) When `VerifyCommitLight` & `VerifyCommitLightTrusting` are called as part
+- (crypto) `SupportsBatchVerifier` returns false
+- (blocksync) wait for `poolRoutine` to stop in `(*Reactor).OnStop`
+
+## IMPROVEMENTS
+
+- (types) Validate `Validator#Address` in `ValidateBasic` ([\#1715](https://github.com/cometbft/cometbft/pull/1715))
+- (abci) Increase ABCI socket message size limit to 2GB ([\#1730](https://github.com/cometbft/cometbft/pull/1730): @troykessler)
+- (state) Save the state using a single DB batch ([\#1735](https://github.com/cometbft/cometbft/pull/1735))
+- (store) Save block using a single DB batch if block is less than 640kB, otherwise each block part is saved individually
+- (rpc) Support setting proxy from env to `DefaultHttpClient`.
+- (rpc) Use default port for HTTP(S) URLs when there is no explicit port ([\#1903](https://github.com/cometbft/cometbft/pull/1903))
+- [#1921](https://github.com/cometbft/cometbft/pull/1921) (crypto/merkle) faster calculation of hashes ()
+</Update>
+
+<Update label="Release" description="v0.38.2" tags={["CometBFT", "Release"]}>
+## BUG FIXES
+
+- (mempool) Avoid infinite wait in transaction sending routine when
+
+## FEATURES
+
+- (mempool) Add `nop` mempool ([\#1643](https://github.com/cometbft/cometbft/pull/1643))
+</Update>
+
+<Update label="Release" description="v0.38.1" tags={["CometBFT", "Release"]}>
+## BUG FIXES
+
+- (state/indexer) Respect both height params while querying for events
+
+## FEATURES
+
+- (metrics) Add metric for mempool size in bytes `SizeBytes`.
+
+## IMPROVEMENTS
+
+- (mempool) Add experimental feature to limit the number of persistent peers and non-persistent
+- (config) Add mempool parameters `experimental_max_gossip_connections_to_persistent_peers` and
+</Update>
+
+<Update label="Release" description="v0.38.0" tags={["CometBFT", "Release"]}>
+## BREAKING CHANGES
+
+- (mempool) Remove priority mempool.
+- (config) Remove `Version` field from `MempoolConfig`.
+- (protobuf) Remove fields `sender`, `priority`, and `mempool_error` from
+- (crypto/merkle) Do not allow verification of Merkle Proofs against empty trees (`nil` root). `Proof.ComputeRootHash` now panics when it encounters an error, but `Proof.Verify` does not panic
+- (state/kvindexer) Remove the function type from the event key stored in the database. This should be breaking only
+- (rpc) Removed `begin_block_events` and `end_block_events` from `BlockResultsResponse`.
+- (pubsub) Added support for big integers and big floats in the pubsub event query system.
+- (kvindexer) Added support for big integers and big floats in the kvindexer.
+- (mempool) Application can now set `ConsensusParams.Block.MaxBytes` to -1
+- (node/state) Add Go API to bootstrap block store and state store to a height. Make sure block sync starts syncing from bootstrapped height.
+- (state/store) Added Go functions to save height at which offline state sync is performed.
+- (p2p) Remove UPnP functionality
+- (node) Removed `ConsensusState()` accessor from `Node`
+- (state) Signature of `ExtendVote` changed in `BlockExecutor`.
+- (state) Move pruneBlocks from node/state to state/execution.
+- (abci) Move `app_hash` parameter from `Commit` to `FinalizeBlock`
+- (abci) Introduce `FinalizeBlock` which condenses `BeginBlock`, `DeliverTx`
+- (p2p) Remove unused p2p/trust package
+- (rpc) Remove global environment and replace with constructor
+- (node) Move DBContext and DBProvider from the node package to the config
+- (inspect) Add a new `inspect` command for introspecting
+- (metrics) Move state-syncing and block-syncing metrics to
+
+## BUG FIXES
+
+- (kvindexer) Forward porting the fixes done to the kvindexer in 0.37 in PR \#77
+- (consensus) Unexpected error conditions in `ApplyBlock` are non-recoverable, so ignoring the error and carrying on is a bug. We replaced a `return` that disregarded the error by a `panic`.
+- (consensus) Rename `(*PeerState).ToJSON` to `MarshalJSON` to fix a logging data race
+- (light) Fixed an edge case where a light client would panic when attempting
+- and* keep the node in its list of providers in the same way it would if
+- (abci) Restore the snake_case naming in JSON serialization of
+- (consensus) Avoid recursive call after rename to (*PeerState).MarshalJSON
+- (mempool/clist_mempool) Prevent a transaction to appear twice in the mempool
+- (docker) Ensure Docker image uses consistent version of Go.
+- (abci-cli) Fix broken abci-cli help command.
+
+## DEPRECATIONS
+
+- (rpc/grpc) Mark the gRPC broadcast API as deprecated.
+
+## FEATURES
+
+- (node/state) Add Go API to bootstrap block store and state store to a height
+- (proxy) Introduce `NewConnSyncLocalClientCreator`, which allows local ABCI
+- (proxy) Introduce `NewUnsyncLocalClientCreator`, which allows local ABCI
+- (abci) New ABCI methods `VerifyVoteExtension` and `ExtendVote` allow validators to validate the vote extension data attached to a pre-commit message and allow applications to let their validators do more than just validate within consensus ([\#9836](https://github.com/tendermint/tendermint/pull/9836))
+
+## IMPROVEMENTS
+
+- (blocksync) Generate new metrics during BlockSync
+- (jsonrpc/client) Improve the error message for client errors stemming from
+- (rpc) Remove response data from response failure logs in order
+- (pubsub/kvindexer) Numeric query conditions and event values are represented as big floats with default precision of 125.
+- (node) Make handshake cancelable ([cometbft/cometbft\#857](https://github.com/cometbft/cometbft/pull/857))
+- (consensus) New metrics (counters) to track duplicate votes and block parts.
+- (mempool) Application can now set `ConsensusParams.Block.MaxBytes` to -1
+- (node) Close evidence.db OnStop ([cometbft/cometbft\#1210](https://github.com/cometbft/cometbft/pull/1210): @chillyvee)
+- (state) Make logging `block_app_hash` and `app_hash` consistent by logging them both as hex.
+- (crypto/merkle) Improve HashAlternatives performance
+- (p2p/pex) Improve addrBook.hash performance
+- (crypto/merkle) Improve HashAlternatives performance
+- (pubsub) Performance improvements for the event query API
+</Update>

--- a/docs.json
+++ b/docs.json
@@ -458,6 +458,12 @@
                                         ]
                                     }
                                 ]
+                            },
+                            {
+                                "tab": "Release Notes",
+                                "pages": [
+                                    "sdk/v0.53/changelog/release-notes"
+                                ]
                             }
                         ]
                     },
@@ -791,6 +797,12 @@
                                             }
                                         ]
                                     }
+                                ]
+                            },
+                            {
+                                "tab": "Release Notes",
+                                "pages": [
+                                    "sdk/v0.50/changelog/release-notes"
                                 ]
                             }
                         ]
@@ -3008,6 +3020,12 @@
                               }
                             ]
                           }
+                        ]
+                      },
+                      {
+                        "tab": "Release Notes",
+                        "pages": [
+                          "cometbft/v0.38/changelog/release-notes"
                         ]
                       }
                     ]

--- a/sdk/v0.50/changelog/release-notes.mdx
+++ b/sdk/v0.50/changelog/release-notes.mdx
@@ -1,0 +1,552 @@
+---
+title: "Release Notes"
+description: "Release history and changelog for Cosmos SDK"
+mode: "wide"
+---
+
+<Update label="2025-03-12" description="v0.50.13" tags={["SDK", "Release"]}>
+## BUG FIXES
+
+- [GHSA-47ww-ff84-4jrg](https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-47ww-ff84-4jrg) Fix x/group can halt when erroring in EndBlocker
+</Update>
+
+<Update label="2025-02-20" description="v0.50.12" tags={["SDK", "Release"]}>
+## BUG FIXES
+
+- [GHSA-x5vx-95h7-rv4p](https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-x5vx-95h7-rv4p) Fix Group module can halt chain when handling a malicious proposal.
+</Update>
+
+<Update label="2024-12-16" description="v0.50.11" tags={["SDK", "Release"]}>
+## FEATURES
+
+- [#21653](https://github.com/cosmos/cosmos-sdk/pull/21653) (crypto/keyring) New Linux-only backend that adds Linux kernel's `keyctl` support.
+
+## IMPROVEMENTS
+
+- [#21941](https://github.com/cosmos/cosmos-sdk/pull/21941) (server) Regenerate addrbook.json for in place testnet.
+
+## BUG FIXES
+
+- Fix [ABS-0043/ABS-0044](https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-8wcc-m6j2-qxvm) Limit recursion depth for unknown field detection and unpack any
+- [#22564](https://github.com/cosmos/cosmos-sdk/pull/22564) (server) Fix fallback genesis path in server
+- [#22425](https://github.com/cosmos/cosmos-sdk/pull/22425) (x/group) Proper address rendering in error
+- [#21906](https://github.com/cosmos/cosmos-sdk/pull/21906) (sims) Skip sims test when running dry on validators
+- [#21919](https://github.com/cosmos/cosmos-sdk/pull/21919) (cli) Query address-by-acc-num by account_id instead of id.
+- [#22229](https://github.com/cosmos/cosmos-sdk/pull/22229) (x/group) Accept `1` and `try` in CLI for group proposal exec.
+</Update>
+
+<Update label="2024-09-20" description="v0.50.10" tags={["SDK", "Release"]}>
+## FEATURES
+
+- [#20779](https://github.com/cosmos/cosmos-sdk/pull/20779) (cli) Added `module-hash-by-height` command to query and retrieve module hashes at a specified blockchain height, enhancing debugging capabilities.
+- [#21372](https://github.com/cosmos/cosmos-sdk/pull/21372) (cli) Added a `bulk-add-genesis-account` genesis command to add many genesis accounts at once.
+- [#21724](https://github.com/cosmos/cosmos-sdk/pull/21724) (types/collections) Added `LegacyDec` collection value.
+
+## IMPROVEMENTS
+
+- [#21460](https://github.com/cosmos/cosmos-sdk/pull/21460) (x/bank) Added `Sender` attribute in `MsgMultiSend` event.
+- [#21701](https://github.com/cosmos/cosmos-sdk/pull/21701) (genutil) Improved error messages for genesis validation.
+- [#21816](https://github.com/cosmos/cosmos-sdk/pull/21816) (testutil/integration) Allow to pass baseapp options in `NewIntegrationApp`.
+
+## BUG FIXES
+
+- [#21769](https://github.com/cosmos/cosmos-sdk/pull/21769) (runtime) Fix baseapp options ordering to avoid overwriting options set by modules.
+- [#21493](https://github.com/cosmos/cosmos-sdk/pull/21493) (x/consensus) Fix regression that prevented to upgrade to &gt; v0.50.7 without consensus version params.
+- [#21256](https://github.com/cosmos/cosmos-sdk/pull/21256) (baseapp) Halt height will not commit the block indicated, meaning that if halt-height is set to 10, only blocks until 9 (included) will be committed. This is to go back to the original behavior before a change was introduced in v0.50.0.
+- [#21444](https://github.com/cosmos/cosmos-sdk/pull/21444) (baseapp) Follow-up, Return PreBlocker events in FinalizeBlockResponse.
+- [#21413](https://github.com/cosmos/cosmos-sdk/pull/21413) (baseapp) Fix data race in sdk mempool.
+</Update>
+
+<Update label="2024-08-07" description="v0.50.9" tags={["SDK", "Release"]}>
+## CHANGES
+
+- [#21159](https://github.com/cosmos/cosmos-sdk/pull/21159) (baseapp) Return PreBlocker events in FinalizeBlockResponse.
+- [#20939](https://github.com/cosmos/cosmos-sdk/pull/20939) Fix collection reverse iterator to include `pagination.key` in the result.
+- [#20969](https://github.com/cosmos/cosmos-sdk/pull/20969) (client/grpc) Fix `node.NewQueryServer` method not setting `cfg`.
+- [#21006](https://github.com/cosmos/cosmos-sdk/pull/21006) (testutil/integration) Fix `NewIntegrationApp` method not writing default genesis to state.
+- [#21080](https://github.com/cosmos/cosmos-sdk/pull/21080) (runtime) Fix `app.yaml` / `app.json` incompatibility with `depinject v1.0.0`.
+</Update>
+
+<Update label="2024-07-15" description="v0.50.8" tags={["SDK", "Release"]}>
+## CHANGES
+
+- [#20690](https://github.com/cosmos/cosmos-sdk/pull/20690) (client) Import mnemonic from file
+- [#20590](https://github.com/cosmos/cosmos-sdk/pull/20590) (x/authz,x/feegrant) Provide updated keeper in depinject for authz and feegrant modules.
+- [#20631](https://github.com/cosmos/cosmos-sdk/pull/20631) Fix json parsing in the wait-tx command.
+- [#20438](https://github.com/cosmos/cosmos-sdk/pull/20438) (x/auth) Add `--skip-signature-verification` flag to multisign command to allow nested multisigs.
+</Update>
+
+<Update label="2024-06-04" description="v0.50.7" tags={["SDK", "Release"]}>
+## IMPROVEMENTS
+
+- [#20328](https://github.com/cosmos/cosmos-sdk/pull/20328) (debug) Add consensus address for debug cmd.
+- [#20264](https://github.com/cosmos/cosmos-sdk/pull/20264) (runtime) Expose grpc query router via depinject.
+- [#20381](https://github.com/cosmos/cosmos-sdk/pull/20381) (x/consensus) Use Comet utility for consensus module consensus param updates.
+- [#20356](https://github.com/cosmos/cosmos-sdk/pull/20356) (client) Overwrite client context when available in `SetCmdClientContext`.
+
+## BUG FIXES
+
+- [#17911](https://github.com/cosmos/cosmos-sdk/pull/17911) (simulation) Fix all problems with executing command `make test-sim-custom-genesis-fast` for simulation test.
+- [#18196](https://github.com/cosmos/cosmos-sdk/pull/18196) (simulation) Fix the problem of `validator set is empty after InitGenesis` in simulation test.
+- [#20346](https://github.com/cosmos/cosmos-sdk/pull/20346) (baseapp) Correctly assign `execModeSimulate` to context for `simulateTx`.
+- [#20144](https://github.com/cosmos/cosmos-sdk/pull/20144) (baseapp) Remove txs from mempool when AnteHandler fails in recheck.
+- [#20107](https://github.com/cosmos/cosmos-sdk/pull/20107) (baseapp) Avoid header height overwrite block height.
+- [#20020](https://github.com/cosmos/cosmos-sdk/pull/20020) (cli) Make bootstrap-state command support both new and legacy genesis format.
+- [#20151](https://github.com/cosmos/cosmos-sdk/pull/20151) (testutil/sims) Set all signatures and don't overwrite the previous one in `GenSignedMockTx`.
+</Update>
+
+<Update label="2024-04-22" description="v0.50.6" tags={["SDK", "Release"]}>
+## FEATURES
+
+- [#19759](https://github.com/cosmos/cosmos-sdk/pull/19759) (types) Align SignerExtractionAdapter in PriorityNonceMempool Remove.
+- [#19870](https://github.com/cosmos/cosmos-sdk/pull/19870) (client) Add new query command `wait-tx`. Alias `event-query-tx-for` to `wait-tx` for backward compatibility.
+
+## IMPROVEMENTS
+
+- [#19903](https://github.com/cosmos/cosmos-sdk/pull/19903) (telemetry) Conditionally emit metrics based on enablement.
+- **Introduction of `Now` Function**: Added a new function called `Now` to the telemetry package. It returns the current system time if telemetry is enabled, or a zero time if telemetry is not enabled.
+- **Atomic Global Variable**: Implemented an atomic global variable to manage the state of telemetry's enablement. This ensures thread safety for the telemetry state.
+- **Conditional Telemetry Emission**: All telemetry functions have been updated to emit metrics only when telemetry is enabled. They perform a check with `isTelemetryEnabled()` and return early if telemetry is disabled, minimizing unnecessary operations and overhead.
+- [#19810](https://github.com/cosmos/cosmos-sdk/pull/19810) (deps) Upgrade prometheus version and fix API breaking change due to prometheus bump.
+- [#19810](https://github.com/cosmos/cosmos-sdk/pull/19810) (deps) Bump `cosmossdk.io/store` to v1.1.0.
+- [#19884](https://github.com/cosmos/cosmos-sdk/pull/19884) (server) Add start customizability to start command options.
+- [#19853](https://github.com/cosmos/cosmos-sdk/pull/19853) (x/gov) Emit `depositor` in `EventTypeProposalDeposit`.
+- [#19844](https://github.com/cosmos/cosmos-sdk/pull/19844) (x/gov) Emit the proposer of governance proposals.
+- [#19616](https://github.com/cosmos/cosmos-sdk/pull/19616) (baseapp) Don't share gas meter in tx execution.
+- [#20114](https://github.com/cosmos/cosmos-sdk/pull/20114) [GHSA-4j93-fm92-rp4m](https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-4j93-fm92-rp4m) (x/authz) Follow up of for `x/authz`.
+- [#19691](https://github.com/cosmos/cosmos-sdk/pull/19745) (crypto) Fix tx sign doesn't throw an error when incorrect Ledger is used.
+- [#19970](https://github.com/cosmos/cosmos-sdk/pull/19970) (baseapp) Fix default config values to use no-op mempool as default.
+- [#20027](https://github.com/cosmos/cosmos-sdk/pull/20027) (crypto) secp256r1 keys now implement gogoproto's customtype interface.
+- [#20028](https://github.com/cosmos/cosmos-sdk/pull/20028) (x/bank) Align query with multi denoms for send-enabled.
+</Update>
+
+<Update label="2024-03-12" description="v0.50.5" tags={["SDK", "Release"]}>
+## FEATURES
+
+- [#19626](https://github.com/cosmos/cosmos-sdk/pull/19626) (baseapp) Add `DisableBlockGasMeter` option to `BaseApp`, which removes the block gas meter during transaction execution.
+
+## IMPROVEMENTS
+
+- [#19707](https://github.com/cosmos/cosmos-sdk/pull/19707) (x/distribution) Add autocli config for `DelegationTotalRewards` for CLI consistency with `q rewards` commands in previous versions.
+- [#19651](https://github.com/cosmos/cosmos-sdk/pull/19651) (x/auth) Allow empty public keys in `GetSignBytesAdapter`.
+
+## BUG FIXES
+
+- [#19725](https://github.com/cosmos/cosmos-sdk/pull/19725) (x/gov) Fetch a failed proposal tally from proposal.FinalTallyResult in the gprc query.
+- [#19709](https://github.com/cosmos/cosmos-sdk/pull/19709) (types) Fix skip staking genesis export when using `CoreAppModuleAdaptor` / `CoreAppModuleBasicAdaptor` for it.
+- [#19549](https://github.com/cosmos/cosmos-sdk/pull/19549) (x/auth) Accept custom get signers when injecting `x/auth/tx`.
+- [GHSA-86h5-xcpx-cfqc](https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-86h5-xcpx-cfqc) (x/staking) Fix a possible bypass of delegator slashing:
+- [GHSA-95rx-m9m5-m94v](https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-95rx-m9m5-m94v) (baseapp) Fix a bug in `baseapp.ValidateVoteExtensions` helper (). The helper has been fixed and for avoiding API breaking changes `currentHeight` and `chainID` arguments are ignored. Those arguments are removed from the helper in v0.51+.
+</Update>
+
+<Update label="2024-02-19" description="v0.50.4" tags={["SDK", "Release"]}>
+## FEATURES
+
+- [#19280](https://github.com/cosmos/cosmos-sdk/pull/19280) (server) Adds in-place testnet CLI command.
+
+## IMPROVEMENTS
+
+- [#19393](https://github.com/cosmos/cosmos-sdk/pull/19393/) (client) Add `ReadDefaultValuesFromDefaultClientConfig` to populate the default values from the default client config in client.Context without creating a app folder.
+
+## BUG FIXES
+
+- (x/auth/vesting) [GHSA-4j93-fm92-rp4m](#bug-fixes) Add `BlockedAddr` check in `CreatePeriodicVestingAccount`.
+- [#19338](https://github.com/cosmos/cosmos-sdk/pull/19338) (baseapp) Set HeaderInfo in context when calling `setState`.
+- [#19200](https://github.com/cosmos/cosmos-sdk/pull/19200) (baseapp): Ensure that sdk side ve math matches cometbft.
+- [#19106](https://github.com/cosmos/cosmos-sdk/pull/19106) Allow empty public keys when setting signatures. Public keys aren't needed for every transaction.
+- [#19198](https://github.com/cosmos/cosmos-sdk/pull/19198) (baseapp) Remove usage of pointers in logs in all optimistic execution goroutines.
+- [#19177](https://github.com/cosmos/cosmos-sdk/pull/19177) (baseapp) Fix baseapp `DefaultProposalHandler` same-sender non-sequential sequence.
+- [#19371](https://github.com/cosmos/cosmos-sdk/pull/19371) (crypto) Avoid CLI redundant log in stdout, log to stderr instead.
+</Update>
+
+<Update label="2024-01-15" description="v0.50.3" tags={["SDK", "Release"]}>
+## FEATURES
+
+- [#18991](https://github.com/cosmos/cosmos-sdk/pull/18991) (types) Add SignerExtractionAdapter to PriorityNonceMempool/Config and provide Default implementation matching existing behavior.
+- [#19043](https://github.com/cosmos/cosmos-sdk/pull/19043) (gRPC) Add `halt_height` to the gRPC `/cosmos/base/node/v1beta1/config` request.
+
+## IMPROVEMENTS
+
+- [#18956](https://github.com/cosmos/cosmos-sdk/pull/18956) (x/bank) Introduced a new `DenomOwnersByQuery` query method for `DenomOwners`, which accepts the denom value as a query string parameter, resolving issues with denoms containing slashes.
+- [#18707](https://github.com/cosmos/cosmos-sdk/pull/18707) (x/gov) Improve genesis validation.
+- [#18772](https://github.com/cosmos/cosmos-sdk/pull/18772) (x/auth/tx) Remove misleading gas wanted from tx simulation failure log.
+- [#18852](https://github.com/cosmos/cosmos-sdk/pull/18852) (client/tx) Add `WithFromName` to tx factory.
+- [#18888](https://github.com/cosmos/cosmos-sdk/pull/18888) (types) Speedup DecCoin.Sort() if len(coins) &lt;= 1
+- [#18875](https://github.com/cosmos/cosmos-sdk/pull/18875) (types) Speedup coins.Sort() if len(coins) &lt;= 1
+- [#18915](https://github.com/cosmos/cosmos-sdk/pull/18915) (baseapp) Add a new `ExecModeVerifyVoteExtension` exec mode and ensure it's populated in the `Context` during `VerifyVoteExtension` execution.
+- [#18930](https://github.com/cosmos/cosmos-sdk/pull/18930) (testutil) Add NodeURI for clientCtx.
+
+## BUG FIXES
+
+- [#19058](https://github.com/cosmos/cosmos-sdk/pull/19058) (baseapp) Fix baseapp posthandler branch would fail if the `runMsgs` had returned an error.
+- [#18609](https://github.com/cosmos/cosmos-sdk/issues/18609) (baseapp) Fixed accounting in the block gas meter after module's beginBlock and before DeliverTx, ensuring transaction processing always starts with the expected zeroed out block gas meter.
+- [#18895](https://github.com/cosmos/cosmos-sdk/pull/18895) (baseapp) Fix de-duplicating vote extensions during validation in ValidateVoteExtensions.
+</Update>
+
+<Update label="2023-12-11" description="v0.50.2" tags={["SDK", "Release"]}>
+## FEATURES
+
+- [#18219](https://github.com/cosmos/cosmos-sdk/pull/18219) (debug) Add debug commands for application codec types.
+- [#17639](https://github.com/cosmos/cosmos-sdk/pull/17639) (client/keys) Allows using and saving public keys encoded as base64.
+- [#17094](https://github.com/cosmos/cosmos-sdk/pull/17094) (server) Add a `shutdown-grace` flag for waiting a given time before exit.
+
+## IMPROVEMENTS
+
+- (telemetry) [#18646] (https://github.com/cosmos/cosmos-sdk/pull/18646) Enable statsd and dogstatsd telemetry sinks.
+- [#18478](https://github.com/cosmos/cosmos-sdk/pull/18478) (server) Add command flag to disable colored logs.
+- [#18025](https://github.com/cosmos/cosmos-sdk/pull/18025) (x/gov) Improve `<appd> q gov proposer` by querying directly a proposal instead of tx events. It is an alias of `q gov proposal` as the proposer is a field of the proposal.
+- [#18063](https://github.com/cosmos/cosmos-sdk/pull/18063) (version) Allow to define extra info to be displayed in `<appd> version --long` command.
+- [#18541](https://github.com/cosmos/cosmos-sdk/pull/18541) (codec/unknownproto)Remove the use of "protoc-gen-gogo/descriptor" in favour of using the official protobuf descriptorpb types inside unknownproto.
+
+## BUG FIXES
+
+- [#18564](https://github.com/cosmos/cosmos-sdk/pull/18564) (x/auth) Fix total fees calculation when batch signing.
+- [#18537](https://github.com/cosmos/cosmos-sdk/pull/18537) (server) Fix panic when defining minimum gas config as `100stake;100uatom`. Use a `,` delimiter instead of `;`. Fixes the server config getter to use the correct delimiter.
+- [#18531](https://github.com/cosmos/cosmos-sdk/pull/18531) Baseapp's `GetConsensusParams` returns an empty struct instead of panicking if no params are found.
+- [#18472](https://github.com/cosmos/cosmos-sdk/pull/18472) (client/tx) Utilizes the correct Pubkey when simulating a transaction.
+- [#18486](https://github.com/cosmos/cosmos-sdk/pull/18486) (baseapp) Fixed FinalizeBlock calls not being passed to ABCIListeners.
+- [#18627](https://github.com/cosmos/cosmos-sdk/pull/18627) (baseapp) Post handlers are run on non successful transaction executions too.
+- [#18654](https://github.com/cosmos/cosmos-sdk/pull/18654) (baseapp) Fixes an issue in which `gogoproto.Merge` does not work with gogoproto messages with custom types.
+</Update>
+
+<Update label="2023-11-07" description="v0.50.1" tags={["SDK", "Release"]}>
+## FEATURES
+
+- [#18071](https://github.com/cosmos/cosmos-sdk/pull/18071) (baseapp) Add hybrid handlers to `MsgServiceRouter`.
+- [#18162](https://github.com/cosmos/cosmos-sdk/pull/18162) (server) Start gRPC & API server in standalone mode.
+- [#17712](https://github.com/cosmos/cosmos-sdk/pull/17712) (baseapp & types) Introduce `PreBlock`, which runs before begin blocker other modules, and allows to modify consensus parameters, and the changes are visible to the following state machine logics. Additionally it can be used for vote extensions.
+- [#17571](https://github.com/cosmos/cosmos-sdk/pull/17571) (genutil) Allow creation of `AppGenesis` without a file lookup.
+- [#17042](https://github.com/cosmos/cosmos-sdk/pull/17042) (codec) Add `CollValueV2` which supports encoding of protov2 messages in collections.
+- [#16976](https://github.com/cosmos/cosmos-sdk/pull/16976) [#238](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/238) (x/gov) Add `failed_reason` field to `Proposal` under `x/gov` to indicate the reason for a failed proposal. Referenced from under `bnb-chain/greenfield-cosmos-sdk`.
+- [#16898](https://github.com/cosmos/cosmos-sdk/pull/16898) (baseapp) Add `preFinalizeBlockHook` to allow vote extensions persistence.
+- [#16887](https://github.com/cosmos/cosmos-sdk/pull/16887) (cli) Add two new CLI commands: `<appd> tx simulate` for simulating a transaction; `<appd> query block-results` for querying CometBFT RPC for block results.
+- [#16852](https://github.com/cosmos/cosmos-sdk/pull/16852) (x/bank) Add `DenomMetadataByQueryString` query in bank module to support metadata query by query string.
+- [#16581](https://github.com/cosmos/cosmos-sdk/pull/16581) (baseapp) Implement Optimistic Execution as an experimental feature (not enabled by default).
+- [#16257](https://github.com/cosmos/cosmos-sdk/pull/16257) (types) Allow setting the base denom in the denom registry.
+- [#16239](https://github.com/cosmos/cosmos-sdk/pull/16239) (baseapp) Add Gas Limits to allow node operators to resource bound queries.
+- [#16209](https://github.com/cosmos/cosmos-sdk/pull/16209) (cli) Make `StartCmd` more customizable.
+- [#16074](https://github.com/cosmos/cosmos-sdk/pull/16074) (types/simulation) Add generic SimulationStoreDecoder for modules using collections.
+- [#16046](https://github.com/cosmos/cosmos-sdk/pull/16046) [#15970](https://github.com/cosmos/cosmos-sdk/pull/15970) (genutil) Add "module-name" flag to genutil `add-genesis-account` to enable initializing module accounts at genesis.* Enable SIGN_MODE_TEXTUAL.
+- [#15958](https://github.com/cosmos/cosmos-sdk/pull/15958) (types) Add `module.NewBasicManagerFromManager` for creating a basic module manager from a module manager.
+- [#15829](https://github.com/cosmos/cosmos-sdk/pull/15829) (types/module) Add new endblocker interface to handle valset updates.
+- [#15818](https://github.com/cosmos/cosmos-sdk/pull/15818) (runtime) Provide logger through `depinject` instead of appBuilder.
+- [#15735](https://github.com/cosmos/cosmos-sdk/pull/15735) (types) Make `ValidateBasic() error` method of `Msg` interface optional. Modules should validate messages directly in their message handlers ([RFC 001](https://docs.cosmos.network/main/rfc/rfc-001-tx-validation)).
+- [#15679](https://github.com/cosmos/cosmos-sdk/pull/15679) (x/genutil) Allow applications to specify a custom genesis migration function for the `genesis migrate` command.
+- [#15657](https://github.com/cosmos/cosmos-sdk/pull/15657) (telemetry) Emit more data (go version, sdk version, upgrade height) in prom metrics.
+- [#15597](https://github.com/cosmos/cosmos-sdk/pull/15597) (client) Add status endpoint for clients.
+- [#15556](https://github.com/cosmos/cosmos-sdk/pull/15556) (testutil/integration) Introduce `testutil/integration` package for module integration testing.
+- [#15547](https://github.com/cosmos/cosmos-sdk/pull/15547) (runtime) Allow runtime to pass event core api service to modules.
+- [#15458](https://github.com/cosmos/cosmos-sdk/pull/15458) (client) Add a `CmdContext` field to client.Context initialized to cobra command's context.
+- [#15301](https://github.com/cosmos/cosmos-sdk/pull/15031) (x/genutil) Add application genesis. The genesis is now entirely managed by the application and passed to CometBFT at note instantiation. Functions that were taking a `cmttypes.GenesisDoc{}` now takes a `genutiltypes.AppGenesis{}`.
+- [#15133](https://github.com/cosmos/cosmos-sdk/pull/15133) (core) Implement RegisterServices in the module manager.
+- [#14894](https://github.com/cosmos/cosmos-sdk/pull/14894) (x/bank) Return a human readable denomination for IBC vouchers when querying bank balances. Added a `ResolveDenom` parameter to `types.QueryAllBalancesRequest` and `--resolve-denom` flag to `GetBalancesCmd()`.
+- [#14860](https://github.com/cosmos/cosmos-sdk/pull/14860) (core) Add `Precommit` and `PrepareCheckState` AppModule callbacks.
+- [#14720](https://github.com/cosmos/cosmos-sdk/pull/14720) (x/gov) Upstream expedited proposals from Osmosis.
+- [#14659](https://github.com/cosmos/cosmos-sdk/pull/14659) (cli) Added ability to query blocks by events with queries directly passed to Tendermint, which will allow for full query operator support, e.g. `>`.
+- [#14650](https://github.com/cosmos/cosmos-sdk/pull/14650) (x/auth) Add Textual SignModeHandler. Enable `SIGN_MODE_TEXTUAL` by following the [UPGRADING.md](./UPGRADING.md) instructions.
+- [#14588](https://github.com/cosmos/cosmos-sdk/pull/14588) (x/crisis) Use CacheContext() in AssertInvariants().
+- [#14484](https://github.com/cosmos/cosmos-sdk/pull/14484) (mempool) Add priority nonce mempool option for transaction replacement.
+- [#14468](https://github.com/cosmos/cosmos-sdk/pull/14468) (query) Implement pagination for collections.
+- [#14373](https://github.com/cosmos/cosmos-sdk/pull/14373) (x/gov) Add new proto field `constitution` of type `string` to gov module genesis state, which allows chain builders to lay a strong foundation by specifying purpose.
+- [#14342](https://github.com/cosmos/cosmos-sdk/pull/14342) (client) Add `<app> config` command is now a sub-command, for setting, getting and migrating Cosmos SDK configuration files.
+- [#14322](https://github.com/cosmos/cosmos-sdk/pull/14322) (x/distribution) Introduce a new gRPC message handler, `DepositValidatorRewardsPool`, that allows explicit funding of a validator's reward pool.
+- [#14224](https://github.com/cosmos/cosmos-sdk/pull/14224) (x/bank) Allow injection of restrictions on transfers using `AppendSendRestriction` or `PrependSendRestriction`.
+
+## IMPROVEMENTS
+
+- [#18189](https://github.com/cosmos/cosmos-sdk/pull/18189) (x/gov) Limit the accepted deposit coins for a proposal to the minimum proposal deposit denoms.
+- [#18049](https://github.com/cosmos/cosmos-sdk/pull/18049) (x/staking) Return early if Slash encounters zero tokens to burn.
+- [#18035](https://github.com/cosmos/cosmos-sdk/pull/18035) (x/staking) Hoisted out of the redelegation loop, the non-changing validator and delegator addresses parsing.
+- [#17913](https://github.com/cosmos/cosmos-sdk/pull/17913) (keyring) Add `NewAutoCLIKeyring` for creating an AutoCLI keyring from a SDK keyring.
+- [#18041](https://github.com/cosmos/cosmos-sdk/pull/18041) (x/consensus) Let `ToProtoConsensusParams()` return an error.
+- [#17780](https://github.com/cosmos/cosmos-sdk/pull/17780) (x/gov) Recover panics and turn them into errors when executing x/gov proposals.
+- [#17667](https://github.com/cosmos/cosmos-sdk/pull/17667) (baseapp) Close databases opened by SDK in `baseApp.Close()`.
+- [#17554](https://github.com/cosmos/cosmos-sdk/pull/17554) (types/module) Introduce `HasABCIGenesis` which is implemented by a module only when a validatorset update needs to be returned.
+- [#17389](https://github.com/cosmos/cosmos-sdk/pull/17389) (cli) gRPC CometBFT commands have been added under `<aapd> q consensus comet`. CometBFT commands placement in the SDK has been simplified. See the exhaustive list below.
+- `client/rpc.StatusCommand()` is now at `server.StatusCommand()`
+- [#17216](https://github.com/cosmos/cosmos-sdk/issues/17216) (testutil) Add `DefaultContextWithKeys` to `testutil` package.
+- [#17187](https://github.com/cosmos/cosmos-sdk/pull/17187) (cli) Do not use `ctx.PrintObjectLegacy` in commands anymore.
+- `<appd> q gov proposer [proposal-id]` now returns a proposal id as int instead of string.
+- [#17164](https://github.com/cosmos/cosmos-sdk/pull/17164) (x/staking) Add `BondedTokensAndPubKeyByConsAddr` to the keeper to enable vote extension verification.
+- [#17109](https://github.com/cosmos/cosmos-sdk/pull/17109) (x/group, x/gov) Let proposal summary be 40x longer than metadata limit.
+- [#17096](https://github.com/cosmos/cosmos-sdk/pull/17096) (version) Improve `getSDKVersion()` to handle module replacements.
+- [#16890](https://github.com/cosmos/cosmos-sdk/pull/16890) (types) Remove `GetTxCmd() *cobra.Command` and `GetQueryCmd() *cobra.Command` from `module.AppModuleBasic` interface.
+- [#16869](https://github.com/cosmos/cosmos-sdk/pull/16869) (x/authz) Improve error message when grant not found.
+- [#16497](https://github.com/cosmos/cosmos-sdk/pull/16497) (all) Removed all exported vestiges of `sdk.MustSortJSON` and `sdk.SortJSON`.
+- [#16238](https://github.com/cosmos/cosmos-sdk/pull/16238) (server) Don't setup p2p node keys if starting a node in GRPC only mode.
+- [#16206](https://github.com/cosmos/cosmos-sdk/pull/16206) (cli) Make ABCI handshake profileable.
+- [#16076](https://github.com/cosmos/cosmos-sdk/pull/16076) (types) Optimize `ChainAnteDecorators`/`ChainPostDecorators` to instantiate the functions once instead of on every invocation of the returned `AnteHandler`/`PostHandler`.
+- [#16071](https://github.com/cosmos/cosmos-sdk/pull/16071) (server) When `mempool.max-txs` is set to a negative value, use a no-op mempool (effectively disable the app mempool).
+- [#16041](https://github.com/cosmos/cosmos-sdk/pull/16041) (types/query) Change pagination max limit to a variable in order to be modified by application devs.
+- [#15958](https://github.com/cosmos/cosmos-sdk/pull/15958) (simapp) Refactor SimApp for removing the global basic manager.
+- [#15901](https://github.com/cosmos/cosmos-sdk/issues/15901) (all modules) All core Cosmos SDK modules query commands have migrated to [AutoCLI](https://docs.cosmos.network/main/core/autocli), ensuring parity between gRPC and CLI queries.
+- [#15867](https://github.com/cosmos/cosmos-sdk/pull/15867) (x/auth) Support better logging for signature verification failure.
+- [#15767](https://github.com/cosmos/cosmos-sdk/pull/15767) (store/cachekv) Reduce peak RAM usage during and after `InitGenesis`.
+- [#15764](https://github.com/cosmos/cosmos-sdk/pull/15764) (x/bank) Speedup x/bank `InitGenesis`.
+- [#15580](https://github.com/cosmos/cosmos-sdk/pull/15580) (x/slashing) Refactor the validator's missed block signing window to be a chunked bitmap instead of a "logical" bitmap, significantly reducing the storage footprint.
+- [#15554](https://github.com/cosmos/cosmos-sdk/pull/15554) (x/gov) Add proposal result log in `active_proposal` event. When a proposal passes but fails to execute, the proposal result is logged in the `active_proposal` event.
+- [#15553](https://github.com/cosmos/cosmos-sdk/pull/15553) (x/consensus) Migrate consensus module to use collections.
+- [#15358](https://github.com/cosmos/cosmos-sdk/pull/15358) (server) Add `server.InterceptConfigsAndCreateContext` as alternative to `server.InterceptConfigsPreRunHandler` which does not set the server context and the default SDK logger.
+- [#15328](https://github.com/cosmos/cosmos-sdk/pull/15328) (mempool) Improve the `PriorityNonceMempool`:
+- Support generic transaction prioritization, instead of `ctx.Priority()`
+- Improve construction through the use of a single `PriorityNonceMempoolConfig` instead of option functions
+- [#15164](https://github.com/cosmos/cosmos-sdk/pull/15164) (x/authz) Add `MsgCancelUnbondingDelegation` to staking authorization.
+- [#15041](https://github.com/cosmos/cosmos-sdk/pull/15041) (server) Remove unnecessary sleeps from gRPC and API server initiation. The servers will start and accept requests as soon as they're ready.
+- [#15023](https://github.com/cosmos/cosmos-sdk/pull/15023) [#15213](https://github.com/cosmos/cosmos-sdk/pull/15213) (baseapp) & Add `MessageRouter` interface to baseapp and pass it to authz, gov and groups instead of concrete type.
+- [#15011](https://github.com/cosmos/cosmos-sdk/pull/15011) Introduce `cosmossdk.io/log` package to provide a consistent logging interface through the SDK. CometBFT logger is now replaced by `cosmossdk.io/log.Logger`.
+- [#14864](https://github.com/cosmos/cosmos-sdk/pull/14864) (x/staking) `<appd> tx staking create-validator` CLI command now takes a json file as an arg instead of using required flags.
+- [#14758](https://github.com/cosmos/cosmos-sdk/pull/14758) (x/auth) Allow transaction event queries to directly passed to Tendermint, which will allow for full query operator support, e.g. `>`.
+- [#14757](https://github.com/cosmos/cosmos-sdk/pull/14757) (x/evidence) Evidence messages do not need to implement a `.Type()` anymore.
+- [#14751](https://github.com/cosmos/cosmos-sdk/pull/14751) (x/auth/tx) Remove `.Type()` and `Route()` methods from all msgs and `legacytx.LegacyMsg` interface.
+- [#14659](https://github.com/cosmos/cosmos-sdk/pull/14659) (cli) Added ability to query blocks by either height/hash `<app> q block --type=height|hash <height|hash>`.
+- [#14590](https://github.com/cosmos/cosmos-sdk/pull/14590) (x/staking) Return undelegate amount in MsgUndelegateResponse.
+- [#14529](https://github.com/cosmos/cosmos-sdk/pull/14529) Add new property `BondDenom` to `SimulationState` struct.
+- [#14439](https://github.com/cosmos/cosmos-sdk/pull/14439) (store) Remove global metric gatherer from store.
+- By default store has a no op metric gatherer, the application developer must set another metric gatherer or us the provided one in `store/metrics`.
+- [#14438](https://github.com/cosmos/cosmos-sdk/pull/14438) (store) Pass logger from baseapp to store.
+- [#14417](https://github.com/cosmos/cosmos-sdk/pull/14417) (baseapp) The store package no longer has a dependency on baseapp.
+- [#14415](https://github.com/cosmos/cosmos-sdk/pull/14415) (module) Loosen assertions in SetOrderBeginBlockers() and SetOrderEndBlockers().
+- [#14410](https://github.com/cosmos/cosmos-sdk/pull/14410) (store) `rootmulti.Store.loadVersion` has validation to check if all the module stores' height is correct, it will error if any module store has incorrect height.
+- [#14406](https://github.com/cosmos/cosmos-sdk/issues/14406) Migrate usage of `types/store.go` to `store/types/..`.
+- [#14384](https://github.com/cosmos/cosmos-sdk/pull/14384) (context)Refactor(context): Pass EventManager to the context as an interface.
+- [#14354](https://github.com/cosmos/cosmos-sdk/pull/14354) (types) Improve performance on Context.KVStore and Context.TransientStore by 40%.
+- [#14151](https://github.com/cosmos/cosmos-sdk/pull/14151) (crypto/keyring) Move keys presentation from `crypto/keyring` to `client/keys`
+- [#14087](https://github.com/cosmos/cosmos-sdk/pull/14087) (signing) Add SignModeHandlerWithContext interface with a new `GetSignBytesWithContext` to get the sign bytes using `context.Context` as an argument to access state.
+- [#14062](https://github.com/cosmos/cosmos-sdk/pull/14062) (server) Remove rosetta from server start.
+- [#3129](https://github.com/cosmos/cosmos-sdk/pull/3129) (crypto) New armor and keyring key derivation uses aead and encryption uses chacha20poly.
+
+## STATE MACHINE BREAKING
+
+- [#18146](https://github.com/cosmos/cosmos-sdk/pull/18146) (x/gov) Add denom check to reject denoms outside of those listed in `MinDeposit`. A new `MinDepositRatio` param is added (with a default value of `0.001`) and now deposits are required to be at least `MinDepositRatio*MinDeposit` to be accepted.
+- [#16235](https://github.com/cosmos/cosmos-sdk/pull/16235) (x/group,x/gov) A group and gov proposal is rejected if the proposal metadata title and summary do not match the proposal title and summary.
+- [#15930](https://github.com/cosmos/cosmos-sdk/pull/15930) (baseapp) change vote info provided by prepare and process proposal to the one in the block.
+- [#15731](https://github.com/cosmos/cosmos-sdk/pull/15731) (x/staking) Introducing a new index to retrieve the delegations by validator efficiently.
+- [#15701](https://github.com/cosmos/cosmos-sdk/pull/15701) (x/staking) The `HistoricalInfoKey` has been updated to use a binary format.
+- [#15580](https://github.com/cosmos/cosmos-sdk/pull/15580) (x/slashing) The validator slashing window now stores "chunked" bitmap entries for each validator's signing window instead of a single boolean entry per signing window index.
+- [#14590](https://github.com/cosmos/cosmos-sdk/pull/14590) (x/staking) `MsgUndelegateResponse` now includes undelegated amount. `x/staking` module's `keeper.Undelegate` now returns 3 values (completionTime,undelegateAmount,error) instead of 2.
+- [#14294](https://github.com/cosmos/cosmos-sdk/pull/14294) (x/feegrant) Moved the logic of rejecting duplicate grant from `msg_server` to `keeper` method.
+
+## API BREAKING CHANGES
+
+- [#17787](https://github.com/cosmos/cosmos-sdk/pull/17787) (x/auth) Remove Tip functionality.
+- (types) `module.EndBlockAppModule` has been replaced by Core API `appmodule.HasEndBlocker` or `module.HasABCIEndBlock` when needing validator updates.
+- (types) `module.BeginBlockAppModule` has been replaced by Core API `appmodule.HasBeginBlocker`.
+- [#17358](https://github.com/cosmos/cosmos-sdk/pull/17358) (types) Remove deprecated `sdk.Handler`, use `baseapp.MsgServiceHandler` instead.
+- [#17197](https://github.com/cosmos/cosmos-sdk/pull/17197) (client) `keys.Commands` does not take a home directory anymore. It is inferred from the root command.
+- [#17157](https://github.com/cosmos/cosmos-sdk/pull/17157) (x/staking) `GetValidatorsByPowerIndexKey` and `ValidateBasic` for historical info takes a validator address codec in order to be able to decode/encode addresses.
+- `GetOperator()` now returns the address as it is represented in state, by default this is an encoded address
+- `GetConsAddr() ([]byte, error)` returns `[]byte` instead of sdk.ConsAddres.
+- `FromABCIEvidence` & `GetConsensusAddress(consAc address.Codec)` now take a consensus address codec to be able to decode the incoming address.
+- (x/distribution) `Delegate` & `SlashValidator` helper function added the mock staking keeper as a parameter passed to the function
+- [#17098](https://github.com/cosmos/cosmos-sdk/pull/17098) (x/staking) `NewMsgCreateValidator`, `NewValidator`, `NewMsgCancelUnbondingDelegation`, `NewMsgUndelegate`, `NewMsgBeginRedelegate`, `NewMsgDelegate` and `NewMsgEditValidator`  takes a string instead of `sdk.ValAddress` or `sdk.AccAddress`:
+- `NewRedelegation` and `NewUnbondingDelegation` takes a validatorAddressCodec and a delegatorAddressCodec in order to decode the addresses.
+- `NewRedelegationResponse` takes a string instead of `sdk.ValAddress` or `sdk.AccAddress`.
+- `NewMsgCreateValidator.Validate()` takes an address codec in order to decode the address.
+- `BuildCreateValidatorMsg` takes a ValidatorAddressCodec in order to decode addresses.
+- [#17098](https://github.com/cosmos/cosmos-sdk/pull/17098) (x/slashing) `NewMsgUnjail` takes a string instead of `sdk.ValAddress`
+- [#17098](https://github.com/cosmos/cosmos-sdk/pull/17098) (x/genutil) `GenAppStateFromConfig`, AddGenesisAccountCmd and `GenTxCmd` takes an addresscodec to decode addresses.
+- [#17098](https://github.com/cosmos/cosmos-sdk/pull/17098) (x/distribution) `NewMsgDepositValidatorRewardsPool`, `NewMsgFundCommunityPool`, `NewMsgWithdrawValidatorCommission` and `NewMsgWithdrawDelegatorReward` takes a string instead of `sdk.ValAddress` or `sdk.AccAddress`.
+- [#16959](https://github.com/cosmos/cosmos-sdk/pull/16959) (x/staking) Add validator and consensus address codec as staking keeper arguments.
+- [#16958](https://github.com/cosmos/cosmos-sdk/pull/16958) (x/staking) DelegationI interface `GetDelegatorAddr` & `GetValidatorAddr` have been migrated to return string instead of sdk.AccAddress and sdk.ValAddress respectively. stakingtypes.NewDelegation takes a string instead of sdk.AccAddress and sdk.ValAddress.
+- [#16899](https://github.com/cosmos/cosmos-sdk/pull/16899) (testutil) The *cli testutil* `QueryBalancesExec` has been removed. Use the gRPC or REST query instead.
+- [#16795](https://github.com/cosmos/cosmos-sdk/pull/16795) (x/staking) `DelegationToDelegationResponse`, `DelegationsToDelegationResponses`, `RedelegationsToRedelegationResponses` are no longer exported.
+- [#16741](https://github.com/cosmos/cosmos-sdk/pull/16741) (x/auth/vesting) Vesting account constructor now return an error with the result of their validate function.
+- [#16650](https://github.com/cosmos/cosmos-sdk/pull/16650) (x/auth) The *cli testutil* `QueryAccountExec` has been removed. Use the gRPC or REST query instead.
+- [#16621](https://github.com/cosmos/cosmos-sdk/pull/16621) (x/auth) Pass address codec to auth new keeper constructor.
+- [#16423](https://github.com/cosmos/cosmos-sdk/pull/16423) (x/auth) `helpers.AddGenesisAccount` has been moved to `x/genutil` to remove the cyclic dependency between `x/auth` and `x/genutil`.
+- [#16342](https://github.com/cosmos/cosmos-sdk/pull/16342) (baseapp) NewContext was renamed to NewContextLegacy. The replacement (NewContext) now does not take a header, instead you should set the header via `WithHeaderInfo` or `WithBlockHeight`. Note that `WithBlockHeight` will soon be deprecated and its recommended to use `WithHeaderInfo`.
+- [#16329](https://github.com/cosmos/cosmos-sdk/pull/16329) (x/mint) Use collections for state management:
+- Removed: keeper `GetParams`, `SetParams`, `GetMinter`, `SetMinter`.
+- [#16328](https://github.com/cosmos/cosmos-sdk/pull/16328) (x/crisis) Use collections for state management:
+- Removed: keeper `GetConstantFee`, `SetConstantFee`
+- [#16324](https://github.com/cosmos/cosmos-sdk/pull/16324) (x/staking) `NewKeeper` now takes a `KVStoreService` instead of a `StoreKey`, and methods in the `Keeper` now take a `context.Context` instead of a `sdk.Context` and return an `error`. Notable changes:
+- `Validator` method now returns `types.ErrNoValidatorFound` instead of `nil` when not found.
+- [#16302](https://github.com/cosmos/cosmos-sdk/pull/16302) (x/distribution) Use collections for FeePool state management.
+- Removed: keeper `GetFeePool`, `SetFeePool`, `GetFeePoolCommunityCoins`
+- [#16272](https://github.com/cosmos/cosmos-sdk/pull/16272) (types) `FeeGranter` in the `FeeTx` interface returns `[]byte` instead of `string`.
+- [#16268](https://github.com/cosmos/cosmos-sdk/pull/16268) (x/gov) Use collections for proposal state management (part 2):
+- this finalizes the gov collections migration
+- Removed: types all the key related functions
+- Removed: keeper `InsertActiveProposalsQueue`, `RemoveActiveProposalsQueue`, `InsertInactiveProposalsQueue`, `RemoveInactiveProposalsQueue`, `IterateInactiveProposalsQueue`, `IterateActiveProposalsQueue`, `ActiveProposalsQueueIterator`, `InactiveProposalsQueueIterator`
+- [#16246](https://github.com/cosmos/cosmos-sdk/issues/16246) (x/slashing) `NewKeeper` now takes a `KVStoreService` instead of a `StoreKey`, and methods in the `Keeper` now take a `context.Context` instead of a `sdk.Context` and return an `error`. `GetValidatorSigningInfo` now returns an error instead of a `found bool`, the error can be `nil` (found), `ErrNoSigningInfoFound` (not found) and any other error.
+- [#16227](https://github.com/cosmos/cosmos-sdk/issues/16227) (module) `manager.RunMigrations()` now take a `context.Context` instead of a `sdk.Context`.
+- [#16216](https://github.com/cosmos/cosmos-sdk/issues/16216) (x/crisis) `NewKeeper` now takes a `KVStoreService` instead of a `StoreKey`, methods in the `Keeper` now take a `context.Context` instead of a `sdk.Context` and return an `error` instead of panicking.
+- [#16211](https://github.com/cosmos/cosmos-sdk/pull/16211) (x/distribution) Use collections for params state management.
+- [#16209](https://github.com/cosmos/cosmos-sdk/pull/16209) (cli) Add API `StartCmdWithOptions` to create customized start command.
+- [#16179](https://github.com/cosmos/cosmos-sdk/issues/16179) (x/mint) `NewKeeper` now takes a `KVStoreService` instead of a `StoreKey`, and methods in the `Keeper` now take a `context.Context` instead of a `sdk.Context` and return an `error`.
+- [#16171](https://github.com/cosmos/cosmos-sdk/pull/16171) (x/gov) Use collections for proposal state management (part 1):
+- Removed: keeper: `GetProposal`, `UnmarshalProposal`, `MarshalProposal`, `IterateProposal`, `GetProposal`, `GetProposalFiltered`, `GetProposals`, `GetProposalID`, `SetProposalID`
+- Removed: errors unused errors
+- [#16164](https://github.com/cosmos/cosmos-sdk/pull/16164) (x/gov) Use collections for vote state management:
+- Removed: types `VoteKey`, `VoteKeys`
+- Removed: keeper `IterateVotes`, `IterateAllVotes`, `GetVotes`, `GetVote`, `SetVote`
+- [#16155](https://github.com/cosmos/cosmos-sdk/pull/16155) (sims)
+- `simulation.NewOperationMsg` now marshals the operation msg as proto bytes instead of legacy amino JSON bytes.
+- `simulation.NewOperationMsg` is now 2-arity instead of 3-arity with the obsolete argument `codec.ProtoCodec` removed.
+- The field `OperationMsg.Msg` is now of type `[]byte` instead of `json.RawMessage`.
+- [#16127](https://github.com/cosmos/cosmos-sdk/pull/16127) (x/gov) Use collections for deposit state management:
+- The following methods are removed from the gov keeper: `GetDeposit`, `GetAllDeposits`, `IterateAllDeposits`.
+- The following functions are removed from the gov types: `DepositKey`, `DepositsKey`.
+- [#16118](https://github.com/cosmos/cosmos-sdk/pull/16118/) (x/gov) Use collections for constitution and params state management.
+- [#16106](https://github.com/cosmos/cosmos-sdk/pull/16106) (x/gov) Remove gRPC query methods from gov keeper.
+- [#16052](https://github.com/cosmos/cosmos-sdk/pull/16062) (x/*all*) `GetSignBytes` implementations on messages and global legacy amino codec definitions have been removed from all modules.
+- [#16052](https://github.com/cosmos/cosmos-sdk/pull/16062) (sims) `GetOrGenerate` no longer requires a codec argument is now 4-arity instead of 5-arity.
+- [#16040](https://github.com/cosmos/cosmos-sdk/pull/16798) (types/math) Remove aliases in `types/math.go` (part 2).
+- [#16040](https://github.com/cosmos/cosmos-sdk/pull/16040) (types/math) Remove aliases in `types/math.go` (part 1).
+- [#16016](https://github.com/cosmos/cosmos-sdk/pull/16016) (x/auth) Use collections for accounts state management:
+- removed: keeper `HasAccountByID`, `AccountAddressByID`, `SetParams
+- [#15999](https://github.com/cosmos/cosmos-sdk/pull/15999) (x/genutil) Genutil now takes the `GenesisTxHanlder` interface instead of deliverTx. The interface is implemented on baseapp
+- [#15988](https://github.com/cosmos/cosmos-sdk/issues/15988) (x/gov) `NewKeeper` now takes a `KVStoreService` instead of a `StoreKey`, methods in the `Keeper` now take a `context.Context` instead of a `sdk.Context` and return an `error` (instead of panicking or returning a `found bool`). Iterators callback functions now return an error instead of a `bool`.
+- [#15985](https://github.com/cosmos/cosmos-sdk/pull/15985) (x/auth) The `AccountKeeper` does not expose the `QueryServer` and `MsgServer` APIs anymore.
+- [#15962](https://github.com/cosmos/cosmos-sdk/issues/15962) (x/authz) `NewKeeper` now takes a `KVStoreService` instead of a `StoreKey`, methods in the `Keeper` now take a `context.Context` instead of a `sdk.Context`. The `Authorization` interface's `Accept` method now takes a `context.Context` instead of a `sdk.Context`.
+- [#15948](https://github.com/cosmos/cosmos-sdk/issues/15948) (x/distribution) `NewKeeper` now takes a `KVStoreService` instead of a `StoreKey` and methods in the `Keeper` now take a `context.Context` instead of a `sdk.Context`. Keeper methods also now return an `error`.
+- [#15891](https://github.com/cosmos/cosmos-sdk/issues/15891) (x/bank) `NewKeeper` now takes a `KVStoreService` instead of a `StoreKey` and methods in the `Keeper` now take a `context.Context` instead of a `sdk.Context`. Also `FundAccount` and `FundModuleAccount` from the `testutil` package accept a `context.Context` instead of a `sdk.Context`, and it's position was moved to the first place.
+- [#15875](https://github.com/cosmos/cosmos-sdk/pull/15875) (x/slashing) `x/slashing.NewAppModule` now requires an `InterfaceRegistry` parameter.
+- [#15852](https://github.com/cosmos/cosmos-sdk/pull/15852) (x/crisis) Crisis keeper now takes a instance of the address codec to be able to decode user addresses
+- [#15822](https://github.com/cosmos/cosmos-sdk/pull/15822) (x/auth) The type of struct field `ante.HandlerOptions.SignModeHandler` has been changed to `x/tx/signing.HandlerMap`.
+- [#15822](https://github.com/cosmos/cosmos-sdk/pull/15822) (client) The return type of the interface method `TxConfig.SignModeHandler` has been changed to `x/tx/signing.HandlerMap`.
+- The signature of `VerifySignature` has been changed to accept a `x/tx/signing.HandlerMap` and other structs from `x/tx` as arguments.
+- The signature of `NewTxConfigWithTextual` has been deprecated and its signature changed to accept a `SignModeOptions`.
+- The signature of `NewSigVerificationDecorator` has been changed to accept a `x/tx/signing.HandlerMap`.
+- [#15818](https://github.com/cosmos/cosmos-sdk/issues/15818) (x/bank) `BaseViewKeeper`'s `Logger` method now doesn't require a context. `NewBaseKeeper`, `NewBaseSendKeeper` and `NewBaseViewKeeper` now also require a `log.Logger` to be passed in.
+- [#15679](https://github.com/cosmos/cosmos-sdk/pull/15679) (x/genutil) `MigrateGenesisCmd` now takes a `MigrationMap` instead of having the SDK genesis migration hardcoded.
+- [#15673](https://github.com/cosmos/cosmos-sdk/pull/15673) (client) Move `client/keys.OutputFormatJSON` and `client/keys.OutputFormatText` to `client/flags` package.
+- [#15648](https://github.com/cosmos/cosmos-sdk/issues/15648) (x/*all*) Make `SetParams` consistent across all modules and validate the params at the message handling instead of `SetParams` method.
+- [#15600](https://github.com/cosmos/cosmos-sdk/pull/15600) [#15873](https://github.com/cosmos/cosmos-sdk/pull/15873) (codec) add support for getting signers to `codec.Codec` and `InterfaceRegistry`:
+- `InterfaceRegistry` is has unexported methods and implements `protodesc.Resolver` plus the `RangeFiles` and `SigningContext` methods. All implementations of `InterfaceRegistry` by other users must now embed the official implementation.
+- `Codec` has new methods `InterfaceRegistry`, `GetMsgAnySigners`, `GetMsgV1Signers`, and `GetMsgV2Signers` as well as unexported methods. All implementations of `Codec` by other users must now embed an official implementation from the `codec` package.
+- `AminoCodec` is marked as deprecated and no longer implements `Codec.
+- [#15597](https://github.com/cosmos/cosmos-sdk/pull/15597) (client) `RegisterNodeService` now requires a config parameter.
+- [#15588](https://github.com/cosmos/cosmos-sdk/pull/15588) (x/nft) `NewKeeper` now takes a `KVStoreService` instead of a `StoreKey` and methods in the `Keeper` now take a `context.Context` instead of a `sdk.Context`.
+- [#15568](https://github.com/cosmos/cosmos-sdk/pull/15568) (baseapp) `SetIAVLLazyLoading` is removed from baseapp.
+- [#15567](https://github.com/cosmos/cosmos-sdk/pull/15567) (x/genutil) `CollectGenTxsCmd` & `GenTxCmd` takes a address.Codec to be able to decode addresses.
+- [#15567](https://github.com/cosmos/cosmos-sdk/pull/15567) (x/bank) `GenesisBalance.GetAddress` now returns a string instead of `sdk.AccAddress`
+- `MsgSendExec` test helper function now takes a address.Codec
+- [#15520](https://github.com/cosmos/cosmos-sdk/pull/15520) (x/auth) `NewAccountKeeper` now takes a `KVStoreService` instead of a `StoreKey` and methods in the `Keeper` now take a `context.Context` instead of a `sdk.Context`.
+- [#15519](https://github.com/cosmos/cosmos-sdk/pull/15519/files) (baseapp) `runTxMode`s were renamed to `execMode`. `ModeDeliver` as changed to `ModeFinalize` and a new `ModeVoteExtension` was added for vote extensions.
+- [#15519](https://github.com/cosmos/cosmos-sdk/pull/15519/files) (baseapp) Writing of state to the multistore was moved to `FinalizeBlock`. `Commit` still handles the committing values to disk.
+- [#15519](https://github.com/cosmos/cosmos-sdk/pull/15519/files) (baseapp) Calls to BeginBlock and EndBlock have been replaced with core api beginblock & endblock.
+- [#15519](https://github.com/cosmos/cosmos-sdk/pull/15519/files) (baseapp) BeginBlock and EndBlock are now internal to baseapp. For testing, user must call `FinalizeBlock`. BeginBlock and EndBlock calls are internal to Baseapp.
+- [#15519](https://github.com/cosmos/cosmos-sdk/pull/15519/files) (baseapp) All calls to ABCI methods now accept a pointer of the abci request and response types
+- [#15517](https://github.com/cosmos/cosmos-sdk/pull/15517) (x/consensus) `NewKeeper` now takes a `KVStoreService` instead of a `StoreKey`.
+- [#15477](https://github.com/cosmos/cosmos-sdk/pull/15477) (x/bank) `banktypes.NewMsgMultiSend` and `keeper.InputOutputCoins` only accept one input.
+- [#15358](https://github.com/cosmos/cosmos-sdk/pull/15358) (server) Remove `server.ErrorCode` that was not used anywhere.
+- [#15344](https://github.com/cosmos/cosmos-sdk/pull/15344) (x/capability) Capability module was removed and is now housed in [IBC-GO](https://github.com/cosmos/ibc-go).
+- [#15328](https://github.com/cosmos/cosmos-sdk/pull/15328) (mempool) The `PriorityNonceMempool` is now generic over type `C comparable` and takes a single `PriorityNonceMempoolConfig[C]` argument. See `DefaultPriorityNonceMempoolConfig` for how to construct the configuration and a `TxPriority` type.
+- [#15299](https://github.com/cosmos/cosmos-sdk/pull/15299) Remove `StdTx` transaction and signing APIs. No SDK version has actually supported `StdTx` since before Stargate.
+- [#15284](https://github.com/cosmos/cosmos-sdk/pull/15284) 
+- [#15284](https://github.com/cosmos/cosmos-sdk/pull/15284) (x/gov) `NewKeeper` now requires `codec.Codec`.
+- [#15284](https://github.com/cosmos/cosmos-sdk/pull/15284) (x/authx) `NewKeeper` now requires `codec.Codec`.
+- `types/tx.Tx` no longer implements `sdk.Tx`.
+- `sdk.Tx` now requires a new method `GetMsgsV2()`.
+- `sdk.Msg.GetSigners` was deprecated and is no longer supported. Use the `cosmos.msg.v1.signer` protobuf annotation instead.
+- `TxConfig` has a new method `SigningContext() *signing.Context`.
+- `SigVerifiableTx.GetSigners()` now returns `([][]byte, error)` instead of `[]sdk.AccAddress`.
+- `AccountKeeper` now has an `AddressCodec() address.Codec` method and the expected `AccountKeeper` for `x/auth/ante` expects this method.
+- [#15211](https://github.com/cosmos/cosmos-sdk/pull/15211) Remove usage of `github.com/cometbft/cometbft/libs/bytes.HexBytes` in favor of `[]byte` thorough the SDK.
+- [#15070](https://github.com/cosmos/cosmos-sdk/pull/15070) (crypto) `GenerateFromPassword` and `Cost` from `bcrypt.go` now take a `uint32` instead of a `int` type.
+- [#15067](https://github.com/cosmos/cosmos-sdk/pull/15067) (types) Remove deprecated alias from `types/errors`. Use `cosmossdk.io/errors` instead.
+- [#15041](https://github.com/cosmos/cosmos-sdk/pull/15041) (server) Refactor how gRPC and API servers are started to remove unnecessary sleeps:
+- `api.Server#Start` now accepts a `context.Context`. The caller is responsible for ensuring that the context is canceled such that the API server can gracefully exit. The caller does not need to stop the server.
+- To start the gRPC server you must first create the server via `NewGRPCServer`, after which you can start the gRPC server via `StartGRPCServer` which accepts a `context.Context`. The caller is responsible for ensuring that the context is canceled such that the gRPC server can gracefully exit. The caller does not need to stop the server.
+- Rename `WaitForQuitSignals` to `ListenForQuitSignals`. Note, this function is no longer blocking. Thus the caller is expected to provide a `context.CancelFunc` which indicates that when a signal is caught, that any spawned processes can gracefully exit.
+- Remove `ServerStartTime` constant.
+- [#15011](https://github.com/cosmos/cosmos-sdk/pull/15011) All functions that were taking a CometBFT logger, now take `cosmossdk.io/log.Logger` instead.
+- [#14977](https://github.com/cosmos/cosmos-sdk/pull/14977) (simapp) Move simulation helpers functions (`AppStateFn` and `AppStateRandomizedFn`) to `testutil/sims`. These takes an extra genesisState argument which is the default state of the app.
+- [#14894](https://github.com/cosmos/cosmos-sdk/pull/14894) (x/bank) Allow a human readable denomination for coins when querying bank balances. Added a `ResolveDenom` parameter to `types.QueryAllBalancesRequest`.
+- [#14847](https://github.com/cosmos/cosmos-sdk/pull/14847) App and ModuleManager methods `InitGenesis`, `ExportGenesis`, `BeginBlock` and `EndBlock` now also return an error.
+- [#14764](https://github.com/cosmos/cosmos-sdk/pull/14764) (x/upgrade) The `x/upgrade` module is extracted to have a separate go.mod file which allows it to be a standalone module.
+- [#14758](https://github.com/cosmos/cosmos-sdk/pull/14758) (x/auth) Refactor transaction searching:
+- Refactor `QueryTxsByEvents` to accept a `query` of type `string` instead of `events` of type `[]string`
+- Refactor CLI methods to accept `--query` flag instead of `--events`
+- Pass `prove=false` to Tendermint's `TxSearch` RPC method
+- [#14751](https://github.com/cosmos/cosmos-sdk/pull/14751) (simulation) Remove the `MsgType` field from `simulation.OperationInput` struct.
+- [#14746](https://github.com/cosmos/cosmos-sdk/pull/14746) (store) Extract Store in its own go.mod and rename the package to `cosmossdk.io/store`.
+- [#14725](https://github.com/cosmos/cosmos-sdk/pull/14725) (x/nft) Extract NFT in its own go.mod and rename the package to `cosmossdk.io/x/nft`.
+- [#14720](https://github.com/cosmos/cosmos-sdk/pull/14720) (x/gov) Add an expedited field in the gov v1 proposal and `MsgNewMsgProposal`.
+- [#14649](https://github.com/cosmos/cosmos-sdk/pull/14649) (x/feegrant) Extract Feegrant in its own go.mod and rename the package to `cosmossdk.io/x/feegrant`.
+- [#14634](https://github.com/cosmos/cosmos-sdk/pull/14634) (tx) Move the `tx` go module to `x/tx`.
+- [#14603](https://github.com/cosmos/cosmos-sdk/pull/14603) (store/streaming)`StoreDecoderRegistry` moved from store to `types/simulations` this breaks the `AppModuleSimulation` interface.
+- [#14597](https://github.com/cosmos/cosmos-sdk/pull/14597) (snapshots) Move `snapshots` to `store/snapshots`, rename and bump proto package to v1.
+- [#14590](https://github.com/cosmos/cosmos-sdk/pull/14590) (x/staking) `MsgUndelegateResponse` now includes undelegated amount. `x/staking` module's `keeper.Undelegate` now returns 3 values (completionTime,undelegateAmount,error)  instead of 2.
+- [#14151](https://github.com/cosmos/cosmos-sdk/pull/14151) (crypto/keyring) Move keys presentation from `crypto/keyring` to `client/keys`
+- [#14050](https://github.com/cosmos/cosmos-sdk/pull/14050) (baseapp) Refactor `ABCIListener` interface to accept Go contexts.
+- [#13850](https://github.com/cosmos/cosmos-sdk/pull/13850/) (x/auth) Remove `MarshalYAML` methods from module (`x/...`) types.
+- [#13850](https://github.com/cosmos/cosmos-sdk/pull/13850) [#14046](https://github.com/cosmos/cosmos-sdk/pull/14046) (modules) and Remove gogoproto stringer annotations. This removes the custom `String()` methods on all types that were using the annotations.
+- (x/evidence) [14724](https://github.com/cosmos/cosmos-sdk/pull/14724) Extract Evidence in its own go.mod and rename the package to `cosmossdk.io/x/evidence`.
+- [#13734](https://github.com/cosmos/cosmos-sdk/pull/13834) (crypto/keyring) The keyring's `Sign` method now takes a new `signMode` argument. It is only used if the signing key is a Ledger hardware device. You can set it to 0 in all other cases.
+- (snapshots) [14048](https://github.com/cosmos/cosmos-sdk/pull/14048) Move the Snapshot package to the store package. This is done in an effort group all storage related logic under one package.
+- [#13701](https://github.com/cosmos/cosmos-sdk/pull/) (signing) Add `context.Context` as an argument `x/auth/signing.VerifySignature`.
+- [#11825](https://github.com/cosmos/cosmos-sdk/pull/11825) (store) Make extension snapshotter interface safer to use, renamed the util function `WriteExtensionItem` to `WriteExtensionPayload`.
+
+## CLIENT BREAKING CHANGES
+
+- [#17910](https://github.com/cosmos/cosmos-sdk/pull/17910) (x/gov) Remove telemetry for counting votes and proposals. It was incorrectly counting votes. Use alternatives, such as state streaming.
+- [#15845](https://github.com/cosmos/cosmos-sdk/pull/15845) (abci) Remove duplicating events in `logs`.
+- [#15845](https://github.com/cosmos/cosmos-sdk/pull/15845) (abci) Add `msg_index` to all event attributes to associate events and messages.
+- [#15701](https://github.com/cosmos/cosmos-sdk/pull/15701) (x/staking) `HistoricalInfoKey` now has a binary format.
+- [#15519](https://github.com/cosmos/cosmos-sdk/pull/15519/files) (store/streaming) State Streaming removed emitting of beginblock, endblock and delivertx in favour of emitting FinalizeBlock.
+- [#15519](https://github.com/cosmos/cosmos-sdk/pull/15519/files) (baseapp) BeginBlock & EndBlock events have begin or endblock in the events in order to identify which stage they are emitted from since they are returned to comet as FinalizeBlock events.
+- [#14652](https://github.com/cosmos/cosmos-sdk/pull/14652) (grpc-web) Use same port for gRPC-Web and the API server.
+
+## CLI BREAKING CHANGES
+
+- (all) The migration of modules to [AutoCLI](https://docs.cosmos.network/main/core/autocli) led to no changes in UX but a [small change in CLI outputs](https://github.com/cosmos/cosmos-sdk/issues/16651) where results can be nested.
+- (all) Query pagination flags have been renamed with the migration to AutoCLI:
+- `--reverse` -> `--page-reverse`
+- `--offset` -> `--page-offset`
+- `--limit` -> `--page-limit`
+- `--count-total` -> `--page-count-total`
+- [#17184](https://github.com/cosmos/cosmos-sdk/pull/17184) (cli) All json keys returned by the `status` command are now snake case instead of pascal case.
+- [#17177](https://github.com/cosmos/cosmos-sdk/pull/17177) (server) Remove `iavl-lazy-loading` configuration.
+- [#16987](https://github.com/cosmos/cosmos-sdk/pull/16987) (x/gov) In `<appd> query gov proposals` the proposal status flag have renamed from `--status` to `--proposal-status`. Additionally, that flags now uses the ENUM values: `PROPOSAL_STATUS_DEPOSIT_PERIOD`, `PROPOSAL_STATUS_VOTING_PERIOD`, `PROPOSAL_STATUS_PASSED`, `PROPOSAL_STATUS_REJECTED`, `PROPOSAL_STATUS_FAILED`.
+- [#16899](https://github.com/cosmos/cosmos-sdk/pull/16899) (x/bank) With the migration to AutoCLI some bank commands have been split in two:
+- Use `total-supply` (or `total`) for querying the total supply and `total-supply-of` for querying the supply of a specific denom.
+- Use `denoms-metadata` for querying all denom metadata and `denom-metadata` for querying a specific denom metadata.
+- [#16276](https://github.com/cosmos/cosmos-sdk/issues/16276) (rosetta) Rosetta migration to standalone repo.
+- [#15826](https://github.com/cosmos/cosmos-sdk/pull/15826) (cli) Remove `<appd> q account` command. Use `<appd> q auth account` instead.
+- [#15299](https://github.com/cosmos/cosmos-sdk/pull/15299) (cli) Remove `--amino` flag from `sign` and `multi-sign` commands. Amino `StdTx` has been deprecated for a while. Amino JSON signing still works as expected.
+- [#14880](https://github.com/cosmos/cosmos-sdk/pull/14880) (x/gov) Remove `<app> tx gov submit-legacy-proposal cancel-software-upgrade` and `software-upgrade` commands. These commands are now in the `x/upgrade` module and using gov v1. Use `tx upgrade software-upgrade` instead.
+- [#14864](https://github.com/cosmos/cosmos-sdk/pull/14864) (x/staking) `<appd> tx staking create-validator` CLI command now takes a json file as an arg instead of using required flags.
+- [#14659](https://github.com/cosmos/cosmos-sdk/pull/14659) (cli) `<app> q block <height>` is removed as it just output json. The new command allows either height/hash and is `<app> q block --type=height|hash <height|hash>`.
+- [#14652](https://github.com/cosmos/cosmos-sdk/pull/14652) (grpc-web) Remove `grpc-web.address` flag.
+- [#14342](https://github.com/cosmos/cosmos-sdk/pull/14342) (client) `<app> config` command is now a sub-command using Confix. Use `<app> config --help` to learn more.
+
+## BUG FIXES
+
+- [#18254](https://github.com/cosmos/cosmos-sdk/pull/18254) (server) Don't hardcode gRPC address to localhost.
+- [#18173](https://github.com/cosmos/cosmos-sdk/pull/18173) (x/gov) Gov hooks now return an error and are *blocking* when they fail. Expect for `AfterProposalFailedMinDeposit` and `AfterProposalVotingPeriodEnded` which log the error and continue.
+- [#17873](https://github.com/cosmos/cosmos-sdk/pull/17873) (x/gov) Fail any inactive and active proposals that cannot be decoded.
+- [#18016](https://github.com/cosmos/cosmos-sdk/pull/18016) (x/slashing) Fixed builder function for missed blocks key (`validatorMissedBlockBitArrayPrefixKey`) in slashing/migration/v4.
+- [#18107](https://github.com/cosmos/cosmos-sdk/pull/18107) (x/bank) Add missing keypair of SendEnabled to restore legacy param set before migration.
+- [#17769](https://github.com/cosmos/cosmos-sdk/pull/17769) (baseapp) Ensure we respect block size constraints in the `DefaultProposalHandler`'s `PrepareProposal` handler when a nil or no-op mempool is used. We provide a `TxSelector` type to assist in making transaction selection generalized. We also fix a comparison bug in tx selection when `req.maxTxBytes` is reached.
+- [#17668](https://github.com/cosmos/cosmos-sdk/pull/17668) (mempool) Fix `PriorityNonceIterator.Next()` nil pointer ref for min priority at the end of iteration.
+- [#17649](https://github.com/cosmos/cosmos-sdk/pull/17649) (config) Fix `mempool.max-txs` configuration is invalid in `app.config`.
+- [#17518](https://github.com/cosmos/cosmos-sdk/pull/17518) (baseapp) Utilizing voting power from vote extensions (CometBFT) instead of the current bonded tokens (x/staking) to determine if a set of vote extensions are valid.
+- [#17251](https://github.com/cosmos/cosmos-sdk/pull/17251) (baseapp) VerifyVoteExtensions and ExtendVote initialize their own contexts/states, allowing VerifyVoteExtensions being called without ExtendVote.
+- [#17236](https://github.com/cosmos/cosmos-sdk/pull/17236) (x/distribution) Using "validateCommunityTax" in "Params.ValidateBasic", preventing panic when field "CommunityTax" is nil.
+- [#17170](https://github.com/cosmos/cosmos-sdk/pull/17170) (x/bank) Avoid empty spendable error message on send coins.
+- [#17146](https://github.com/cosmos/cosmos-sdk/pull/17146) (x/group) Rename x/group legacy ORM package's error codespace from "orm" to "legacy_orm", preventing collisions with ORM's error codespace "orm".
+- [#16905](https://github.com/cosmos/cosmos-sdk/pull/16905) (types/query) Collections Pagination now applies proper count when filtering results.
+- [#16841](https://github.com/cosmos/cosmos-sdk/pull/16841) (x/bank) Correctly process legacy `DenomAddressIndex` values.
+- [#16733](https://github.com/cosmos/cosmos-sdk/pull/16733) (x/auth/vesting) Panic on overflowing and negative EndTimes when creating a PeriodicVestingAccount.
+- [#16713](https://github.com/cosmos/cosmos-sdk/pull/16713) (x/consensus) Add missing ABCI param in `MsgUpdateParams`.
+- [#16700](https://github.com/cosmos/cosmos-sdk/pull/16700) (baseapp) Fix consensus failure in returning no response to malformed transactions.
+- [#16639](https://github.com/cosmos/cosmos-sdk/pull/16639) Make sure we don't execute blocks beyond the halt height.
+- [#16613](https://github.com/cosmos/cosmos-sdk/pull/16613) (baseapp) Ensure each message in a transaction has a registered handler, otherwise `CheckTx` will fail.
+- [#16596](https://github.com/cosmos/cosmos-sdk/pull/16596) (baseapp) Return error during `ExtendVote` and `VerifyVoteExtension` if the request height is earlier than `VoteExtensionsEnableHeight`.
+- [#16259](https://github.com/cosmos/cosmos-sdk/pull/16259) (baseapp) Ensure the `Context` block height is correct after `InitChain` and prior to the second block.
+- [#16231](https://github.com/cosmos/cosmos-sdk/pull/16231) [#16138](https://github.com/cosmos/cosmos-sdk/pull/16138) (x/gov) Fix Rawlog JSON formatting of proposal_vote option field.* (cli) Fix snapshot commands panic if snapshot don't exists.
+- [#16043](https://github.com/cosmos/cosmos-sdk/pull/16043) (x/staking) Call `AfterUnbondingInitiated` hook for new unbonding entries only and fix `UnbondingDelegation` entries handling. This is a behavior change compared to Cosmos SDK v0.47.x, now the hook is called only for new unbonding entries.
+- [#16010](https://github.com/cosmos/cosmos-sdk/pull/16010) (types) Let `module.CoreAppModuleBasicAdaptor` fallback to legacy genesis handling.
+- [#15691](https://github.com/cosmos/cosmos-sdk/pull/15691) (types) Make `Coin.Validate()` check that `.Amount` is not nil.
+- [#15258](https://github.com/cosmos/cosmos-sdk/pull/15258) (x/crypto) Write keyhash file with permissions 0600 instead of 0555.
+- [#15059](https://github.com/cosmos/cosmos-sdk/pull/15059) (x/auth) `ante.CountSubKeys` returns 0 when passing a nil `Pubkey`.
+- [#15030](https://github.com/cosmos/cosmos-sdk/pull/15030) (x/capability) Prevent `x/capability` from consuming `GasMeter` gas during `InitMemStore`
+- [#14739](https://github.com/cosmos/cosmos-sdk/pull/14739) (types/coin) Deprecate the method `Coin.IsEqual` in favour of  `Coin.Equal`. The difference between the two methods is that the first one results in a panic when denoms are not equal. This panic lead to unexpected behavior.
+
+## DEPRECATED
+
+- [#16980](https://github.com/cosmos/cosmos-sdk/pull/16980) (types) Deprecate `IntProto` and `DecProto`. Instead, `math.Int` and `math.LegacyDec` should be used respectively. Both types support `Marshal` and `Unmarshal` for binary serialization.
+- [#14567](https://github.com/cosmos/cosmos-sdk/pull/14567) (x/staking) The `delegator_address` field of `MsgCreateValidator` has been deprecated.
+</Update>

--- a/sdk/v0.53/changelog/release-notes.mdx
+++ b/sdk/v0.53/changelog/release-notes.mdx
@@ -1,0 +1,80 @@
+---
+title: "Release Notes"
+description: "Release history and changelog for Cosmos SDK"
+mode: "wide"
+---
+
+<Update label="2025-04-29 " description="v0.53.0" tags={["SDK", "Release"]}>
+## FEATURES
+
+- [#24062](https://github.com/cosmos/cosmos-sdk/pull/24062) [#24145](https://github.com/cosmos/cosmos-sdk/pull/24145) (simsx) Add new simsx framework on top of simulations for better module dev experience.
+- [#24069](https://github.com/cosmos/cosmos-sdk/pull/24069) (baseapp) Create CheckTxHandler to allow extending the logic of CheckTx.
+- [#24093](https://github.com/cosmos/cosmos-sdk/pull/24093) (types) Added a new method, `IsGT`, for `types.Coin`. This method is used to check if a `types.Coin` is greater than another `types.Coin`.
+- [#24071](https://github.com/cosmos/cosmos-sdk/pull/24071) (client/keys) Add support for importing hex key using standard input.
+- [#23780](https://github.com/cosmos/cosmos-sdk/pull/23780) (types) Add a ValueCodec for the math.Uint type that can be used in collections maps.
+- [#24045](https://github.com/cosmos/cosmos-sdk/pull/24045) (perf)Sims: Replace runsim command with Go stdlib testing. CLI: `Commit` default true, `Lean`, `SimulateEveryOperation`, `PrintAllInvariants`, `DBBackend` params removed
+- [#24040](https://github.com/cosmos/cosmos-sdk/pull/24040) (crypto/keyring) Expose the db keyring used in the keystore.
+- [#23919](https://github.com/cosmos/cosmos-sdk/pull/23919) (types) Add MustValAddressFromBech32 function.
+- [#23708](https://github.com/cosmos/cosmos-sdk/pull/23708) (all) Add unordered transaction support.
+- Adds a `--timeout-timestamp` flag that allows users to specify a block time at which the unordered transactions should expire from the mempool.
+- [#23815](https://github.com/cosmos/cosmos-sdk/pull/23815) (x/epochs) Upstream `x/epochs` from Osmosis
+- [#23811](https://github.com/cosmos/cosmos-sdk/pull/23811) (client) Add auto cli for node service.
+- [#24018](https://github.com/cosmos/cosmos-sdk/pull/24018) (genutil) Allow manually setting the consensus key type in genesis
+- [#18557](https://github.com/cosmos/cosmos-sdk/pull/18557) (client) Add `--qrcode` flag to `keys show` command to support displaying keys address QR code.
+- [#24030](https://github.com/cosmos/cosmos-sdk/pull/24030) (x/auth) Allow usage of ed25519 keys for transaction signing.
+- [#24163](https://github.com/cosmos/cosmos-sdk/pull/24163) (baseapp) Add `StreamingManager` to baseapp to extend the abci listeners.
+- [#23933](https://github.com/cosmos/cosmos-sdk/pull/23933) (x/protocolpool) Add x/protocolpool module.
+- x/distribution can now utilize an externally managed community pool. NOTE: this will make the message handlers for FundCommunityPool and CommunityPoolSpend error, as well as the query handler for CommunityPool.
+- [#18101](https://github.com/cosmos/cosmos-sdk/pull/18101) (client) Add a `keyring-default-keyname` in `client.toml` for specifying a default key name, and skip the need to use the `--from` flag when signing transactions.
+- [#24355](https://github.com/cosmos/cosmos-sdk/pull/24355) (x/gov) Allow users to set a custom CalculateVoteResultsAndVotingPower function to be used in govkeeper.Tally.
+- [#24436](https://github.com/cosmos/cosmos-sdk/pull/24436) (x/mint) Allow users to set a custom minting function used in the `x/mint` begin blocker.
+- The `InflationCalculationFn` argument to `mint.NewAppModule()` is now ignored and must be nil.  To set a custom `InflationCalculationFn` on the default minter, use `mintkeeper.WithMintFn(mintkeeper.DefaultMintFn(customInflationFn))`.
+- [#24428](https://github.com/cosmos/cosmos-sdk/pull/24428) (api) Add block height to response headers
+
+## IMPROVEMENTS
+
+- [#24561](https://github.com/cosmos/cosmos-sdk/pull/24561) (client) TimeoutTimestamp flag has been changed to TimeoutDuration, which now sets the timeout timestamp of unordered transactions to the current time + duration passed.
+- [#24541](https://github.com/cosmos/cosmos-sdk/pull/24541) (telemetry) Telemetry now includes a pre_blocker metric key. x/upgrade should migrate to this key in v0.54.0.
+- [#24541](https://github.com/cosmos/cosmos-sdk/pull/24541) (x/auth) x/auth's PreBlocker now emits telemetry under the pre_blocker metric key.
+- [#24431](https://github.com/cosmos/cosmos-sdk/pull/24431) (x/bank) Reduce the number of `ValidateDenom` calls in `bank.SendCoins` and `Coin`.
+- The `AmountOf()` method on`sdk.Coins` no longer will `panic` if given an invalid denom and will instead return a zero value.
+- [#24391](https://github.com/cosmos/cosmos-sdk/pull/24391) (x/staking) Replace panics with error results; more verbose error messages
+- [#24354](https://github.com/cosmos/cosmos-sdk/pull/24354) (x/staking) Optimize validator endblock by reducing bech32 conversions, resulting in significant performance improvement
+- [#18950](https://github.com/cosmos/cosmos-sdk/pull/18950) (client/keys) Improve `<appd> keys add`, `<appd> keys import` and `<appd> keys rename` by checking name validation.
+- [#18703](https://github.com/cosmos/cosmos-sdk/pull/18703) (client/keys) Improve `<appd> keys add` and `<appd> keys show` by checking whether there are duplicate keys in the multisig case.
+- [#18745](https://github.com/cosmos/cosmos-sdk/pull/18745) (client/keys) Improve `<appd> keys export` and `<appd> keys mnemonic` by adding --yes option to skip interactive confirmation.
+- [#24106](https://github.com/cosmos/cosmos-sdk/pull/24106) (x/bank) `SendCoins` now checks for `SendRestrictions` before instead of after deducting coins using `subUnlockedCoins`.
+- [#24036](https://github.com/cosmos/cosmos-sdk/pull/24036) (crypto/ledger) Improve error message when deriving paths using index &gt; 100
+- [#23844](https://github.com/cosmos/cosmos-sdk/pull/23844) (gRPC) Add debug log prints for each gRPC request.
+- [#24073](https://github.com/cosmos/cosmos-sdk/pull/24073) (gRPC) Adds error handling for out-of-gas panics in grpc query handlers.
+- [#24072](https://github.com/cosmos/cosmos-sdk/pull/24072) (server) Return BlockHeader by shallow copy in server Context.
+- [#24053](https://github.com/cosmos/cosmos-sdk/pull/24053) (x/bank) Resolve a foot-gun by swapping send restrictions check in `InputOutputCoins` before coin deduction.
+- [#24336](https://github.com/cosmos/cosmos-sdk/pull/24336) (codec/types) Most types definitions were moved to `github.com/cosmos/gogoproto/types/any` with aliases to these left in `codec/types` so that there should be no breakage to existing code. This allows protobuf generated code to optionally reference the SDK's custom `Any` type without a direct dependency on the SDK. This can be done by changing the `protoc` `M` parameter for `any.proto` to `Mgoogle/protobuf/any.proto=github.com/cosmos/gogoproto/types/any`.
+
+## BUG FIXES
+
+- [#24460](https://github.com/cosmos/cosmos-sdk/pull/24460) (x/gov)Do not call Remove during Walk in defaultCalculateVoteResultsAndVotingPower.
+- (baseapp) [24261](https://github.com/cosmos/cosmos-sdk/pull/24261) Fix post handler error always results in code 1
+- [#24068](https://github.com/cosmos/cosmos-sdk/pull/24068) (server) Allow align block header with skip check header in grpc server.
+- [#24044](https://github.com/cosmos/cosmos-sdk/pull/24044) (x/gov) Fix some places in which we call Remove inside a Walk (x/gov).
+- [#24042](https://github.com/cosmos/cosmos-sdk/pull/24042) (baseapp) Fixed a data race inside BaseApp.getContext, found by end-to-end (e2e) tests.
+- [#24059](https://github.com/cosmos/cosmos-sdk/pull/24059) (client/server) Consistently set viper prefix in client and server. It defaults for the binary name for both client and server.
+- [#24041](https://github.com/cosmos/cosmos-sdk/pull/24041) (client/keys) `keys delete` won't terminate when a key is not found, but will log the error.
+- [#24027](https://github.com/cosmos/cosmos-sdk/pull/24027) (baseapp) Ensure that `BaseApp.Init` checks that the commit multistore is set to protect against nil dereferences.
+- [GHSA-47ww-ff84-4jrg](https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-47ww-ff84-4jrg) (x/group) Fix x/group can halt when erroring in EndBlocker
+- [#23934](https://github.com/cosmos/cosmos-sdk/pull/23934) (x/distribution) Fix vulnerability in `incrementReferenceCount` in distribution.
+- [#23879](https://github.com/cosmos/cosmos-sdk/pull/23879) (baseapp) Ensure finalize block response is not empty in the defer check of FinalizeBlock to avoid panic by nil pointer.
+- [#23883](https://github.com/cosmos/cosmos-sdk/pull/23883) (query) Fix NPE in query pagination.
+- [#23860](https://github.com/cosmos/cosmos-sdk/pull/23860) (client) Add missing `unordered` field for legacy amino signing of tx body.
+- [#23836](https://github.com/cosmos/cosmos-sdk/pull/23836) (x/bank) Fix `DenomMetadata` rpc allow value with slashes.
+- (query) [87d3a43](https://github.com/cosmos/cosmos-sdk/commit/87d3a432af95f4cf96aa02351ed5fcc51cca6e7b) Fix collection filtered pagination.
+- [#23952](https://github.com/cosmos/cosmos-sdk/pull/23952) (sims) Use liveness matrix for validator sign status in sims
+- [#24055](https://github.com/cosmos/cosmos-sdk/pull/24055) (baseapp) Align block header when query with latest height.
+- [#24074](https://github.com/cosmos/cosmos-sdk/pull/24074) (baseapp) Use CometBFT's ComputeProtoSizeForTxs in defaultTxSelector.SelectTxForProposal for consistency.
+- [#24090](https://github.com/cosmos/cosmos-sdk/pull/24090) (cli) Prune cmd should disable async pruning.
+- [#19239](https://github.com/cosmos/cosmos-sdk/pull/19239) (x/auth) Sets from flag in multi-sign command to avoid no key name provided error.
+- [#23741](https://github.com/cosmos/cosmos-sdk/pull/23741) (x/auth) Support legacy global AccountNumber for legacy compatibility.
+- [#24526](https://github.com/cosmos/cosmos-sdk/pull/24526) (baseapp) Fix incorrect retention height when `commitHeight` equals `minRetainBlocks`.
+- [#24594](https://github.com/cosmos/cosmos-sdk/pull/24594) (x/protocolpool) Fix NPE when initializing module via depinject.
+- [#24610](https://github.com/cosmos/cosmos-sdk/pull/24610) (x/epochs) Fix semantics of `CurrentEpochStartHeight` being set before epoch has started.
+</Update>


### PR DESCRIPTION
  Add release notes to navigation for Cosmos SDK and CometBFT                   
                                                                                
  - Added Release Notes tab to SDK v0.53, v0.50, and CometBFT v0.38 in          
  navigation                                                                    
  - Generated release notes pages with clean, consistent formatting             
  - Matches existing EVM release notes style   