### PR TITLE
fix: replace broken relative links in PoA docs

### DIFF
--- a/enterprise/components/poa/architecture.mdx
+++ b/enterprise/components/poa/architecture.mdx
@@ -42,9 +42,9 @@ The PoA module plugs into the Cosmos SDK as a replacement for the standard staki
 
 **Key Integration Points:**
 
-1. **Replaces [x/staking](../../../x/staking/README.md)**: PoA provides validator management without token delegation or bonding
-2. **Integrates with [x/gov](../../../x/gov/README.md)**: Custom governance hooks ensure only active validators can participate and tally function override allocates vote weight to validator power ([details](#governance))
-3. **Uses [x/auth](../../../x/auth/README.md) & [x/bank](../../../x/bank/README.md)**: Standard account and token management for fee distribution ([details](#fee-distribution))
+1. **Replaces [x/staking](/sdk/v0.53/build/modules/staking/README)**: PoA provides validator management without token delegation or bonding
+2. **Integrates with [x/gov](/sdk/v0.53/build/modules/gov/README)**: Custom governance hooks ensure only active validators can participate and tally function override allocates vote weight to validator power ([details](#governance))
+3. **Uses [x/auth](/sdk/v0.53/build/modules/auth/auth) & [x/bank](/sdk/v0.53/build/modules/bank/README)**: Standard account and token management for fee distribution ([details](#fee-distribution))
 4. **ABCI Lifecycle**: Implements `EndBlocker` to communicate validator updates to CometBFT ([details](#abci-integration))
 
 ### Architectural Decisions
@@ -58,14 +58,14 @@ Unlike proof-of-stake where validators are determined by token weight, PoA uses 
 
 **Custom Fee Distribution**
 
-Rather than using the standard [x/distribution](../../../x/distribution/README.md) module, PoA implements its own fee mechanism:
+Rather than using the standard [x/distribution](/sdk/v0.53/build/modules/distribution/README) module, PoA implements its own fee mechanism:
 - Fees allocated proportionally to validator power (not delegated stake)
 - Validators withdraw fees on-demand
 - See [Fee Distribution](#fee-distribution) for complete details
 
 **Governance Without Staking**
 
-Standard SDK [governance](../../../x/gov/README.md) uses bonded tokens for voting weight. PoA replaces this with validator power:
+Standard SDK [governance](/sdk/v0.53/build/modules/gov/README) uses bonded tokens for voting weight. PoA replaces this with validator power:
 - Only active validators (power > 0) can submit, deposit, or vote on proposals
 - Voting weight determined by validator power, not token holdings
 - Prevents non-validator governance participation
@@ -90,13 +90,13 @@ The PoA module is controlled by a single admin address configured at genesis. Th
 
 The admin could be set to any authority that has an address. This includes a group from x/groups, the governance module account, and multisigs.
 
-**Location**: Admin address stored in [`x/poa/types/keys.go:10`](../x/poa/types/keys.go#L10) (params prefix)
+**Location**: Admin address stored in [`x/poa/types/keys.go:10`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/types/keys.go#L10) (params prefix)
 
 Only the admin can update itself with a parameter change.
 
 ### Managing Validator Set
 
-**MsgUpdateValidators** ([`x/poa/keeper/msg_server.go:72`](../x/poa/keeper/msg_server.go#L72))
+**MsgUpdateValidators** ([`x/poa/keeper/msg_server.go:72`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/msg_server.go#L72))
 
 The admin can batch update validators through a single transaction:
 
@@ -114,7 +114,7 @@ The admin can batch update validators through a single transaction:
 
 ### Updating Parameters
 
-**MsgUpdateParams** ([`x/poa/keeper/msg_server.go:26`](../x/poa/keeper/msg_server.go#L26))
+**MsgUpdateParams** ([`x/poa/keeper/msg_server.go:26`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/msg_server.go#L26))
 
 The admin can update module parameters (currently only the admin address itself). This requires:
 - Transaction signed by current admin
@@ -124,7 +124,7 @@ The admin can update module parameters (currently only the admin address itself)
 
 ### Validator Registration
 
-**MsgCreateValidator** ([`x/poa/keeper/msg_server.go:45`](../x/poa/keeper/msg_server.go#L45))
+**MsgCreateValidator** ([`x/poa/keeper/msg_server.go:45`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/msg_server.go#L45))
 
 **Permissionless Creation**: Any address can register as a validator candidate:
 
@@ -139,7 +139,7 @@ The admin can update module parameters (currently only the admin address itself)
    - Not earning fees
    - Cannot vote in governance
 
-**Location**: [`x/poa/keeper/validator.go:95`](../x/poa/keeper/validator.go#L95)
+**Location**: [`x/poa/keeper/validator.go:95`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/validator.go#L95)
 
 ### Gaining Consensus Power
 
@@ -157,7 +157,7 @@ Validators can only gain consensus power through admin action:
 - Power can be adjusted up or down by admin
 - Setting power = 0 removes validator from consensus without deleting
 
-**Location**: [`x/poa/keeper/validator.go:19`](../x/poa/keeper/validator.go#L19)
+**Location**: [`x/poa/keeper/validator.go:19`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/validator.go#L19)
 
 ### Removing Validators
 
@@ -182,7 +182,7 @@ The PoA module implements a custom checkpoint-based fee distribution system that
 
 **See [Fee Distribution Documentation](./distribution.md)** for complete details.
 
-**Location**: [`x/poa/keeper/distribution.go`](../x/poa/keeper/distribution.go)
+**Location**: [`x/poa/keeper/distribution.go`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/distribution.go)
 
 ## Governance
 
@@ -199,13 +199,13 @@ The PoA module restricts governance participation to active validators only, usi
 
 **See [Governance Documentation](./governance.md)** for complete details.
 
-**Location**: [`x/poa/keeper/governance.go`](../x/poa/keeper/governance.go) and [`x/poa/keeper/hooks.go`](../x/poa/keeper/hooks.go)
+**Location**: [`x/poa/keeper/governance.go`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/governance.go) and [`x/poa/keeper/hooks.go`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/hooks.go)
 
 ## Technical Implementation
 
 ### Storage Design
 
-**Collections Schema** ([`x/poa/types/keys.go`](../x/poa/types/keys.go))
+**Collections Schema** ([`x/poa/types/keys.go`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/types/keys.go))
 
 The module uses `cosmossdk.io/collections` for type-safe state management:
 
@@ -219,11 +219,11 @@ The module uses `cosmossdk.io/collections` for type-safe state management:
 | 5 | `total_allocated` | - | `ValidatorFees` | Sum of allocated fees |
 
 
-**Location**: [`x/poa/keeper/keeper.go:16`](../x/poa/keeper/keeper.go#L16)
+**Location**: [`x/poa/keeper/keeper.go:16`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/keeper.go#L16)
 
 ### ABCI Integration
 
-**EndBlocker** ([`x/poa/keeper/abci.go:9`](../x/poa/keeper/abci.go#L9))
+**EndBlocker** ([`x/poa/keeper/abci.go:9`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/abci.go#L9))
 
 The module integrates with CometBFT consensus through ABCI:
 
@@ -241,7 +241,7 @@ ValidatorUpdate {
 }
 ```
 
-**Location**: [`x/poa/module.go:128`](../x/poa/module.go#L128)
+**Location**: [`x/poa/module.go:128`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/module.go#L128)
 
 ## Security Considerations
 

--- a/enterprise/components/poa/distribution.mdx
+++ b/enterprise/components/poa/distribution.mdx
@@ -21,7 +21,7 @@ Fees flow through the PoA system differently than standard Cosmos SDK:
 
 **Why Checkpointing?**: Ensures fair distribution when power changes. If power changes mid-period, fees are allocated based on old power distribution before the change takes effect.
 
-**Location**: [`x/poa/keeper/distribution.go:18`](../x/poa/keeper/distribution.go#L18)
+**Location**: [`x/poa/keeper/distribution.go:18`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/distribution.go#L18)
 
 ## Distribution Algorithm
 
@@ -119,7 +119,7 @@ After this checkpoint, $A_{total}(t+1) = B_{collector}(t)$ (all fees are now all
 
 ## Withdrawing Fees
 
-**MsgWithdrawFees** ([`x/poa/keeper/msg_server.go:91`](../x/poa/keeper/msg_server.go#L91))
+**MsgWithdrawFees** ([`x/poa/keeper/msg_server.go:91`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/msg_server.go#L91))
 
 Any validator operator can withdraw accumulated fees:
 
@@ -137,7 +137,7 @@ Withdrawal:    100 utokens transferred to operator
 Remainder:     0.7543 utokens remain allocated (less than least significant utoken digit)
 ```
 
-**Location**: [`x/poa/keeper/distribution.go:106`](../x/poa/keeper/distribution.go#L106)
+**Location**: [`x/poa/keeper/distribution.go:106`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/distribution.go#L106)
 
 ## Withdrawal Formula
 

--- a/enterprise/components/poa/governance.mdx
+++ b/enterprise/components/poa/governance.mdx
@@ -13,7 +13,7 @@ The PoA module integrates with Cosmos SDK governance to restrict participation t
 
 The PoA module restricts governance participation to authorized validators only through governance hooks.
 
-**Governance Hooks** ([`x/poa/keeper/hooks.go`](../x/poa/keeper/hooks.go))
+**Governance Hooks** ([`x/poa/keeper/hooks.go`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/hooks.go))
 
 The module implements `govtypes.GovHooks`:
 
@@ -31,11 +31,11 @@ The module implements `govtypes.GovHooks`:
 - If validator has power = 0 → transaction fails
 - Error: "voter X is not an active PoA validator"
 
-**Location**: [`x/poa/keeper/governance.go:92`](../x/poa/keeper/governance.go#L92)
+**Location**: [`x/poa/keeper/governance.go:92`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/governance.go#L92)
 
 ## Voting Power
 
-**Custom Vote Tallying** ([`x/poa/keeper/governance.go:18`](../x/poa/keeper/governance.go#L18)). An example of the wiring can be found in the [SimApp](../simapp/app.go#L197-214).
+**Custom Vote Tallying** ([`x/poa/keeper/governance.go:18`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/governance.go#L18)). An example of the wiring can be found in the [SimApp](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/simapp/app.go#L197-214).
 
 Standard governance uses staked tokens as voting weight. PoA governance uses validator power:
 
@@ -146,7 +146,7 @@ When a vote is cast:
 
 At the end of the voting period, the [custom tally function](#vote-tallying-algorithm) is called:
 
-**NewPoACalculateVoteResultsAndVotingPowerFn** ([`x/poa/keeper/governance.go:18`](../x/poa/keeper/governance.go#L18))
+**NewPoACalculateVoteResultsAndVotingPowerFn** ([`x/poa/keeper/governance.go:18`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/governance.go#L18))
 
 1. Iterate all votes on the proposal
 2. For each vote, look up the validator by voter address
@@ -165,7 +165,7 @@ At the end of the voting period, the [custom tally function](#vote-tallying-algo
 
 ### Governance Hooks
 
-**Location**: [`x/poa/keeper/hooks.go`](../x/poa/keeper/hooks.go)
+**Location**: [`x/poa/keeper/hooks.go`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/hooks.go)
 
 The module implements the `govtypes.GovHooks` interface:
 
@@ -186,11 +186,11 @@ Each hook implementation:
 
 ### Custom Tally Function
 
-**Location**: [`x/poa/keeper/governance.go:18`](../x/poa/keeper/governance.go#L18)
+**Location**: [`x/poa/keeper/governance.go:18`](https://github.com/cosmos/cosmos-sdk/blob/main/enterprise/poa/x/poa/keeper/governance.go#L18)
 
 The tally function replaces the standard governance tally:
 
-```
+```go
 func NewPoACalculateVoteResultsAndVotingPowerFn(keeper) TallyFn {
     return func(ctx, proposal) (totalVotingPower, results) {
         // Iterate votes

--- a/enterprise/components/poa/overview.mdx
+++ b/enterprise/components/poa/overview.mdx
@@ -9,18 +9,18 @@ This directory contains detailed documentation for the Proof of Authority (PoA) 
 
 ## Available Documentation
 
-- **[API Reference](./api)** - Complete API reference for gRPC queries and transactions
-- **[Architecture](./architecture)** - System architecture and module integration details
-- **[Distribution](./distribution)** - Fee distribution mechanics and algorithms
-- **[Governance](./governance)** - Governance integration and power-based voting
+- **[API Reference](/enterprise/components/poa/api)** - Complete API reference for gRPC queries and transactions
+- **[Architecture](/enterprise/components/poa/architecture)** - System architecture and module integration details
+- **[Distribution](/enterprise/components/poa/distribution)** - Fee distribution mechanics and algorithms
+- **[Governance](/enterprise/components/poa/governance)** - Governance integration and power-based voting
 
 ## Architecture Diagram
 
-The module architecture is documented in the [Architecture](./architecture) section.
+The module architecture is documented in the [Architecture](/enterprise/components/poa/architecture) section.
 
 ## Quick Links
 
-- [Main Module README](../README.md)
-- [Core SDK Modules](../../../x/README.md)
-- [Enterprise Modules Overview](../../README.md)
+- [Main Module README](/enterprise/components/poa/overview)
+- [Core SDK Modules](/sdk/v0.53/build/modules/modules)
+- [Enterprise Modules Overview](/enterprise/overview)
 


### PR DESCRIPTION
## Summary

- Replace 32 broken relative file paths in the PoA enterprise docs (`architecture.mdx`, `distribution.mdx`, `governance.mdx`, `overview.mdx`)
- Source code links now point to the correct `cosmos/cosmos-sdk` GitHub URLs under `enterprise/poa/x/poa/`
- SDK module links (`x/staking`, `x/gov`, `x/auth`, `x/bank`, `x/distribution`) replaced with internal doc page links
- Relative `./` links in `overview.mdx` replaced with absolute internal paths

## Test plan

- [x] `npx mint broken-links` returns no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)