### PR TITLE
docs: sync example tutorials from cosmos/example

### DIFF
--- a/sdk/next/tutorials/example/00-overview.mdx
+++ b/sdk/next/tutorials/example/00-overview.mdx
@@ -1,0 +1,36 @@
+---
+title: Build a Chain
+---
+
+The Cosmos SDK is a developer-first framework for building custom blockchains. This tutorial series shows you how to build a module from scratch, wire it into a chain, and run it locally, all in minutes.
+
+By the end, you will have:
+
+- A working Cosmos SDK chain running on your machine
+- A custom module you built yourself, wired into the chain
+- A clear mental model of how modules, keepers, messages, and queries fit together
+
+This series starts from zero; you don't need any prior Cosmos SDK experience to follow along.
+
+## The example repo
+
+All tutorials in this series are based on [cosmos/example](https://github.com/cosmos/example), a reference Cosmos SDK chain built around a custom `x/counter` module.
+
+The repo has two main branches:
+
+- `main`: the complete chain with the full `x/counter` module wired in. This is used in the [Quickstart guide](/sdk/next/tutorials/example/02-quickstart).
+- `tutorial/start`: the same chain without the counter module. The `x/counter` directory and its app wiring are stripped out so you can build the module from scratch by [following the tutorial](/sdk/next/tutorials/example/03-build-a-module).
+
+If you want to follow along and build the module yourself, start from `tutorial/start`. If you want to browse the finished implementation first, use `main`.
+
+## What's in this series
+
+1. [Prerequisites](/sdk/next/tutorials/example/01-prerequisites): Install Go, Make, Docker, and Git. Clone the repo and get familiar with the layout.
+
+2. [Quickstart](/sdk/next/tutorials/example/02-quickstart): Build and run the chain in minutes. Submit a transaction, query the result, and see the counter module in action before you build it yourself.
+
+3. [Build a Module from Scratch](/sdk/next/tutorials/example/03-build-a-module): Build a minimal counter module step by step: proto definitions, keeper, message server, query server, and app wiring. Start here if you want to understand how a module comes together.
+
+4. [Full Module Walkthrough](/sdk/next/tutorials/example/04-counter-walkthrough): Walk through the complete `x/counter` implementation on `main` with additional features. See how to add params, fees, governance-gated updates, sentinel errors, telemetry, and simulation on top of the minimal module.
+
+5. [Run and Test](/sdk/next/tutorials/example/05-run-and-test): Learn the full development workflow: running a local chain, using the CLI, and working with the three layers of testing: unit tests, end-to-end tests, and simulation.

--- a/sdk/next/tutorials/example/01-prerequisites.mdx
+++ b/sdk/next/tutorials/example/01-prerequisites.mdx
@@ -1,0 +1,99 @@
+---
+title: Prerequisites
+---
+
+Before starting the tutorial, make sure you have the following tools installed.
+
+<Warning>
+This tutorial is intended for macOS and Linux systems. Other systems may have additional requirements.
+</Warning>
+
+## Go
+
+The example chain requires Go 1.25 or higher. 
+
+```bash
+go version
+# go version go1.25.0 linux/amd64   # Linux
+# go version go1.25.0 darwin/arm64  # macOS
+```
+
+If Go is not installed, download it from [go.dev/dl](https://go.dev/dl).
+
+## Make
+
+Make is used to run build and development commands throughout the tutorial.
+
+```bash
+make --version
+# GNU Make 3.81
+```
+
+Make is pre-installed on most Linux and macOS systems. If it is missing:
+
+- **macOS:** `xcode-select --install`
+- **Linux (Debian/Ubuntu):** `sudo apt install build-essential`
+
+## Docker
+
+Docker is required to run `make proto-gen`, which generates Go code from the module's proto files using [buf](https://buf.build).
+
+```bash
+docker --version
+# Docker version 29.2.1
+```
+
+Download Docker from [docs.docker.com/get-docker](https://docs.docker.com/get-docker).
+
+Docker must be running before you execute `make proto-gen`.
+
+## Git
+
+```bash
+git --version
+# git version 2.52.0
+```
+
+## Clone the repository
+
+Clone [cosmos/example](https://github.com/cosmos/example) and navigate into it:
+
+```bash
+git clone https://github.com/cosmos/example
+cd example
+```
+
+The repo has two branches used in this tutorial series:
+
+- `main` — the complete chain with the full `x/counter` module wired in.
+- `tutorial/start` — the same chain with the counter module stripped out. Start here if you want to build the module yourself from scratch.
+
+## Repository Layout
+
+After cloning, the repository looks like this:
+
+```text
+example/
+├── exampled/         # Binary entrypoint (main.go + CLI root command)
+├── app.go            # Chain application, module wiring lives here
+├── proto/            # Proto definitions for all modules
+├── x/                # Module implementations
+│   └── counter/      # The example counter module
+├── tests/            # E2E and integration tests
+├── scripts/          # Local node and proto generation scripts
+├── docs/             # This tutorial series
+└── Makefile          # Build, test, and dev commands
+```
+
+## Where things live
+
+The tutorials in this section will walk you through the most common kinds of chain changes and show you where they usually live in the repo:
+
+- Add or modify a module: `x/<module>/` and `proto/`
+- Wire a module into the chain: `app.go`
+- Change the binary or CLI: `exampled/`
+- Run the chain or tests: `Makefile` targets
+
+---
+
+Next: [Quickstart →](/sdk/next/tutorials/example/02-quickstart)

--- a/sdk/next/tutorials/example/02-quickstart.mdx
+++ b/sdk/next/tutorials/example/02-quickstart.mdx
@@ -1,0 +1,105 @@
+---
+title: Quickstart
+---
+
+Building on Cosmos is simple: you can start a chain with a [single command](#start-the-chain). This quickstart gets you from zero to a running chain, a submitted transaction, and a queried result in minutes.
+
+`exampled` is a simple Cosmos SDK chain that shows the core pieces of a working app chain. It includes the basic building-block modules for accounts, bank, staking, distribution, slashing, governance, and more, plus a custom `x/counter` module. In the next tutorials, you'll build a simple version of that module yourself and then walk through the full implementation.
+
+<Note>
+Before continuing, make sure you have completed the [Prerequisites](/sdk/next/tutorials/example/01-prerequisites) to get your environment set up.
+</Note>
+
+## Install the binary
+
+Run the following to compile the `exampled` binary and place it on your `$PATH`.
+
+```bash
+make install
+```
+
+Verify the install by running:
+
+```bash
+exampled version
+```
+
+You can also run the following to see all available node CLI commands:
+
+```bash
+exampled
+```
+
+## Start the chain
+
+Run the following to start a single-node local chain. It handles all setup automatically: initializes the chain data, creates test accounts, and starts the node. Leave it running in this terminal.
+
+```bash
+make start
+```
+
+## Query the counter
+
+Open a second terminal and query the current count:
+
+```bash
+exampled query counter count
+```
+
+You should see the following output, which means the counter is starting at `0`:
+
+
+```text
+{}
+```
+
+You can also query the module parameters:
+
+```bash
+exampled query counter params
+```
+
+This shows that the fee to increment the counter is stored as a module parameter. The base coin denomination for the `exampled` chain is `stake`.
+
+```yaml
+params:
+  add_cost:
+    - amount: "100"
+      denom: stake
+  max_add_value: "100"
+```
+
+## Submit an add transaction
+
+Send an `Add` transaction to increment the counter. This charges a fee from the funded `alice` account you are sending the transaction from:
+
+```bash
+exampled tx counter add 5 --from alice --chain-id demo --yes
+```
+
+## Query the counter again
+
+After submitting the transaction, query the counter again to see the updated module state:
+
+```bash
+exampled query counter count
+```
+
+You should see the following:
+
+```
+count: "5"
+```
+
+Congratulations! You just ran a blockchain, submitted a transaction, and queried module state.
+
+## Next steps
+
+In the following tutorials, you will:
+
+1. Build a minimal version of this module from scratch to understand the core pattern
+2. Walk through the full `x/counter` module example to see what it adds
+3. See how modules are wired into a chain and how to run the full test suite
+
+
+Next: [Build a Module from Scratch →](/sdk/next/tutorials/example/03-build-a-module)

--- a/sdk/next/tutorials/example/03-build-a-module.mdx
+++ b/sdk/next/tutorials/example/03-build-a-module.mdx
@@ -1,0 +1,745 @@
+---
+title: Build a Module from Scratch
+---
+
+In [quickstart](/sdk/next/tutorials/example/02-quickstart), you started a chain and submitted a transaction to increase the counter. In this tutorial, you'll build a simple counter module from scratch. It follows the same overall structure as the full `x/counter`, but uses a stripped-down version so you can focus on the core steps of building and wiring a module yourself.
+
+By the end, you'll have built a working module and wired it into a running chain. For a deeper dive into how modules work in the Cosmos SDK, see [Intro to Modules](/sdk/next/learn/concepts/modules).
+
+<Note>
+Before continuing, you must follow the [Prerequisites guide](/sdk/next/tutorials/example/01-prerequisites) to make sure everything is installed.
+</Note>
+
+## Making modules
+
+The Cosmos SDK makes it easy to build custom business logic directly into your chain through modules. Every module follows the same overall pattern:
+
+```text
+proto files → code generation → keeper → msg server → query server → module.go → app wiring
+```
+
+First, you'll define what the module does:
+
+- Define messages: users can send `Add` to increase the counter
+- Define queries: users can query `Count` to read the current value
+- Define genesis state: the module starts with a count of `0`
+
+Then you'll wire that behavior into the SDK:
+
+- Run `proto-gen` to generate the Go types and interfaces
+- Implement your business logic in a `keeper` to store the count and update it
+- Implement `MsgServer` and `QueryServer` to pass messages and queries into the keeper
+- Register the module in `module.go`
+- Wire it into the chain in `app.go`
+
+You'll build the following module structure:
+
+```text
+proto/example/counter/v1/
+├── tx.proto            # Transaction message and Msg service definition
+├── query.proto         # Query message and Query service definition
+└── genesis.proto       # Genesis state definition
+
+x/counter/
+├── keeper/
+│   ├── keeper.go         # Keeper struct and state methods
+│   ├── msg_server.go     # MsgServer implementation
+│   └── query_server.go   # QueryServer implementation
+├── types/
+│   ├── keys.go           # Module name and store key constants
+│   ├── codec.go          # Interface registration
+│   └── *.pb.go           # Generated from proto — do not edit
+├── module.go             # AppModule wiring
+└── autocli.go            # CLI command definitions
+```
+
+## Step 1: Setup
+
+This tutorial uses the `tutorial/start` branch, which is a blank template for you to create the module from scratch and wire it into `app.go`.
+
+1. Clone the repo if you haven't already:
+
+```bash
+git clone https://github.com/cosmos/example
+cd example
+```
+
+2. Check out the `tutorial/start` branch and make the new module directories:
+
+```bash
+git checkout tutorial/start
+mkdir -p x/counter/keeper x/counter/types proto/example/counter/v1
+```
+
+You should see empty placeholder directories at `x/counter/` and `proto/example/counter/v1/`.
+
+## Step 2: Proto files
+
+Proto files are the source of truth for the module's public API. You define messages and services here. For a deeper look at how protobuf is used across modules, see [Encoding and Protobuf](/sdk/next/learn/concepts/encoding#how-protobuf-is-used-in-modules).
+
+In this tutorial, the counter module stores one number, `Add` increases it by the amount the user submits, and the query returns the current value. 
+
+First, create the three proto files:
+
+```bash
+touch proto/example/counter/v1/tx.proto \
+  proto/example/counter/v1/query.proto \
+  proto/example/counter/v1/genesis.proto
+```
+
+Then add the following contents to each file.
+
+### tx.proto
+
+This is the first module file you define. It declares the transaction message shape for `Add`: what the user sends to increment the counter, and what the module returns after handling it. To learn more about how messages are defined and routed, see [Messages](/sdk/next/learn/concepts/transactions#messages). Add the following code to `tx.proto`.
+
+```proto
+syntax = "proto3";
+
+// Matches the module's protobuf namespace.
+package example.counter;
+
+// Provides Cosmos SDK message annotations like signer and service markers.
+import "cosmos/msg/v1/msg.proto";
+
+// Generated Go types are written into x/counter/types.
+option go_package = "github.com/cosmos/example/x/counter/types";
+
+service Msg {
+  // Marks this as a transaction service, not a normal gRPC service.
+  option (cosmos.msg.v1.service) = true;
+  // Add is the one transaction this minimal module supports.
+  rpc Add(MsgAddRequest) returns (MsgAddResponse);
+}
+
+message MsgAddRequest {
+  // The sender signs this message.
+  option (cosmos.msg.v1.signer) = "sender";
+  string sender = 1;
+  uint64 add    = 2;
+}
+
+message MsgAddResponse {
+  // Return the new counter value after the add succeeds.
+  uint64 updated_count = 1;
+}
+```
+
+### query.proto
+
+This file defines the read-only gRPC query service and the response type for fetching the current count. To learn more about how queries differ from transactions, see [Queries](/sdk/next/learn/concepts/transactions#queries). Add the following code to `query.proto`.
+
+```proto
+syntax = "proto3";
+
+// Matches the module's protobuf namespace.
+package example.counter;
+
+// Enables the REST gateway route annotation below.
+import "google/api/annotations.proto";
+
+// Generated Go types are written into x/counter/types.
+option go_package = "github.com/cosmos/example/x/counter/types";
+
+service Query {
+  rpc Count(QueryCountRequest) returns (QueryCountResponse) {
+    // Exposes this query over the HTTP API as well as gRPC.
+    option (google.api.http).get = "/example/counter/v1/count";
+  }
+}
+
+// Empty because this query only needs the module's current state.
+message QueryCountRequest  {}
+
+message QueryCountResponse {
+  // The current counter value.
+  uint64 count = 1;
+}
+```
+
+### genesis.proto
+
+This file defines the data the module stores in genesis so the counter can be initialized when the chain starts. Add the following code to `genesis.proto`.
+
+```proto
+syntax = "proto3";
+
+// Matches the module's protobuf namespace.
+package example.counter;
+
+// Generated Go types are written into x/counter/types.
+option go_package = "github.com/cosmos/example/x/counter/types";
+
+message GenesisState {
+  // The counter value to load when the chain initializes.
+  uint64 count = 1;
+}
+```
+
+## Step 3: Generate Code
+
+1. Make sure Docker is running. 
+
+2. The first time you run proto-gen you need to build the builder image. Run the following commands:
+
+```bash
+make proto-image-build
+make proto-gen
+```
+
+This compiles the proto files using [buf](https://buf.build) inside Docker to produce the Go interfaces you will then implement.
+
+The generated files will appear in `x/counter/types/`:
+
+```text
+x/counter/types/
+├── tx.pb.go         # MsgAddRequest, MsgAddResponse, MsgServer interface
+├── query.pb.go      # QueryCountRequest, QueryCountResponse, QueryServer interface
+├── query.pb.gw.go   # REST gateway registration
+└── genesis.pb.go    # GenesisState
+```
+
+> **Do not edit generated files.** Changes to public types belong in the proto files. Re-run `make proto-gen` after any proto change.
+
+The most important generated output is the `MsgServer` and `QueryServer` interfaces. In Steps 5 and 6, you'll implement them in `keeper/msg_server.go` and `keeper/query_server.go`.
+
+
+## Step 4: Types
+
+Next, you'll define the module types and identifiers in `x/counter/types` that the rest of the module depends on.
+
+Create the two files for this section:
+
+```bash
+touch x/counter/types/keys.go \
+  x/counter/types/codec.go
+```
+
+Then add the following contents to each file.
+
+### keys.go
+
+This file defines the module's basic identifiers: the module name used throughout the SDK, and the store key used to claim the module's KV store namespace. For more on how modules access state through store keys, see [How modules access state](/sdk/next/learn/concepts/store#how-modules-access-state).
+
+```go
+// x/counter/types/keys.go
+package types
+
+const (
+    // ModuleName is the name the SDK uses to refer to this module.
+    ModuleName = "counter"
+    // StoreKey is the key for this module's KV store.
+    StoreKey   = ModuleName
+)
+```
+
+`ModuleName` identifies the module throughout the SDK (routing, events, governance). `StoreKey` is the key used to claim the module's isolated namespace in the chain's KV store (set equal to `ModuleName` by convention).
+
+### Interface Registration
+
+This file registers your generated message types with the SDK interface registry so the application can decode and route your module's transactions correctly.
+
+```go
+// x/counter/types/codec.go
+package types
+
+import (
+    codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+    sdk        "github.com/cosmos/cosmos-sdk/types"
+    "github.com/cosmos/cosmos-sdk/types/msgservice"
+)
+
+func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
+    // Register MsgAddRequest as an sdk.Msg so the app can decode it from transactions.
+    registry.RegisterImplementations((*sdk.Msg)(nil),
+        &MsgAddRequest{},
+    )
+    // Register the generated Msg service description for routing.
+    msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
+}
+```
+
+`_Msg_serviceDesc` is generated by `make proto-gen` — it describes the `Msg` gRPC service defined in `tx.proto`.
+
+
+## Step 5: Keeper
+
+In this step, you create the keeper, which is the part of the module that owns the counter state and provides the methods the rest of the module will call. For a conceptual overview of the keeper's role, see [Keeper](/sdk/next/learn/concepts/modules#keeper).
+
+Create the keeper file:
+
+```bash
+touch x/counter/keeper/keeper.go
+```
+
+Then add the following contents.
+
+This file defines the keeper struct, sets up the counter's storage item, and implements the core state methods for reading, updating, and loading the counter at genesis.
+
+```go
+// x/counter/keeper/keeper.go
+package keeper
+
+import (
+    "context"
+    "errors"
+
+    "cosmossdk.io/collections"
+    "cosmossdk.io/core/store"
+    "github.com/cosmos/cosmos-sdk/codec"
+    "github.com/cosmos/example/x/counter/types"
+)
+
+type Keeper struct {
+    Schema  collections.Schema
+    counter collections.Item[uint64]
+}
+
+func NewKeeper(storeService store.KVStoreService, cdc codec.Codec) *Keeper {
+    sb := collections.NewSchemaBuilder(storeService)
+    k := Keeper{
+        // Store the counter under prefix 0 in this module's KV store.
+        counter: collections.NewItem(sb, collections.NewPrefix(0), "counter", collections.Uint64Value),
+    }
+    schema, err := sb.Build()
+    if err != nil {
+        panic(err)
+    }
+    k.Schema = schema
+    return &k
+}
+
+func (k *Keeper) GetCount(ctx context.Context) (uint64, error) {
+    count, err := k.counter.Get(ctx)
+    // Treat missing state as zero so a fresh chain starts cleanly.
+    if err != nil && !errors.Is(err, collections.ErrNotFound) {
+        return 0, err
+    }
+    return count, nil
+}
+
+func (k *Keeper) AddCount(ctx context.Context, amount uint64) (uint64, error) {
+    count, err := k.GetCount(ctx)
+    if err != nil {
+        return 0, err
+    }
+    // Increment the current count and write it back to state.
+    newCount := count + amount
+    return newCount, k.counter.Set(ctx, newCount)
+}
+
+func (k *Keeper) InitGenesis(ctx context.Context, gs *types.GenesisState) error {
+    return k.counter.Set(ctx, gs.Count)
+}
+
+func (k *Keeper) ExportGenesis(ctx context.Context) (*types.GenesisState, error) {
+    count, err := k.GetCount(ctx)
+    if err != nil {
+        return nil, err
+    }
+    return &types.GenesisState{Count: count}, nil
+}
+```
+
+`collections.Item[uint64]` is a typed KV store entry; the `collections` package handles encoding and namespacing. `GetCount` treats `ErrNotFound` as zero so the counter starts at zero without explicit initialization.
+
+> **State layout**
+>
+> - `StoreKey` (`"counter"`) is the module's isolated namespace within the chain's global KV store. No other module can read or write this namespace.
+> - `collections.NewPrefix(0)` is a single-byte prefix that identifies the `counter` item within the module's namespace. A module with multiple items would use `NewPrefix(0)`, `NewPrefix(1)`, etc. to keep them separate.
+> - `ErrNotFound` treated as zero means the keeper never needs to explicitly set an initial value — the first `GetCount` call on a fresh chain returns `0` by convention.
+
+
+## Step 6: MsgServer
+
+In this step, you implement the transaction handler for the generated `MsgServer` interface. This is the code path that runs when a user submits `tx counter add`. For a conceptual overview of message execution, see [Message execution](/sdk/next/learn/concepts/modules#message-execution-msgserver).
+
+Create the message server file:
+
+```bash
+touch x/counter/keeper/msg_server.go
+```
+
+Then add the following contents.
+
+This file implements the generated `MsgServer` interface and forwards the `Add` transaction to the keeper's `AddCount` method.
+
+```go
+// x/counter/keeper/msg_server.go
+package keeper
+
+import (
+    "context"
+
+    "github.com/cosmos/example/x/counter/types"
+)
+
+type msgServer struct {
+    *Keeper
+}
+
+func NewMsgServerImpl(k *Keeper) types.MsgServer {
+    return &msgServer{k}
+}
+
+func (m msgServer) Add(ctx context.Context, req *types.MsgAddRequest) (*types.MsgAddResponse, error) {
+    // Delegate the state update to the keeper.
+    newCount, err := m.AddCount(ctx, req.GetAdd())
+    if err != nil {
+        return nil, err
+    }
+    // Return the updated count back to the caller.
+    return &types.MsgAddResponse{UpdatedCount: newCount}, nil
+}
+```
+
+`msgServer` embeds `*Keeper` and delegates directly to `AddCount`. The handler itself contains no business logic.
+
+
+## Step 7: QueryServer
+
+In this step, you implement the read-only query handler for the generated `QueryServer` interface. This is the code path that runs when someone queries the current counter value. For more on how modules expose queries, see [Queries](/sdk/next/learn/concepts/modules#queries).
+
+Create the query server file:
+
+```bash
+touch x/counter/keeper/query_server.go
+```
+
+Then add the following contents.
+
+This file implements the generated `QueryServer` interface and returns the current counter value from the keeper.
+
+```go
+// x/counter/keeper/query_server.go
+package keeper
+
+import (
+    "context"
+
+    "github.com/cosmos/example/x/counter/types"
+)
+
+type queryServer struct {
+    *Keeper
+}
+
+func NewQueryServer(k *Keeper) types.QueryServer {
+    return &queryServer{k}
+}
+
+func (q queryServer) Count(ctx context.Context, _ *types.QueryCountRequest) (*types.QueryCountResponse, error) {
+    // Read the current count from state and return it in the query response.
+    count, err := q.GetCount(ctx)
+    if err != nil {
+        return nil, err
+    }
+    return &types.QueryCountResponse{Count: count}, nil
+}
+```
+
+
+## Step 8: module.go
+
+In this step, you connect your keeper and generated services to the Cosmos SDK module framework so the application knows how to initialize the module, expose its query routes, and register its transaction handlers.
+
+Create the module file:
+
+```bash
+touch x/counter/module.go
+```
+
+Then add the following contents.
+
+This file defines the app module types and wires your keeper into genesis handling, service registration, and gRPC gateway registration.
+
+```go
+// x/counter/module.go
+package counter
+
+import (
+    "context"
+    "encoding/json"
+
+    "cosmossdk.io/core/appmodule"
+    "github.com/cosmos/cosmos-sdk/client"
+    "github.com/cosmos/cosmos-sdk/codec"
+    codecTypes "github.com/cosmos/cosmos-sdk/codec/types"
+    sdk "github.com/cosmos/cosmos-sdk/types"
+    "github.com/cosmos/cosmos-sdk/types/module"
+    "github.com/grpc-ecosystem/grpc-gateway/runtime"
+
+    "github.com/cosmos/example/x/counter/keeper"
+    countertypes "github.com/cosmos/example/x/counter/types"
+)
+
+var (
+    // Compile-time checks that AppModule implements the required module interfaces.
+    _ appmodule.AppModule        = AppModule{}
+    _ module.HasConsensusVersion = AppModule{}
+    _ module.HasGenesis          = AppModule{}
+    _ module.HasServices         = AppModule{}
+)
+
+type AppModuleBasic struct {
+    cdc codec.Codec
+}
+
+func (a AppModuleBasic) Name() string { return countertypes.ModuleName }
+
+func (a AppModuleBasic) RegisterLegacyAminoCodec(*codec.LegacyAmino) {}
+
+func (a AppModuleBasic) RegisterInterfaces(registry codecTypes.InterfaceRegistry) {
+    countertypes.RegisterInterfaces(registry)
+}
+
+func (a AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+    // Start the module with a zero counter by default.
+    return cdc.MustMarshalJSON(&countertypes.GenesisState{Count: 0})
+}
+
+func (a AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, _ client.TxEncodingConfig, bz json.RawMessage) error {
+    gs := countertypes.GenesisState{}
+    return cdc.UnmarshalJSON(bz, &gs)
+}
+
+func (a AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
+    // Expose the Query service through the HTTP gateway.
+    if err := countertypes.RegisterQueryHandlerClient(context.Background(), mux, countertypes.NewQueryClient(clientCtx)); err != nil {
+        panic(err)
+    }
+}
+
+type AppModule struct {
+    AppModuleBasic
+    keeper *keeper.Keeper
+}
+
+func NewAppModule(cdc codec.Codec, k *keeper.Keeper) AppModule {
+    return AppModule{AppModuleBasic: AppModuleBasic{cdc: cdc}, keeper: k}
+}
+
+func (a AppModule) IsOnePerModuleType() {}
+func (a AppModule) IsAppModule()        {}
+
+func (a AppModule) ConsensusVersion() uint64 { return 1 }
+
+func (a AppModule) RegisterServices(cfg module.Configurator) {
+    // Connect the generated service interfaces to your keeper-backed implementations.
+    countertypes.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(a.keeper))
+    countertypes.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServer(a.keeper))
+}
+
+func (a AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, bz json.RawMessage) {
+    gs := &countertypes.GenesisState{}
+    cdc.MustUnmarshalJSON(bz, gs)
+    // Load the initial counter value into state at chain start.
+    if err := a.keeper.InitGenesis(ctx, gs); err != nil {
+        panic(err)
+    }
+}
+
+func (a AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
+    gs, err := a.keeper.ExportGenesis(ctx)
+    if err != nil {
+        panic(err)
+    }
+    // Write the current counter value back out for exports.
+    return cdc.MustMarshalJSON(gs)
+}
+```
+
+The `var _ interface = Struct{}` block at the top is a Go compile-time check — if the struct is missing any required method, the build fails immediately.
+
+`RegisterServices` is the most important method. It connects the generated server interfaces to your implementations, making them reachable from the SDK's message and query routers.
+
+
+## Step 9: AutoCLI
+
+In this step, you define the CLI metadata for your module. AutoCLI reads this configuration together with your proto services and generates the `exampled query counter` and `exampled tx counter` commands automatically.
+
+Create the AutoCLI file:
+
+```bash
+touch x/counter/autocli.go
+```
+
+Then add the following contents.
+
+This file tells `AutoCLI` how to expose the `Count` query and `Add` transaction as simple command-line commands.
+
+```go
+// x/counter/autocli.go
+package counter
+
+import (
+    autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
+)
+
+func (a AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
+    return &autocliv1.ModuleOptions{
+        Query: &autocliv1.ServiceCommandDescriptor{
+            Service: "example.counter.Query",
+            RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+                // exampled query counter count
+                {RpcMethod: "Count", Use: "count", Short: "Query the current counter value"},
+            },
+        },
+        Tx: &autocliv1.ServiceCommandDescriptor{
+            Service: "example.counter.Msg",
+            RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+                // exampled tx counter add 4 --from alice
+                {RpcMethod: "Add", Use: "add [amount]", Short: "Add to the counter",
+                    PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "add"}}},
+            },
+        },
+    }
+}
+```
+
+`PositionalArgs` maps the first CLI argument to the `add` field in `MsgAddRequest`, so `add 4` works instead of `add --add 4`.
+
+
+## Step 10: Wire into app.go
+
+In this step, you wire your new module into the application so the chain creates its store, constructs its keeper, and includes it in module startup and genesis handling. For a full explanation of what `app.go` does and why the wiring order matters, see [app.go Overview](/sdk/next/learn/concepts/app-go).
+
+Open `app.go`. Each code block below starts with the exact marker comment to look for in the file. Paste your code directly below each marker.
+
+### 1. Imports
+
+Add the counter module, keeper, and shared types imports to `app.go`.
+
+```go
+// counter tutorial app wiring 1: add counter imports here
+	counter       "github.com/cosmos/example/x/counter"
+	counterkeeper "github.com/cosmos/example/x/counter/keeper"
+	countertypes  "github.com/cosmos/example/x/counter/types"
+```
+
+### 2. Keeper Field
+
+Store the counter keeper on `ExampleApp` so the rest of the app can reference it.
+
+```go
+// counter tutorial app wiring 2: add the counter keeper field here
+CounterKeeper         *counterkeeper.Keeper
+```
+
+### 3. Store Key
+
+Give the counter module its own KV store namespace.
+
+```go
+// counter tutorial app wiring 3: add the counter store key here
+countertypes.StoreKey,
+```
+
+### 4. Keeper Instantiation
+
+Construct the counter keeper using the module store and app codec.
+
+```go
+// counter tutorial app wiring 4: create the counter keeper here
+app.CounterKeeper = counterkeeper.NewKeeper(
+	runtime.NewKVStoreService(keys[countertypes.StoreKey]),
+	appCodec,
+)
+```
+
+### 5. Module Manager
+
+Register the counter module with the app's module manager.
+
+```go
+// counter tutorial app wiring 5: register the counter module here
+counter.NewAppModule(appCodec, app.CounterKeeper),
+```
+
+### 6. Genesis Order
+
+Include the counter module when the app initializes state from genesis.
+
+```go
+// counter tutorial app wiring 6: add the counter module to genesis order here
+countertypes.ModuleName,
+```
+
+### 7. Export Order
+
+Include the counter module when the app exports state back out to genesis.
+
+```go
+// counter tutorial app wiring 7: add the counter module to export order here
+countertypes.ModuleName,
+```
+
+
+## Step 11: Build
+
+Run the following to compile the app and make sure the new module wiring is valid before you try to run the chain.
+
+```bash
+go build ./...
+```
+
+Fix any compilation errors before continuing.
+
+
+## Step 12: Test your module
+
+Now you'll run the app locally and use one transaction plus one query to confirm the module works end-to-end.
+
+### Start the chain
+
+First, install the binary and start the demo chain.
+
+```bash
+make install
+make start
+```
+
+This builds and installs `exampled` and then runs `scripts/local_node.sh`, which:
+- resets the local chain data
+- initializes genesis
+- creates and funds the `alice` and `bob` test accounts
+- creates a validator transaction
+- starts the chain
+
+You'll see the chain running and it should start producing blocks. 
+
+### Submit a transaction
+
+Open a second terminal and submit a transaction that adds `4` to the counter:
+
+```bash
+exampled tx counter add 4 --from alice --chain-id demo --yes
+```
+
+If the transaction succeeds, the response should include `code: 0`, which means the chain accepted and executed the transaction without an application error:
+
+```
+code: 0
+```
+
+### Query the chain
+
+Query the counter to confirm the stored value changed using the query command that `AutoCLI` generated earlier:
+
+```bash
+exampled query counter count
+```
+
+You should see the following output:
+
+```text
+count: "4"
+```
+
+Congratulations, you've just created a Cosmos module from scratch and wired it into a real chain!
+
+## Next steps
+
+The simple counter module you built here follows the same structure as the full `x/counter` example in the `main` branch. Next, you'll see how the full module extends that foundation with features like params, fee collection, tests, and more.
+
+Next: [Full Counter Module Walkthrough →](/sdk/next/tutorials/example/04-counter-walkthrough)

--- a/sdk/next/tutorials/example/04-counter-walkthrough.mdx
+++ b/sdk/next/tutorials/example/04-counter-walkthrough.mdx
@@ -1,0 +1,565 @@
+---
+title: Full Counter Module Walkthrough
+---
+
+If you came here from the module building tutorial, switch back to the `main` branch of the [`cosmos/example` repo](https://github.com/cosmos/example) first:
+
+```bash
+git checkout main
+```
+
+The minimal counter you built in the previous tutorial captures the core SDK module pattern. The full `x/counter` module example in `main` follows the same pattern and adds several features on top.
+
+This walkthrough is meant to show you exactly what each feature is, what it does, and how you can add a similar feature to any module.
+
+## Minimal vs full counter
+
+The full counter in the `main` branch adds quite a bit of functionality to the minimal tutorial counter.
+
+| Feature | minimal x/counter | full x/counter |
+|---|---|---|
+| [State](#params-and-authority) | `count` | `count` + `params` |
+| [Messages](#params-and-authority) | `Add` | `Add` + `UpdateParams` |
+| [Queries](#params-and-authority) | `Count` | `Count` + `Params` |
+| [Validation](#expected-keepers-and-fee-collection) | None | `MaxAddValue` limit, overflow check |
+| [Fees](#expected-keepers-and-fee-collection) | None | `AddCost` charged via bank module |
+| [Authority](#params-and-authority) | None | Governance-gated param updates |
+| [Errors](#sentinel-errors) | Generic | Named sentinel errors |
+| [Telemetry](#telemetry) | None | OpenTelemetry counter metric |
+| [CLI](#autocli) | AutoCLI | AutoCLI + `EnhanceCustomCommand` |
+| [Simulation](#simulation) | None | `simsx` weighted operations |
+| [Block hooks](#beginblock-and-endblock) | None | `BeginBlock` + `EndBlock` |
+| [Unit tests](#unit-tests) | None | Full keeper/msg/query test suite |
+
+The wiring code in [`msg_server.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/msg_server.go), [`query_server.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/query_server.go), [`module.go`](https://github.com/cosmos/example/blob/main/x/counter/module.go), and [`types/`](https://github.com/cosmos/example/tree/main/x/counter/types) is structurally similar between the two. Much of the new keeper logic lives in a single method: `AddCount` in [`keeper.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/keeper.go).
+
+## Params and authority
+
+A [module param](/sdk/next/learn/concepts/modules#params) is on-chain configuration that controls how the module behaves without changing the code.
+
+The full counter adds a `Params` type that lets the chain governance configure the module's behavior at runtime. In the full module, params control how large an `Add` can be and how much it costs.
+
+### Where the code lives
+
+- [`proto/example/counter/v1/state.proto`](https://github.com/cosmos/example/blob/main/proto/example/counter/v1/state.proto) defines the `Params` type
+- [`proto/example/counter/v1/tx.proto`](https://github.com/cosmos/example/blob/main/proto/example/counter/v1/tx.proto) adds the `UpdateParams` message
+- [`proto/example/counter/v1/query.proto`](https://github.com/cosmos/example/blob/main/proto/example/counter/v1/query.proto) adds the `Params` query
+- [`x/counter/keeper/keeper.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/keeper.go) stores the params and authority
+- [`x/counter/keeper/msg_server.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/msg_server.go) checks the authority on updates
+- [`x/counter/keeper/query_server.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/query_server.go) returns the current params
+
+### Try it
+
+You can inspect the current params with:
+
+```bash
+exampled query counter params
+```
+
+### Add this to your module
+
+To add runtime-configurable params to your own module, make these changes:
+
+1. Define a `Params` type in proto
+2. Add a privileged `UpdateParams` message
+3. Add a query to read the current params
+4. Store the params and authority in your keeper
+5. Check the authority in `MsgServer` before writing new params
+
+### state.proto
+
+The relevant addition in [`state.proto`](https://github.com/cosmos/example/blob/main/proto/example/counter/v1/state.proto) is:
+
+```proto
+message Params {
+  uint64 max_add_value = 1;
+  repeated cosmos.base.v1beta1.Coin add_cost = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins",
+    (amino.dont_omitempty) = true
+  ];
+}
+```
+
+`MaxAddValue` caps how much a single `Add` call can increment the counter. `AddCost` sets an optional fee charged for each add operation.
+
+### tx.proto - UpdateParams
+
+The relevant addition in [`tx.proto`](https://github.com/cosmos/example/blob/main/proto/example/counter/v1/tx.proto) is:
+
+```proto
+rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
+
+message MsgUpdateParams {
+  option (cosmos.msg.v1.signer) = "authority";
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  Params params = 2 [(gogoproto.nullable) = false];
+}
+
+message MsgUpdateParamsResponse {}
+```
+
+`UpdateParams` is a privileged message. Only the `authority` address can call it. By default that address is the governance module account, so params can only be changed through a governance proposal.
+
+### query.proto - Params
+
+[`query.proto`](https://github.com/cosmos/example/blob/main/proto/example/counter/v1/query.proto) adds a second query to expose the current params:
+
+```proto
+rpc Params(QueryParamsRequest) returns (QueryParamsResponse);
+```
+
+### The authority pattern
+
+The keeper stores the authority address and checks it on every `UpdateParams` call:
+
+```go
+type Keeper struct {
+    // ...
+    // authority is the address capable of executing a MsgUpdateParams message.
+    // Typically, this should be the x/gov module account.
+    authority string
+}
+```
+
+```go
+// msg_server.go
+func (m msgServer) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
+    if m.authority != msg.Authority {
+        return nil, sdkerrors.Wrapf(govtypes.ErrInvalidSigner,
+            "invalid authority; expected %s, got %s", m.authority, msg.Authority)
+    }
+    return &types.MsgUpdateParamsResponse{}, m.SetParams(ctx, msg.Params)
+}
+```
+
+The authority defaults to the governance module account at keeper construction:
+
+```go
+authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+```
+
+This pattern, storing authority in the keeper and checking it in `MsgServer`, is the standard Cosmos SDK approach to governance-gated configuration.
+
+
+## Expected keepers and fee collection
+
+This section shows the standard Cosmos SDK pattern for [module-to-module interaction](/sdk/next/learn/concepts/modules#inter-module-access). `x/counter` uses an expected keeper to call into the bank module and charge a fee for each add operation.
+
+### Where the code lives
+
+- [`x/counter/types/expected_keepers.go`](https://github.com/cosmos/example/blob/main/x/counter/types/expected_keepers.go) defines the narrow bank keeper interface
+- [`x/counter/keeper/keeper.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/keeper.go) stores the bank keeper dependency and charges the fee in `AddCount`
+- [`app.go`](https://github.com/cosmos/example/blob/main/app.go) passes `app.BankKeeper` into `counterkeeper.NewKeeper`
+- [`app.go`](https://github.com/cosmos/example/blob/main/app.go) adds a module account entry so the counter module can receive fees
+
+### app.go changes
+
+This feature requires two `app.go` changes:
+
+- add `countertypes.ModuleName: nil` to `maccPerms`
+- pass `app.BankKeeper` into `counterkeeper.NewKeeper(...)`
+
+In [`app.go`](https://github.com/cosmos/example/blob/main/app.go), those changes look like this:
+
+```go
+maccPerms = map[string][]string{
+    // ...
+    countertypes.ModuleName: nil,
+}
+```
+
+```go
+app.CounterKeeper = counterkeeper.NewKeeper(
+    runtime.NewKVStoreService(keys[countertypes.StoreKey]),
+    appCodec,
+    app.BankKeeper,
+)
+```
+
+### Try it
+
+Submit an add transaction and the configured `AddCost` fee will be charged from the sender:
+
+```bash
+exampled tx counter add 5 --from alice --chain-id demo --yes
+```
+
+### Add this to your module
+
+To add fee collection through the bank module, make these changes:
+
+1. Define a narrow bank keeper interface in `types/expected_keepers.go`
+2. Add a `bankKeeper` field to your keeper
+3. Charge the fee inside your keeper business logic
+4. Add a module account entry in `maccPerms`
+5. Pass `app.BankKeeper` into your keeper constructor in `app.go`
+
+### expected_keepers.go
+
+Rather than importing the bank module directly, the counter module defines the minimal interface it needs:
+
+```go
+// x/counter/types/expected_keepers.go
+type BankKeeper interface {
+    SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+}
+```
+
+This keeps the dependency explicit and narrow. The counter module cannot accidentally call any other bank method.
+
+### Keeper struct
+
+```go
+type Keeper struct {
+    Schema     collections.Schema
+    counter    collections.Item[uint64]
+    params     collections.Item[types.Params]
+    bankKeeper types.BankKeeper
+    authority  string
+}
+```
+
+### Fee charging in AddCount
+
+```go
+func (k *Keeper) AddCount(ctx context.Context, sender string, amount uint64) (uint64, error) {
+    if amount >= math.MaxUint64 {
+        return 0, ErrNumTooLarge
+    }
+
+    params, err := k.GetParams(ctx)
+    if err != nil {
+        return 0, err
+    }
+
+    if params.MaxAddValue > 0 && amount > params.MaxAddValue {
+        return 0, ErrExceedsMaxAdd
+    }
+
+    if !params.AddCost.IsZero() {
+        senderAddr, err := sdk.AccAddressFromBech32(sender)
+        if err != nil {
+            return 0, err
+        }
+        if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, senderAddr, types.ModuleName, params.AddCost); err != nil {
+            return 0, sdkerrors.Wrap(ErrInsufficientFunds, err.Error())
+        }
+    }
+
+    count, err := k.GetCount(ctx)
+    if err != nil {
+        return 0, err
+    }
+
+    newCount := count + amount
+    if err := k.counter.Set(ctx, newCount); err != nil {
+        return 0, err
+    }
+
+    sdkCtx := sdk.UnwrapSDKContext(ctx)
+    sdkCtx.EventManager().EmitEvent(
+        sdk.NewEvent(
+            "count_increased",
+            sdk.NewAttribute("count", fmt.Sprintf("%v", newCount)),
+        ),
+    )
+
+    countMetric.Add(ctx, int64(amount))
+
+    return newCount, nil
+}
+```
+
+All the business logic, validation, fee charging, state mutation, events, and telemetry, lives in `AddCount`. The `MsgServer` stays thin:
+
+```go
+func (m msgServer) Add(ctx context.Context, req *types.MsgAddRequest) (*types.MsgAddResponse, error) {
+    newCount, err := m.AddCount(ctx, req.GetSender(), req.GetAdd())
+    if err != nil {
+        return nil, err
+    }
+    return &types.MsgAddResponse{UpdatedCount: newCount}, nil
+}
+```
+
+Because `AddCount` is a named keeper method, it can also be called from `BeginBlock`, governance hooks, or other modules, not just from the `MsgServer`.
+
+### Module accounts
+
+A module account is an on-chain account owned by a module instead of a user. Modules use module accounts to hold funds, receive fees, or get special permissions like minting or burning.
+
+Because `x/counter` receives fees from users, it needs a module account entry in [`app.go`](https://github.com/cosmos/example/blob/main/app.go):
+
+```go
+maccPerms = map[string][]string{
+    // ...
+    countertypes.ModuleName: nil,
+}
+```
+
+This lives in the `maccPerms` map in [`app.go`](https://github.com/cosmos/example/blob/main/app.go). Here, `nil` means the module account can receive funds but does not get extra permissions like minting or burning.
+
+## Sentinel errors
+
+Rather than returning generic errors, `x/counter` defines [named sentinel errors](/sdk/next/build/building-modules/errors) with registered codes. That makes failures easier to understand and easier for clients to match on programmatically.
+
+### Where the code lives
+
+- [`x/counter/keeper/errors.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/errors.go) defines the registered module errors
+- [`x/counter/keeper/keeper.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/keeper.go) returns those errors from business logic checks
+
+```go
+// keeper/errors.go
+var (
+    ErrNumTooLarge       = errors.Register("counter", 0, "requested integer to add is too large")
+    ErrExceedsMaxAdd     = errors.Register("counter", 1, "add value exceeds max allowed")
+    ErrInsufficientFunds = errors.Register("counter", 2, "insufficient funds to pay add cost")
+)
+```
+
+Registered errors produce structured error responses on-chain that clients can match against by code, not just by string.
+
+## Telemetry
+
+[Telemetry](/sdk/next/learn/advanced/telemetry) records how often the counter is updated so you can observe module activity in an OpenTelemetry-compatible system.
+
+### Where the code lives
+
+- [`x/counter/keeper/telemetry.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/telemetry.go) defines the meter and counter metric
+- [`x/counter/keeper/keeper.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/keeper.go) records the metric from `AddCount`
+
+```go
+// x/counter/keeper/telemetry.go
+var (
+    meter = otel.Meter("github.com/cosmos/example/x/counter")
+
+    countMetric metric.Int64Counter
+)
+
+func init() {
+    var err error
+    countMetric, err = meter.Int64Counter("count")
+    if err != nil {
+        panic(err)
+    }
+}
+```
+
+`countMetric.Add(ctx, int64(amount))` in `AddCount` increments an OpenTelemetry counter every time the module state is updated. This makes module activity visible in any OTel-compatible observability system.
+
+## AutoCLI
+
+[AutoCLI](/sdk/next/learn/advanced/autocli) exposes the module's queries and transactions as CLI commands. The full module example keeps the same basic AutoCLI setup as the minimal module and adds the recommended setting for custom command integration.
+
+### Where the code lives
+
+- [`x/counter/autocli.go`](https://github.com/cosmos/example/blob/main/x/counter/autocli.go) defines the generated query and tx commands
+
+### Try it
+
+These commands come from the AutoCLI configuration. `count` and `add` are customized explicitly in `autocli.go`, and `params` is still available from the generated query service.
+
+```bash
+exampled query counter count
+exampled query counter params
+exampled tx counter add 5 --from alice --chain-id demo --yes
+```
+
+Both modules use AutoCLI. The only difference is that `x/counter` sets `EnhanceCustomCommand: true`, which merges any hand-written CLI commands with the auto-generated ones. Since neither module has hand-written commands, it is a no-op here, but it is a good default for fuller modules.
+
+The [`autocli.go`](https://github.com/cosmos/example/blob/main/x/counter/autocli.go) file in `x/counter`:
+
+```go
+// autocli.go
+func (a AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
+    return &autocliv1.ModuleOptions{
+        Query: &autocliv1.ServiceCommandDescriptor{
+            Service:              "example.counter.Query",
+            EnhanceCustomCommand: true,
+            RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+                {RpcMethod: "Count", Use: "count", Short: "Query the current counter value"},
+            },
+        },
+        Tx: &autocliv1.ServiceCommandDescriptor{
+            Service:              "example.counter.Msg",
+            EnhanceCustomCommand: true,
+            RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+                {RpcMethod: "Add", Use: "add [amount]", Short: "Add to the counter",
+                    PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "add"}}},
+            },
+        },
+    }
+}
+```
+
+
+## Simulation
+
+[Simulation](/sdk/next/build/building-modules/simulator) lets the SDK generate randomized transactions against the module during fuzz-style testing.
+
+### Where the code lives
+
+- [`x/counter/simulation/msg_factory.go`](https://github.com/cosmos/example/blob/main/x/counter/simulation/msg_factory.go) defines how to generate random `Add` messages
+- [`x/counter/module.go`](https://github.com/cosmos/example/blob/main/x/counter/module.go) registers those weighted operations
+
+### Test it
+
+You can exercise simulation through the repo's simulation test targets described in the running and testing tutorial.
+
+`x/counter` implements `simsx`-based simulation, which lets the SDK's simulation framework generate random `Add` transactions during fuzz testing:
+
+```go
+// x/counter/simulation/msg_factory.go
+func MsgAddFactory() simsx.SimMsgFactoryFn[*types.MsgAddRequest] {
+    return func(ctx context.Context, testData *simsx.ChainDataSource, reporter simsx.SimulationReporter) ([]simsx.SimAccount, *types.MsgAddRequest) {
+        sender := testData.AnyAccount(reporter)
+        if reporter.IsSkipped() {
+            return nil, nil
+        }
+
+        r := testData.Rand()
+        addAmount := uint64(r.Intn(100) + 1)
+
+        msg := &types.MsgAddRequest{
+            Sender: sender.AddressBech32,
+            Add:    addAmount,
+        }
+
+        return []simsx.SimAccount{sender}, msg
+    }
+}
+```
+
+`module.go` registers this factory:
+
+```go
+func (a AppModule) WeightedOperationsX(weights simsx.WeightSource, reg simsx.Registry) {
+    reg.Add(weights.Get("msg_add", 100), simulation.MsgAddFactory())
+}
+```
+
+
+## BeginBlock and EndBlock
+
+These [hooks](/sdk/next/learn/concepts/modules#block-hooks) let a module run code automatically at the start or end of every block. In `x/counter`, they are purposefully empty to demonstrate where and how these features can be added.
+
+### Where the code lives
+
+- [`x/counter/module.go`](https://github.com/cosmos/example/blob/main/x/counter/module.go) implements `BeginBlock` and `EndBlock`
+- [`app.go`](https://github.com/cosmos/example/blob/main/app.go) adds the module to `SetOrderBeginBlockers` and `SetOrderEndBlockers`
+
+### app.go changes
+
+Because the module advertises block hooks, [`app.go`](https://github.com/cosmos/example/blob/main/app.go) must include `countertypes.ModuleName` in both blocker order lists.
+
+### Add this to your module
+
+To add begin and end blockers to your own module, make two changes:
+
+1. Implement the hooks in `x/<module>/module.go`
+2. Add your module name to `SetOrderBeginBlockers` and `SetOrderEndBlockers` in `app.go`
+
+`module.go` implements `HasBeginBlocker` and `HasEndBlocker`:
+
+```go
+func (a AppModule) BeginBlock(ctx context.Context) error {
+    // optional: logic to execute at the start of every block
+    return nil
+}
+
+func (a AppModule) EndBlock(ctx context.Context) error {
+    // optional: logic to execute at the end of every block
+    return nil
+}
+```
+
+In [`app.go`](https://github.com/cosmos/example/blob/main/app.go), the module is added to the blocker order lists like this:
+
+```go
+app.ModuleManager.SetOrderBeginBlockers(
+    // ...
+    countertypes.ModuleName,
+)
+
+app.ModuleManager.SetOrderEndBlockers(
+    // ...
+    countertypes.ModuleName,
+)
+```
+
+`x/counter` has no per-block logic, so both methods return nil. They exist to demonstrate the pattern: modules that need per-block execution (staking, distribution) implement real logic here. For example, a counter that auto-increments every block would call `k.AddCount(ctx, 1)` from `BeginBlock` instead of exposing a message type.
+
+## Unit tests
+
+The full module example includes a real [test suite](/sdk/next/learn/concepts/testing) for keeper logic, query behavior, message handling, and bank keeper interactions.
+
+### Where the code lives
+
+- [`x/counter/keeper/keeper_test.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/keeper_test.go)
+- [`x/counter/keeper/msg_server_test.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/msg_server_test.go)
+- [`x/counter/keeper/query_server_test.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/query_server_test.go)
+
+### Run them
+
+You can run the counter module tests directly with:
+
+```bash
+go test ./x/counter/...
+```
+
+### Add this to your module
+
+Start with keeper, message server, and query server tests. If your module depends on another keeper, use a small mock interface like `MockBankKeeper` so you can control success and failure cases in isolation.
+
+`x/counter` ships a full test suite in [`x/counter/keeper/`](https://github.com/cosmos/example/tree/main/x/counter/keeper):
+
+| File | What it tests |
+|---|---|
+| `keeper_test.go` | `KeeperTestSuite` setup, `InitGenesis`, `ExportGenesis`, `GetCount`, `AddCount`, `SetParams` |
+| `msg_server_test.go` | `MsgAdd`, event emission, `MsgUpdateParams` |
+| `query_server_test.go` | `QueryCount`, `QueryParams` |
+
+All three files share the `KeeperTestSuite` struct defined in [`keeper_test.go`](https://github.com/cosmos/example/blob/main/x/counter/keeper/keeper_test.go), which sets up an isolated in-memory store, a mock bank keeper, and a real keeper instance:
+
+```go
+type KeeperTestSuite struct {
+    suite.Suite
+    ctx         sdk.Context
+    keeper      *keeper.Keeper
+    queryClient types.QueryClient
+    msgServer   types.MsgServer
+    bankKeeper  *MockBankKeeper
+    authority   string
+}
+```
+
+`MockBankKeeper` lets tests control exactly what the bank keeper returns without needing a real bank module:
+
+```go
+type MockBankKeeper struct {
+    SendCoinsFromAccountToModuleFn func(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+}
+```
+
+Tests set `SendCoinsFromAccountToModuleFn` to simulate success or failure:
+
+```go
+s.bankKeeper.SendCoinsFromAccountToModuleFn = func(...) error {
+    return errors.New("insufficient funds")
+}
+```
+
+## Gas
+
+`minimum-gas-prices` in `app.toml` sets the minimum fee a node requires before it will accept and relay a transaction. The local dev chain started by `make start` leaves this empty, so transactions are accepted with no fee beyond the `AddCost` module parameter.
+
+To require a minimum network fee, set it in `app.toml`:
+
+```toml
+minimum-gas-prices = "0.025stake"
+```
+
+Transactions that don't meet the minimum will be rejected by the node before they reach your module. This is a per-node setting, not a chain-wide consensus rule, so validators on a live network each configure their own threshold.
+
+Next: [Running and Testing →](/sdk/next/tutorials/example/05-run-and-test)

--- a/sdk/next/tutorials/example/05-run-and-test.mdx
+++ b/sdk/next/tutorials/example/05-run-and-test.mdx
@@ -1,0 +1,235 @@
+---
+title: Running and Testing
+---
+
+Now that you've [built a module from scratch](/sdk/next/tutorials/example/03-build-a-module) and walked through the [full counter module](/sdk/next/tutorials/example/04-counter-walkthrough), the next step is learning the workflow for running and validating a production-ready chain. This page shows how to start the chain locally, interact with it through the CLI, and use the main layers of testing before shipping changes.
+
+## Single-node local chain
+
+Use a single-node chain for the fastest local development loop. It gives you one validator with predictable state so you can quickly test queries and transactions.
+
+### Start
+
+```bash
+make start
+```
+
+This builds the binary, initializes chain data, and starts a single validator node. It handles cleanup automatically — existing chain state is reset on each run.
+
+The chain uses:
+- Chain ID: `demo`
+- Pre-funded accounts: `alice`, `bob`
+- Default denomination: `stake`
+
+### Stop
+
+Press `Ctrl+C` in the terminal running `make start`.
+
+### Reset chain state
+
+```bash
+make start
+```
+
+Re-running `make start` resets state automatically. There is no separate reset command.
+
+## Localnet (multi-validator)
+
+Use localnet when you want a setup that is closer to a real network. It runs multiple validators in Docker so you can test multi-node behavior locally.
+
+For a multi-validator setup using Docker:
+
+```bash
+# Initialize localnet configuration
+make localnet-init
+
+# Start all validators
+make localnet-start
+
+# View logs
+make localnet-logs
+
+# Stop
+make localnet-stop
+
+# Clean all localnet data
+make localnet-clean
+```
+
+## CLI reference
+
+Once the chain is running, these are the core [CLI](/sdk/next/learn/concepts/cli-grpc-rest#cli) commands you'll use to inspect state and submit transactions.
+
+### Query commands
+
+Use query commands to read module state without changing anything on-chain.
+
+```bash
+# Query the current counter value
+exampled query counter count
+
+# Query the module parameters
+exampled query counter params
+
+# Query with a specific node (if not using default localhost:26657)
+exampled query counter count --node tcp://localhost:26657
+```
+
+### Transaction commands
+
+Use transaction commands to submit state-changing messages to the chain.
+
+```bash
+# Add to the counter
+exampled tx counter add 10 --from alice --chain-id demo --yes
+
+# Add with a gas limit
+exampled tx counter add 10 --from alice --chain-id demo --gas 200000 --yes
+
+# Update module parameters (requires governance authority)
+exampled tx counter update-params --from alice --chain-id demo --yes
+```
+
+### Useful flags
+
+These flags are the ones you'll use most often while iterating locally.
+
+| Flag | Description |
+|---|---|
+| `--from` | Key name or address to sign with |
+| `--chain-id` | Chain ID (use `demo` for local) |
+| `--yes` | Skip confirmation prompt |
+| `--gas` | Gas limit for the transaction |
+| `--node` | RPC endpoint (default: `tcp://localhost:26657`) |
+| `--output json` | Output response as JSON |
+
+
+## Node Configuration
+
+When you run `make start`, the chain creates `~/.exampleapp/config/` automatically and initializes two config files inside it:
+
+| File | What it controls |
+|---|---|
+| `app.toml` | SDK application settings: gas prices, pruning, API/gRPC servers, telemetry |
+| `config.toml` | CometBFT settings: peer networking, consensus timeouts, mempool, RPC |
+
+### app.toml
+
+The most common settings to change during development:
+
+| Setting | Default | Description |
+|---|---|---|
+| `minimum-gas-prices` | `"0stake"` | Minimum fee the node accepts before processing a transaction |
+| `pruning` | `"default"` | How much historical state to keep (`default`, `nothing`, `everything`, `custom`) |
+| `api.enable` | `true` | Enables the REST API on port 1317 |
+| `grpc.enable` | `true` | Enables the gRPC server on port 9090 |
+
+### config.toml
+
+The settings most likely to change during development:
+
+| Setting | Default | Description |
+|---|---|---|
+| `moniker` | `"test"` | Human-readable name for the node |
+| `log_level` | `"info"` | Log verbosity (`debug`, `info`, `error`) |
+| `consensus.timeout_commit` | `"5s"` | How long to wait after a block is committed before starting the next one |
+| `p2p.seeds` | `""` | Seed nodes to connect to on a live network |
+| `p2p.persistent_peers` | `""` | Peers to maintain permanent connections to |
+
+## Unit tests
+
+Start here when you want fast feedback on module logic without running a chain. These tests isolate the [keeper](/sdk/next/learn/concepts/testing#keeper-unit-tests) and gRPC servers from the rest of the app.
+
+The unit test logic lives in the counter keeper package on `main`: the shared suite setup is in [x/counter/keeper/keeper_test.go](https://github.com/cosmos/example/blob/main/x/counter/keeper/keeper_test.go), message-path tests are in [x/counter/keeper/msg_server_test.go](https://github.com/cosmos/example/blob/main/x/counter/keeper/msg_server_test.go), and query-path tests are in [x/counter/keeper/query_server_test.go](https://github.com/cosmos/example/blob/main/x/counter/keeper/query_server_test.go).
+
+The keeper test suite covers the keeper, msg server, and query server in isolation using an in-memory store and a mock bank keeper. No running chain is required.
+
+```bash
+go test ./x/counter/...
+```
+
+To run with verbose output:
+
+```bash
+go test -v ./x/counter/...
+```
+
+To run a specific test:
+
+```bash
+go test -v -run TestKeeperTestSuite/TestAddCount ./x/counter/...
+```
+
+The test suite is structured around three files:
+
+| File | Tests |
+|---|---|
+| `keeper/keeper_test.go` | Genesis, `GetCount`, `AddCount`, `SetParams` |
+| `keeper/msg_server_test.go` | `MsgAdd`, event emission, `MsgUpdateParams` |
+| `keeper/query_server_test.go` | `QueryCount`, `QueryParams` |
+
+## E2E tests
+
+Run [E2E tests](/sdk/next/learn/concepts/testing#integration-tests) when you want to verify the full request path against a real node. They give you higher confidence than unit tests, but take longer to complete.
+
+The E2E logic lives on `main` in [tests/counter_test.go](https://github.com/cosmos/example/blob/main/tests/counter_test.go), which starts an in-process network, builds signed transactions, and verifies query results. The shared network fixture it uses is defined in [tests/test_helpers.go](https://github.com/cosmos/example/blob/main/tests/test_helpers.go).
+
+The E2E test suite starts a real in-process validator network and submits actual transactions against it. This tests the full stack: transaction encoding, message routing, keeper logic, and query responses.
+
+```bash
+go test -v -run TestE2ETestSuite ./tests/...
+```
+
+E2E tests take longer than unit tests because they spin up a real node. Run them before merging significant changes.
+
+## Simulation tests
+
+[Simulation tests](/sdk/next/learn/concepts/testing#simulation-tests) stress the chain with randomized activity to catch edge cases that targeted tests can miss. In this repo, that simulation flow is built with `simsx`, the Cosmos SDK's higher-level simulation framework for defining random on-chain activity at the module level.
+
+The top-level simulation test commands on `main` run through [sim_test.go](https://github.com/cosmos/example/blob/main/sim_test.go). The counter module's `simsx` registration lives in [x/counter/module.go](https://github.com/cosmos/example/blob/main/x/counter/module.go), the random `MsgAdd` generation lives in [x/counter/simulation/msg_factory.go](https://github.com/cosmos/example/blob/main/x/counter/simulation/msg_factory.go), and randomized counter genesis lives in [x/counter/simulation/genesis.go](https://github.com/cosmos/example/blob/main/x/counter/simulation/genesis.go).
+
+In practice, `simsx` lets each module describe three things: how to generate random starting state, which operations can happen during simulation, and how often each operation should be chosen. For `x/counter`, that means generating a random initial counter value, registering `MsgAdd` as a simulation operation, and assigning it a weight so the simulator knows how frequently to try it relative to other module operations.
+
+When you run a simulation target, the test harness repeatedly builds app instances, creates random accounts and balances, generates random transactions from the registered module operations, and executes them over many blocks. That makes `simsx` useful for catching issues that are hard to cover with hand-written tests, like state machine bugs, unexpected panics, invariant violations, and non-deterministic behavior across runs.
+
+Simulation runs the chain with randomly generated transactions to detect non-determinism and invariant violations.
+
+```bash
+# Full simulation
+make test-sim-full
+
+# Determinism check
+make test-sim-determinism
+
+# All simulation tests
+make test-sim
+```
+
+Simulation requires the `sims` build tag, which the Makefile targets handle automatically.
+
+## Lint
+
+Linting is the quickest way to catch style problems and common code-quality issues before CI or code review does.
+
+The lint commands are defined in the repo [Makefile](https://github.com/cosmos/example/blob/main/Makefile), which installs `golangci-lint` and runs it across the full module tree.
+
+```bash
+make lint
+```
+
+This installs and runs `golangci-lint` across the repository. To auto-fix issues where possible:
+
+```bash
+make lint-fix
+```
+
+## Test summary
+
+Use this table as a quick reference for choosing the right validation command for the kind of change you made.
+
+| Command | What it validates |
+|---|---|
+| `go test ./x/counter/...` | Keeper, MsgServer, QueryServer in isolation |
+| `go test -run TestE2ETestSuite ./tests/...` | Full transaction and query flow on a live node |
+| `make test-sim-full` | Non-determinism and invariant violations |
+| `make lint` | Code style and static analysis |


### PR DESCRIPTION
Auto-synced from cosmos/example. Transforms docs/*.md to sdk/next/tutorials/example/*.mdx. Do not edit these files directly — edit the source in cosmos/example and let the sync bot update them.