### PR TITLE
Landing fixes

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -7,5 +7,5 @@ node_modules/
 # Ignore other common directories that don't need parsing
 .git/
 dist/
-build/
+/build/
 coverage/

--- a/index.mdx
+++ b/index.mdx
@@ -158,7 +158,7 @@ import { MobileMenuDrawer } from '/snippets/mobile-menu-drawer.jsx';
        <DocCard
           title="Skip.Go API"
           description="API for building seamless cross-chain experiences."
-          docsLink="https://docs.skip.build"
+          docsLink="/skip-go/general/getting-started"
           githubLink="https://github.com/skip-mev"
         />
       </DocCardGrid>

--- a/skip-go/support-requirements/chain-integration-request.mdx
+++ b/skip-go/support-requirements/chain-integration-request.mdx
@@ -3,6 +3,6 @@ title: "Chain Integration Request"
 mode: "wide"
 ---
 
-import SkipAPIChainForm from '/snippets/SkipAPIChainForm.jsx';
+import SkipAPIChainForm from '/skip-go/snippets/SkipAPIChainForm.jsx';
 
 <SkipAPIChainForm />

--- a/snippets/cosmos-stack-diagram.jsx
+++ b/snippets/cosmos-stack-diagram.jsx
@@ -1,7 +1,3 @@
-'use client'
-
-import React from 'react'
-
 export const CosmosStackDiagram = () => {
   return (
     <div className="relative w-full rounded-[24px] md:rounded-[32px] overflow-hidden">

--- a/snippets/cosmos-stack-learn.jsx
+++ b/snippets/cosmos-stack-learn.jsx
@@ -1,7 +1,3 @@
-'use client'
-
-import React, { useState } from 'react'
-
 export const CosmosStackLearn = () => {
   const [selectedTech, setSelectedTech] = useState('Cosmos SDK')
 

--- a/snippets/docs-navigation-drawer.jsx
+++ b/snippets/docs-navigation-drawer.jsx
@@ -1,5 +1,3 @@
-import React, { useEffect, useState } from 'react';
-
 export const DocsNavigationDrawer = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [isVisible, setIsVisible] = useState(false);

--- a/snippets/mobile-menu-drawer.jsx
+++ b/snippets/mobile-menu-drawer.jsx
@@ -1,5 +1,3 @@
-import React, { useEffect, useState } from 'react';
-
 export const MobileMenuDrawer = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [isVisible, setIsVisible] = useState(false);


### PR DESCRIPTION
Fixes:
1. Fix the .mintignore file to only ignore root-level build directories (it was ignoring   
  paths like sdk/v0.47/build/)
2. Removed React imports from the JSX components (Mintlify provides React hooks globally so imports were throwing warnings)
3.  Skip.Go link was updated to the correct path