### PR TITLE
Fix comet rpc docs path

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -4638,7 +4638,10 @@
                           },
                           {
                             "group": "RPC Methods",
-                            "openapi": "cometbft/v0.38/api-reference/rpc/openapi.yaml"
+                            "openapi": {
+                              "source": "cometbft/v0.38/api-reference/rpc/openapi.yaml",
+                              "directory": "cometbft/v0.38/api-reference/rpc"
+                            }
                           }
                         ]
                       },


### PR DESCRIPTION
Current path was: https://docs.cosmos.network/api-reference/abci/abci_query

Now they are in the the cometbft directory: /cometbft/v0.38/api-reference/rpc/tx/broadcast_tx_async