### PR TITLE
Fix getOfflineSignerAuto description and signer variant comments

### DIFF
--- a/cosmjs/v0.38.x/concepts/account/injected-wallets.mdx
+++ b/cosmjs/v0.38.x/concepts/account/injected-wallets.mdx
@@ -50,17 +50,18 @@ Keplr and similar wallets offer multiple signer variants:
 // Amino only — broadest compatibility, required for Ledger via Keplr
 const aminoSigner = window.keplr.getOfflineSignerOnlyAmino(chainId);
 
-// Auto (sync) — prefers Direct signing, falls back to Amino
+// Sync — returns both Direct and Amino signers simultaneously
 const autoSigner = window.keplr.getOfflineSigner(chainId);
 
-// Auto (async) — same auto-detection as getOfflineSigner, returns Promise<OfflineSigner>
+// Async — auto-selects Direct for mnemonic accounts, Amino for Ledger accounts
 const asyncSigner = await window.keplr.getOfflineSignerAuto(chainId);
 ```
 
 For most applications, `getOfflineSigner` is the right choice. It
-synchronously returns a signer that prefers Direct signing and falls back to
-Amino based on what the wallet supports. Use `getOfflineSignerAuto` when you
-need the async variant (e.g. for wallets that require async initialization).
+synchronously returns a signer that implements both `OfflineDirectSigner` and
+`OfflineAminoSigner`. Use `getOfflineSignerAuto` when you need async
+auto-detection — it returns `Promise<OfflineSigner>` and automatically selects
+Amino for Ledger-based accounts.
 
 ## Detecting the Extension
 

--- a/cosmjs/v0.38.x/concepts/account/injected-wallets.mdx
+++ b/cosmjs/v0.38.x/concepts/account/injected-wallets.mdx
@@ -50,15 +50,17 @@ Keplr and similar wallets offer multiple signer variants:
 // Amino only — broadest compatibility, required for Ledger via Keplr
 const aminoSigner = window.keplr.getOfflineSignerOnlyAmino(chainId);
 
-// Direct (Protobuf) preferred, falls back to Amino
+// Auto (sync) — prefers Direct signing, falls back to Amino
 const autoSigner = window.keplr.getOfflineSigner(chainId);
 
-// Direct only — most compact encoding, but not all features supported
-const directSigner = window.keplr.getOfflineSignerAuto(chainId);
+// Auto (async) — same auto-detection as getOfflineSigner, returns Promise<OfflineSigner>
+const asyncSigner = await window.keplr.getOfflineSignerAuto(chainId);
 ```
 
-For most applications, `getOfflineSigner` (the auto variant) is the right
-choice. It lets the wallet pick the best signing mode it supports.
+For most applications, `getOfflineSigner` is the right choice. It
+synchronously returns a signer that prefers Direct signing and falls back to
+Amino based on what the wallet supports. Use `getOfflineSignerAuto` when you
+need the async variant (e.g. for wallets that require async initialization).
 
 ## Detecting the Extension
 


### PR DESCRIPTION
PR review. 

Corrects the inline comments and prose description for the Keplr signer variants in the injected wallets doc:

- `getOfflineSigner` returns both `OfflineDirectSigner` and `OfflineAminoSigner` simultaneously (not "prefers Direct, falls back to Amino")
- `getOfflineSignerAuto` is async and auto-selects Amino for Ledger accounts, Direct for mnemonic accounts

Verified against `@keplr-wallet/types` type signatures.
