### PR TITLE
Remove bstm gas meter docs as unnecessary

### DIFF
--- a/sdk/next/experimental/blockstm.mdx
+++ b/sdk/next/experimental/blockstm.mdx
@@ -146,14 +146,6 @@ Once Block-STM is wired in, you may initially notice that most blocks execute sl
 
 Work has already been done within the SDK and Cosmos EVM for common transaction types such as bank sends and EVM gas sends. The following steps describe the additional configuration needed.
 
-### Disable the Block Gas Meter
-
-The block gas meter is difficult to support when executing transactions in parallel. Disabling it is safe if validators validate the total gas wanted in `ProcessProposal`, which is the case in the default handler.
-
-```go
-bApp.SetDisableBlockGasMeter(true)
-```
-
 ### Enable Virtual Fee Collection (EVM-specific)
 
 This alters how fee collection works for EVM transactions, accumulating fees to the fee collector module in the `EndBlocker` instead of using regular sends during transaction execution.


### PR DESCRIPTION
Updates the docs to reflect changes in https://github.com/cosmos/cosmos-sdk/pull/26138