### PR TITLE
update IBC docs for ibc-go v11

### DIFF
--- a/ibc/next/ibc/apps/ibcmodule.mdx
+++ b/ibc/next/ibc/apps/ibcmodule.mdx
@@ -10,9 +10,9 @@ The Cosmos SDK expects all IBC modules to implement the [`IBCModule`
 interface](https://github.com/cosmos/ibc-go/tree/main/modules/core/05-port/types/module.go). This interface contains all of the callbacks IBC expects modules to implement. They include callbacks related to channel handshake, closing and packet callbacks (`OnRecvPacket`, `OnAcknowledgementPacket` and `OnTimeoutPacket`).
 
 ```go
-/ IBCModule implements the ICS26 interface for given the keeper.
-/ The implementation of the IBCModule interface could for example be in a file called ibc_module.go,
-/ but ultimately file structure is up to the developer
+// IBCModule implements the ICS26 interface for given the keeper.
+// The implementation of the IBCModule interface could for example be in a file called ibc_module.go,
+// but ultimately file structure is up to the developer
 type IBCModule struct {
     keeper keeper.Keeper
 }
@@ -34,7 +34,7 @@ var (
 }
   _ module.AppModuleBasic = AppModuleBasic{
 }
-  / Add this line
+  // Add this line
   _ porttypes.IBCModule   = IBCModule{
 }
 )
@@ -58,7 +58,7 @@ Here are the channel handshake callbacks that modules are expected to implement:
 > Note that some of the code below is _pseudo code_, indicating what actions need to happen but leaving it up to the developer to implement a custom implementation. E.g. the `checkArguments` and `negotiateAppVersion` functions.
 
 ```go expandable
-/ Called by IBC Handler on MsgOpenInit
+// Called by IBC Handler on MsgOpenInit
 func (im IBCModule)
 
 OnChanOpenInit(ctx sdk.Context,
@@ -69,12 +69,12 @@ OnChanOpenInit(ctx sdk.Context,
   counterparty channeltypes.Counterparty,
   version string,
 ) (string, error) {
-  / ... do custom initialization logic
+  // ... do custom initialization logic
 
-  / Use above arguments to determine if we want to abort handshake
-  / Examples:
-  / - Abort if order == UNORDERED,
-  / - Abort if version is unsupported
+  // Use above arguments to determine if we want to abort handshake
+  // Examples:
+  // - Abort if order == UNORDERED,
+  // - Abort if version is unsupported
     if err := checkArguments(args); err != nil {
     return "", err
 }
@@ -82,7 +82,7 @@ OnChanOpenInit(ctx sdk.Context,
 return version, nil
 }
 
-/ Called by IBC Handler on MsgOpenTry
+// Called by IBC Handler on MsgOpenTry
 func (im IBCModule)
 
 OnChanOpenTry(
@@ -94,24 +94,24 @@ OnChanOpenTry(
   counterparty channeltypes.Counterparty,
   counterpartyVersion string,
 ) (string, error) {
-  / ... do custom initialization logic
+  // ... do custom initialization logic
 
-  / Use above arguments to determine if we want to abort handshake
+  // Use above arguments to determine if we want to abort handshake
     if err := checkArguments(args); err != nil {
     return "", err
 }
 
-  / Construct application version
-  / IBC applications must return the appropriate application version
-  / This can be a simple string or it can be a complex version constructed
-  / from the counterpartyVersion and other arguments.
-  / The version returned will be the channel version used for both channel ends.
+  // Construct application version
+  // IBC applications must return the appropriate application version
+  // This can be a simple string or it can be a complex version constructed
+  // from the counterpartyVersion and other arguments.
+  // The version returned will be the channel version used for both channel ends.
     appVersion := negotiateAppVersion(counterpartyVersion, args)
 
 return appVersion, nil
 }
 
-/ Called by IBC Handler on MsgOpenAck
+// Called by IBC Handler on MsgOpenAck
 func (im IBCModule)
 
 OnChanOpenAck(
@@ -127,12 +127,12 @@ error {
     return sdkerrors.Wrapf(types.ErrInvalidVersion, "invalid counterparty version: %s, expected %s", counterpartyVersion, types.Version)
 }
 
-  / do custom logic
+  // do custom logic
 
   return nil
 }
 
-/ Called by IBC Handler on MsgOpenConfirm
+// Called by IBC Handler on MsgOpenConfirm
 func (im IBCModule)
 
 OnChanOpenConfirm(
@@ -142,7 +142,7 @@ OnChanOpenConfirm(
 )
 
 error {
-  / do custom logic
+  // do custom logic
 
   return nil
 }
@@ -155,7 +155,7 @@ The channel closing handshake will also invoke module callbacks that can return 
 Currently, all IBC modules in this repository return an error for `OnChanCloseInit` to prevent the channels from closing. This is because any user can call `ChanCloseInit` by submitting a `MsgChannelCloseInit` transaction.
 
 ```go expandable
-/ Called by IBC Handler on MsgCloseInit
+// Called by IBC Handler on MsgCloseInit
 func (im IBCModule)
 
 OnChanCloseInit(
@@ -165,15 +165,15 @@ OnChanCloseInit(
 )
 
 error {
-  / ... do custom finalization logic
+  // ... do custom finalization logic
 
-  / Use above arguments to determine if we want to abort handshake
+  // Use above arguments to determine if we want to abort handshake
     err := checkArguments(args)
 
 return err
 }
 
-/ Called by IBC Handler on MsgCloseConfirm
+// Called by IBC Handler on MsgCloseConfirm
 func (im IBCModule)
 
 OnChanCloseConfirm(
@@ -183,9 +183,9 @@ OnChanCloseConfirm(
 )
 
 error {
-  / ... do custom finalization logic
+  // ... do custom finalization logic
 
-  / Use above arguments to determine if we want to abort handshake
+  // Use above arguments to determine if we want to abort handshake
     err := checkArguments(args)
 
 return err
@@ -256,9 +256,9 @@ module must trigger execution on the port-bound module through the use of callba
 > Note that some of the code below is _pseudo code_, indicating what actions need to happen but leaving it up to the developer to implement a custom implementation. E.g. the `EncodePacketData(customPacketData)` function.
 
 ```go expandable
-/ Sending custom application packet data
+// Sending custom application packet data
     data := EncodePacketData(customPacketData)
-/ Send packet to IBC, authenticating with channelCap
+// Send packet to IBC, authenticating with channelCap
 sequence, err := IBCChannelKeeper.SendPacket(
   ctx,
   sourcePort,
@@ -302,14 +302,14 @@ OnRecvPacket(
 )
 
 ibcexported.Acknowledgement {
-  / Decode the packet data
+  // Decode the packet data
     packetData := DecodePacketData(packet.Data)
 
-  / do application state changes based on packet data and return the acknowledgement
-  / NOTE: The acknowledgement will indicate to the IBC handler if the application
-  / state changes should be written via the `Success()` function. Application state
-  / changes are only written if the acknowledgement is successful or the acknowledgement
-  / returned is nil indicating that an asynchronous acknowledgement will occur.
+  // do application state changes based on packet data and return the acknowledgement
+  // NOTE: The acknowledgement will indicate to the IBC handler if the application
+  // state changes should be written via the `Success()` function. Application state
+  // changes are only written if the acknowledgement is successful or the acknowledgement
+  // returned is nil indicating that an asynchronous acknowledgement will occur.
     ack := processPacket(ctx, packet, packetData)
 
 return ack
@@ -319,8 +319,8 @@ return ack
 Reminder, the `Acknowledgement` interface:
 
 ```go
-/ Acknowledgement defines the interface used to return
-/ acknowledgements in the OnRecvPacket callback.
+// Acknowledgement defines the interface used to return
+// acknowledgements in the OnRecvPacket callback.
 type Acknowledgement interface {
     Success()
 
@@ -353,10 +353,10 @@ OnAcknowledgementPacket(
   acknowledgement []byte,
   relayer sdk.AccAddress,
 ) error {
-  / Decode acknowledgement
+  // Decode acknowledgement
     ack := DecodeAcknowledgement(acknowledgement)
 
-  / process ack
+  // process ack
   res, err := processAck(ack)
 
 return res, err
@@ -381,7 +381,7 @@ OnTimeoutPacket(
   packet channeltypes.Packet,
   relayer sdk.AccAddress,
 ) error {
-  / do custom timeout logic
+  // do custom timeout logic
 }
 ```
 
@@ -394,13 +394,13 @@ The following interface are optional and MAY be implemented by an IBCModule.
 The `PacketDataUnmarshaler` interface is defined as follows:
 
 ```go
-/ PacketDataUnmarshaler defines an optional interface which allows a middleware to
-/ request the packet data to be unmarshaled by the base application.
+// PacketDataUnmarshaler defines an optional interface which allows a middleware to
+// request the packet data to be unmarshaled by the base application.
 type PacketDataUnmarshaler interface {
-  / UnmarshalPacketData unmarshals the packet data into a concrete type
-  / ctx, portID, channelID are provided as arguments, so that (if needed)
-  / the packet data can be unmarshaled based on the channel version.
-  / The version of the underlying app is also returned.
+  // UnmarshalPacketData unmarshals the packet data into a concrete type
+  // ctx, portID, channelID are provided as arguments, so that (if needed)
+  // the packet data can be unmarshaled based on the channel version.
+  // The version of the underlying app is also returned.
   UnmarshalPacketData(ctx sdk.Context, portID, channelID string, bz []byte) (interface{
 }, string, error)
 }

--- a/ibc/next/ibc/apps/ibcmodule.mdx
+++ b/ibc/next/ibc/apps/ibcmodule.mdx
@@ -18,6 +18,14 @@ type IBCModule struct {
 }
 ```
 
+All `IBCModule` implementations must also implement `SetICS4Wrapper`, which is called by the `IBCStackBuilder` during application setup to wire the ICS4 channel handler into the module:
+
+```go
+func (im *IBCModule) SetICS4Wrapper(wrapper porttypes.ICS4Wrapper) {
+  im.keeper.SetICS4Wrapper(wrapper)
+}
+```
+
 Additionally, in the `module.go` file, add the following line:
 
 ```go
@@ -110,6 +118,7 @@ OnChanOpenAck(
   ctx sdk.Context,
   portID,
   channelID string,
+  counterpartyChannelID string,
   counterpartyVersion string,
 )
 
@@ -287,7 +296,9 @@ func (im IBCModule)
 
 OnRecvPacket(
   ctx sdk.Context,
+  channelVersion string,
   packet channeltypes.Packet,
+  relayer sdk.AccAddress,
 )
 
 ibcexported.Acknowledgement {
@@ -337,9 +348,11 @@ func (im IBCModule)
 
 OnAcknowledgementPacket(
   ctx sdk.Context,
+  channelVersion string,
   packet channeltypes.Packet,
   acknowledgement []byte,
-) (*sdk.Result, error) {
+  relayer sdk.AccAddress,
+) error {
   / Decode acknowledgement
     ack := DecodeAcknowledgement(acknowledgement)
 
@@ -364,8 +377,10 @@ func (im IBCModule)
 
 OnTimeoutPacket(
   ctx sdk.Context,
+  channelVersion string,
   packet channeltypes.Packet,
-) (*sdk.Result, error) {
+  relayer sdk.AccAddress,
+) error {
   / do custom timeout logic
 }
 ```

--- a/ibc/next/ibc/integration.mdx
+++ b/ibc/next/ibc/integration.mdx
@@ -30,24 +30,24 @@ We need to register the core `ibc` and `transfer` `Keeper`s. The `transferv2` pa
 ```go title="app.go" expandable
 import (
 
-  / other imports
-  / ...
+  // other imports
+  // ...
   ibckeeper "github.com/cosmos/ibc-go/v11/modules/core/keeper"
   ibctransferkeeper "github.com/cosmos/ibc-go/v11/modules/apps/transfer/keeper"
-  / ibc v2 import (no separate keeper needed)
+  // ibc v2 import (no separate keeper needed)
   transferv2 "github.com/cosmos/ibc-go/v11/modules/apps/transfer/v2"
 )
 
 type App struct {
-  / baseapp, keys and subspaces definitions
+  // baseapp, keys and subspaces definitions
 
-  / other keepers
-  / ...
-  IBCKeeper        *ibckeeper.Keeper / IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
-  TransferKeeper   *ibctransferkeeper.Keeper / for cross-chain fungible token transfers
+  // other keepers
+  // ...
+  IBCKeeper        *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
+  TransferKeeper   *ibctransferkeeper.Keeper // for cross-chain fungible token transfers
 
-  / ...
-  / module and simulation manager definitions
+  // ...
+  // module and simulation manager definitions
 }
 ```
 
@@ -63,8 +63,8 @@ Initialize the IBC `Keeper`s (for core `ibc` and `transfer` modules), and any ad
 ```go expandable
 import (
 
-  / other imports
-  / ...
+  // other imports
+  // ...
   authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
   ibcexported "github.com/cosmos/ibc-go/v11/modules/core/exported"
@@ -75,11 +75,11 @@ import (
 )
 
 func NewApp(...args) *App {
-  / define codecs and baseapp
+  // define codecs and baseapp
 
-  / ... other module keepers
+  // ... other module keepers
 
-  / Create IBC Keeper
+  // Create IBC Keeper
   app.IBCKeeper = ibckeeper.NewKeeper(
 		appCodec,
 		runtime.NewKVStoreService(keys[ibcexported.StoreKey]),
@@ -87,7 +87,7 @@ func NewApp(...args) *App {
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 
-  / Create Transfer Keeper
+  // Create Transfer Keeper
   app.TransferKeeper = ibctransferkeeper.NewKeeper(
 		appCodec,
 		app.AccountKeeper.AddressCodec(),
@@ -99,7 +99,7 @@ func NewApp(...args) *App {
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 
-  / ... continues
+  // ... continues
 }
 ```
 
@@ -116,8 +116,8 @@ Use `porttypes.NewIBCStackBuilder` to wire up a stack. The builder wires the `ap
 The transfer stack below shows how to wire up transfer with rate limiting and packet forward middleware. Note that `Base` is the bottom of the stack (the application), and each `Next` call adds a middleware on top:
 
 ```go expandable
-/ Create Transfer Stack for IBC Classic
-/ Stack order (top to bottom): RateLimit -> PacketForward -> Transfer
+// Create Transfer Stack for IBC Classic
+// Stack order (top to bottom): RateLimit -> PacketForward -> Transfer
 transferApp := transfer.NewIBCModule(app.TransferKeeper)
 
 transferStack := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper).
@@ -152,24 +152,24 @@ Once the `Router` has been set, no new routes can be added.
 ```go title="app.go" expandable
 import (
 
-  / other imports
-  / ...
+  // other imports
+  // ...
   porttypes "github.com/cosmos/ibc-go/v11/modules/core/05-port/types"
   ibctransfertypes "github.com/cosmos/ibc-go/v11/modules/apps/transfer/types"
 )
 
 func NewApp(...args) *App {
-  / .. continuation from above
+  // .. continuation from above
 
-  / Create static IBC router, add transfer module route, then set and seal it
+  // Create static IBC router, add transfer module route, then set and seal it
     ibcRouter := porttypes.NewRouter()
 
 ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack)
-  / Setting Router will finalize all routes by sealing router
-  / No more routes can be added
+  // Setting Router will finalize all routes by sealing router
+  // No more routes can be added
   app.IBCKeeper.SetRouter(ibcRouter)
 
-  / ... continues
+  // ... continues
 ```
 
 #### IBC v2 Router
@@ -180,12 +180,12 @@ However, if instead, `someModule` is a prefix-based route, port IDs like `someMo
 Note that the router will panic when you add a route that conflicts with an already existing route. This is also the case if you add a prefix-based route that conflicts with an existing direct route or vice versa.
 
 ```go
-/ IBC v2 router creation
+// IBC v2 router creation
 	ibcRouterV2 := ibcapi.NewRouter()
 
 ibcRouterV2.AddRoute(ibctransfertypes.PortID, ibcv2TransferStack)
-  / Setting Router will finalize all routes by sealing router
-  / No more routes can be added
+  // Setting Router will finalize all routes by sealing router
+  // No more routes can be added
 	app.IBCKeeper.SetRouterV2(ibcRouterV2)
 ```
 
@@ -196,8 +196,8 @@ In order to use IBC, we need to add the new modules to the module `Manager` and 
 ```go title="app.go" expandable
 import (
 
-  / other imports
-  / ...
+  // other imports
+  // ...
   "github.com/cosmos/cosmos-sdk/types/module"
 
   ibc "github.com/cosmos/ibc-go/v11/modules/core"
@@ -205,28 +205,28 @@ import (
 )
 
 func NewApp(...args) *App {
-  / ... continuation from above
+  // ... continuation from above
 
   app.ModuleManager = module.NewManager(
-    / other modules
-    / ...
-    / highlight-start
+    // other modules
+    // ...
+    // highlight-start
 +   ibc.NewAppModule(app.IBCKeeper),
 +   transfer.NewAppModule(app.TransferKeeper),
-    / highlight-end
+    // highlight-end
   )
 
-  / ...
+  // ...
 
   app.simulationManager = module.NewSimulationManagerFromAppModules(
-    / other modules
-    / ...
+    // other modules
+    // ...
     app.ModuleManager.Modules,
     map[string]module.AppModuleSimulation{
 },
   )
 
-  / ... continues
+  // ... continues
 ```
 
 ### Module account permissions
@@ -237,21 +237,21 @@ the `transfer` `ModuleAccount` to mint and burn relayed tokens.
 ```go title="app.go" expandable
 import (
 
-  / other imports
-  / ...
+  // other imports
+  // ...
   "github.com/cosmos/cosmos-sdk/types/module"
   authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
-  / highlight-next-line
+  // highlight-next-line
 + ibctransfertypes "github.com/cosmos/ibc-go/v11/modules/apps/transfer/types"
 )
 
-/ app.go
+// app.go
 var (
-  / module account permissions
+  // module account permissions
   maccPerms = map[string][]string{
-    / other module accounts permissions
-    / ...
+    // other module accounts permissions
+    // ...
     ibctransfertypes.ModuleName: {
     authtypes.Minter, authtypes.Burner
 },
@@ -268,28 +268,28 @@ All light clients must be registered with `module.Manager` in a chain's app.go f
 ```go title="app.go" expandable
 import (
 
-  / other imports
-  / ...
+  // other imports
+  // ...
   "github.com/cosmos/cosmos-sdk/types/module"
-  / highlight-next-line
+  // highlight-next-line
 + ibctm "github.com/cosmos/ibc-go/v11/modules/light-clients/07-tendermint"
 )
 
-/ app.go
-/ after sealing the IBC router
+// app.go
+// after sealing the IBC router
     clientKeeper := app.IBCKeeper.ClientKeeper
     storeProvider := app.IBCKeeper.ClientKeeper.GetStoreProvider()
     tmLightClientModule := ibctm.NewLightClientModule(appCodec, storeProvider)
 
 clientKeeper.AddRoute(ibctm.ModuleName, &tmLightClientModule)
-/ ...
+// ...
 app.ModuleManager = module.NewManager(
-  / ...
+  // ...
   ibc.NewAppModule(app.IBCKeeper),
-  transfer.NewAppModule(app.TransferKeeper), / i.e ibc-transfer module
+  transfer.NewAppModule(app.TransferKeeper), // i.e ibc-transfer module
 
-  / register light clients on IBC
-  / highlight-next-line
+  // register light clients on IBC
+  // highlight-next-line
 + ibctm.NewAppModule(tmLightClientModule),
 )
 ```
@@ -314,8 +314,8 @@ connection handshake.
 ```go title="app.go" expandable
 import (
 
-  / other imports
-  / ...
+  // other imports
+  // ...
   stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
   ibcexported "github.com/cosmos/ibc-go/v11/modules/core/exported"
   ibckeeper "github.com/cosmos/ibc-go/v11/modules/core/keeper"
@@ -323,34 +323,34 @@ import (
 )
 
 func NewApp(...args) *App {
-  / ... continuation from above
+  // ... continuation from above
 
-  / add x/staking, ibc and transfer modules to BeginBlockers
+  // add x/staking, ibc and transfer modules to BeginBlockers
   app.ModuleManager.SetOrderBeginBlockers(
-    / other modules ...
+    // other modules ...
     stakingtypes.ModuleName,
     ibcexported.ModuleName,
     ibctransfertypes.ModuleName,
   )
 
 app.ModuleManager.SetOrderEndBlockers(
-    / other modules ...
+    // other modules ...
     stakingtypes.ModuleName,
     ibcexported.ModuleName,
     ibctransfertypes.ModuleName,
   )
 
-  / ...
+  // ...
     genesisModuleOrder := []string{
-    / other modules
-    / ...
+    // other modules
+    // ...
     ibcexported.ModuleName,
     ibctransfertypes.ModuleName,
 }
 
 app.ModuleManager.SetOrderInitGenesis(genesisModuleOrder...)
 
-  / ... continues
+  // ... continues
 ```
 
 That's it! You have now wired up the IBC module and the `transfer` module, and are now able to send fungible tokens across

--- a/ibc/next/ibc/integration.mdx
+++ b/ibc/next/ibc/integration.mdx
@@ -7,7 +7,7 @@ title: Integration
 Learn how to integrate IBC to your application
 
 This document outlines the required steps to integrate and configure the [IBC
-module](https://github.com/cosmos/ibc-go/tree/main/modules/core) to your Cosmos SDK application and enable sending fungible token transfers to other chains. An [example app using ibc-go v10 is linked](https://github.com/gjermundgaraba/probe/tree/ibc/v10).
+module](https://github.com/cosmos/ibc-go/tree/main/modules/core) to your Cosmos SDK application and enable sending fungible token transfers to other chains. There is a [simapp included using ibc-go](https://github.com/cosmos/ibc-go/tree/main/simapp) as a reference.
 
 ## Integrating the IBC module
 
@@ -25,18 +25,17 @@ Integrating the IBC module to your SDK-based application is straightforward. The
 
 ### Add application fields to `App`
 
-We need to register the core `ibc` and `transfer` `Keeper`s. To support the use of IBC v2, `transferv2` and `callbacksv2` must also be registered as follows:
+We need to register the core `ibc` and `transfer` `Keeper`s. The `transferv2` package is used for IBC v2 routing and does not require a separate keeper — the same `TransferKeeper` is reused.
 
 ```go title="app.go" expandable
 import (
 
   / other imports
   / ...
-  ibckeeper "github.com/cosmos/ibc-go/v10/modules/core/keeper"
-  ibctransferkeeper "github.com/cosmos/ibc-go/v10/modules/apps/transfer/keeper"
-  / ibc v2 imports
-  transferv2 "github.com/cosmos/ibc-go/v10/modules/apps/transfer/v2"
-  ibccallbacksv2 "github.com/cosmos/ibc-go/v10/modules/apps/callbacks/v2"
+  ibckeeper "github.com/cosmos/ibc-go/v11/modules/core/keeper"
+  ibctransferkeeper "github.com/cosmos/ibc-go/v11/modules/apps/transfer/keeper"
+  / ibc v2 import (no separate keeper needed)
+  transferv2 "github.com/cosmos/ibc-go/v11/modules/apps/transfer/v2"
 )
 
 type App struct {
@@ -45,7 +44,7 @@ type App struct {
   / other keepers
   / ...
   IBCKeeper        *ibckeeper.Keeper / IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
-  TransferKeeper   ibctransferkeeper.Keeper / for cross-chain fungible token transfers
+  TransferKeeper   *ibctransferkeeper.Keeper / for cross-chain fungible token transfers
 
   / ...
   / module and simulation manager definitions
@@ -68,11 +67,11 @@ import (
   / ...
   authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
-  ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
-  ibckeeper "github.com/cosmos/ibc-go/v10/modules/core/keeper"
-    "github.com/cosmos/ibc-go/v10/modules/apps/transfer"
-  ibctransfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
-  ibctm "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint"
+  ibcexported "github.com/cosmos/ibc-go/v11/modules/core/exported"
+  ibckeeper "github.com/cosmos/ibc-go/v11/modules/core/keeper"
+    "github.com/cosmos/ibc-go/v11/modules/apps/transfer"
+  ibctransfertypes "github.com/cosmos/ibc-go/v11/modules/apps/transfer/types"
+  ibctm "github.com/cosmos/ibc-go/v11/modules/light-clients/07-tendermint"
 )
 
 func NewApp(...args) *App {
@@ -84,7 +83,6 @@ func NewApp(...args) *App {
   app.IBCKeeper = ibckeeper.NewKeeper(
 		appCodec,
 		runtime.NewKVStoreService(keys[ibcexported.StoreKey]),
-		app.GetSubspace(ibcexported.ModuleName),
 		app.UpgradeKeeper,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
@@ -92,9 +90,8 @@ func NewApp(...args) *App {
   / Create Transfer Keeper
   app.TransferKeeper = ibctransferkeeper.NewKeeper(
 		appCodec,
+		app.AccountKeeper.AddressCodec(),
 		runtime.NewKVStoreService(keys[ibctransfertypes.StoreKey]),
-		app.GetSubspace(ibctransfertypes.ModuleName),
-		app.IBCKeeper.ChannelKeeper,
 		app.IBCKeeper.ChannelKeeper,
 		app.MsgServiceRouter(),
 		app.AccountKeeper,
@@ -106,45 +103,36 @@ func NewApp(...args) *App {
 }
 ```
 
+<Note>
+  Starting from ibc-go v11, consensus parameter authority takes precedence over keeper authority for all IBC modules due to [`sdk.ValidateAuthority`](https://github.com/cosmos/cosmos-sdk/blob/d17338af62722f9fa4108d8494b876dff64a4c6e/types/authority.go#L11).
+</Note>
+
 ### Create Application Stacks with Middleware
 
-Middleware stacks in IBC allow you to wrap an `IBCModule` with additional logic for packets and acknowledgements. This is a chain of handlers that execute in order. The transfer stack below shows how to wire up transfer to use packet forward middleware, and the callbacks middleware. Note that the order is important.
+Middleware stacks in IBC allow you to wrap an `IBCModule` with additional logic for packets and acknowledgements. This is a chain of handlers that execute in order.
+
+Use `porttypes.NewIBCStackBuilder` to wire up a stack. The builder wires the `app`, `ics4Wrapper`, and each middleware together automatically via `SetUnderlyingApplication` and `SetICS4Wrapper` — you do **not** pass these into middleware constructors directly.
+
+The transfer stack below shows how to wire up transfer with rate limiting and packet forward middleware. Note that `Base` is the bottom of the stack (the application), and each `Next` call adds a middleware on top:
 
 ```go expandable
 / Create Transfer Stack for IBC Classic
-    maxCallbackGas := uint64(10_000_000)
-    wasmStackIBCHandler := wasm.NewIBCHandler(app.WasmKeeper, app.IBCKeeper.ChannelKeeper, app.IBCKeeper.ChannelKeeper)
+/ Stack order (top to bottom): RateLimit -> PacketForward -> Transfer
+transferApp := transfer.NewIBCModule(app.TransferKeeper)
 
-var transferStack porttypes.IBCModule
-transferStack = transfer.NewIBCModule(app.TransferKeeper)
-/ callbacks wraps the transfer stack as its base app, and uses PacketForwardKeeper as the ICS4Wrapper
-/ i.e. packet-forward-middleware is higher on the stack and sits between callbacks and the ibc channel keeper
-/ Since this is the lowest level middleware of the transfer stack, it should be the first entrypoint for transfer keeper's
-/ WriteAcknowledgement.
-    cbStack := ibccallbacks.NewIBCMiddleware(transferStack, app.PacketForwardKeeper, wasmStackIBCHandler, maxCallbackGas)
-
-transferStack = packetforward.NewIBCMiddleware(
-  cbStack,
-  app.PacketForwardKeeper,
-  0, / retries on timeout
-  packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp,
-)
+transferStack := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper).
+    Base(transferApp).
+    Next(packetforward.NewIBCMiddleware(app.PFMKeeper, 0, packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp)).
+    Next(ratelimiting.NewIBCMiddleware(app.RateLimitKeeper)).
+    Build()
 ```
 
 #### IBC v2 Application Stack
 
-For IBC v2, an example transfer stack is shown below. In this case the transfer stack is using the callbacks middleware.
+For IBC v2, register the transfer v2 module directly on the v2 router — no middleware stack is needed:
 
 ```go
-/ Create IBC v2 transfer middleware stack
-/ the callbacks gas limit is recommended to be 10M for use with wasm contracts
-    maxCallbackGas := uint64(10_000_000)
-    wasmStackIBCHandler := wasm.NewIBCHandler(app.WasmKeeper, app.IBCKeeper.ChannelKeeper, app.IBCKeeper.ChannelKeeper)
-
-var ibcv2TransferStack ibcapi.IBCModule
-	ibcv2TransferStack = transferv2.NewIBCModule(app.TransferKeeper)
-
-ibcv2TransferStack = ibccallbacksv2.NewIBCMiddleware(transferv2.NewIBCModule(app.TransferKeeper), app.IBCKeeper.ChannelKeeperV2, wasmStackIBCHandler, app.IBCKeeper.ChannelKeeperV2, maxCallbackGas)
+ibcRouterV2.AddRoute(ibctransfertypes.PortID, transferv2.NewIBCModule(app.TransferKeeper))
 ```
 
 ### Register module routes in the IBC `Router`
@@ -166,8 +154,8 @@ import (
 
   / other imports
   / ...
-  porttypes "github.com/cosmos/ibc-go/v10/modules/core/05-port/types"
-  ibctransfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
+  porttypes "github.com/cosmos/ibc-go/v11/modules/core/05-port/types"
+  ibctransfertypes "github.com/cosmos/ibc-go/v11/modules/apps/transfer/types"
 )
 
 func NewApp(...args) *App {
@@ -212,8 +200,8 @@ import (
   / ...
   "github.com/cosmos/cosmos-sdk/types/module"
 
-  ibc "github.com/cosmos/ibc-go/v10/modules/core"
-    "github.com/cosmos/ibc-go/v10/modules/apps/transfer"
+  ibc "github.com/cosmos/ibc-go/v11/modules/core"
+    "github.com/cosmos/ibc-go/v11/modules/apps/transfer"
 )
 
 func NewApp(...args) *App {
@@ -255,7 +243,7 @@ import (
   authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
   / highlight-next-line
-+ ibctransfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
++ ibctransfertypes "github.com/cosmos/ibc-go/v11/modules/apps/transfer/types"
 )
 
 / app.go
@@ -284,7 +272,7 @@ import (
   / ...
   "github.com/cosmos/cosmos-sdk/types/module"
   / highlight-next-line
-+ ibctm "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint"
++ ibctm "github.com/cosmos/ibc-go/v11/modules/light-clients/07-tendermint"
 )
 
 / app.go
@@ -329,9 +317,9 @@ import (
   / other imports
   / ...
   stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-  ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
-  ibckeeper "github.com/cosmos/ibc-go/v10/modules/core/keeper"
-  ibctransfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
+  ibcexported "github.com/cosmos/ibc-go/v11/modules/core/exported"
+  ibckeeper "github.com/cosmos/ibc-go/v11/modules/core/keeper"
+  ibctransfertypes "github.com/cosmos/ibc-go/v11/modules/apps/transfer/types"
 )
 
 func NewApp(...args) *App {

--- a/ibc/next/ibc/middleware/develop.mdx
+++ b/ibc/next/ibc/middleware/develop.mdx
@@ -25,13 +25,13 @@ func MarshalAsIBCDoes(ack channeltypes.Acknowledgement) ([]byte, error) {
 The interfaces a middleware must implement are found [here](https://github.com/cosmos/ibc-go/blob/main/modules/core/05-port/types/module.go).
 
 ```go
-/ Middleware implements the ICS26 Module interface
+// Middleware implements the ICS26 Module interface
 type Middleware interface {
-    IBCModule / middleware has access to an underlying application which may be wrapped by more middleware
-  ICS4Wrapper / middleware has access to ICS4Wrapper which may be core IBC Channel Handler or a higher-level middleware that wraps this middleware.
+    IBCModule // middleware has access to an underlying application which may be wrapped by more middleware
+  ICS4Wrapper // middleware has access to ICS4Wrapper which may be core IBC Channel Handler or a higher-level middleware that wraps this middleware.
 
-  / SetUnderlyingModule sets the underlying IBC module. This function may be used after
-	/ the middleware's initialization to set the ibc module which is below this middleware.
+  // SetUnderlyingModule sets the underlying IBC module. This function may be used after
+	// the middleware's initialization to set the ibc module which is below this middleware.
 	SetUnderlyingApplication(IBCModule)
 }
 ```
@@ -39,24 +39,24 @@ type Middleware interface {
 An `IBCMiddleware` struct implementing the `Middleware` interface can be defined with its constructor as follows. Note that the constructor **does not** accept the underlying `app` or `ics4Wrapper` — those are wired up later by `IBCStackBuilder` via `SetUnderlyingApplication` and `SetICS4Wrapper`:
 
 ```go expandable
-/ @ x/module_name/ibc_middleware.go
+// @ x/module_name/ibc_middleware.go
 
-/ IBCMiddleware implements the ICS26 callbacks and ICS4Wrapper for the middleware given its keeper.
+// IBCMiddleware implements the ICS26 callbacks and ICS4Wrapper for the middleware given its keeper.
 type IBCMiddleware struct {
     app         porttypes.IBCModule
     ics4Wrapper porttypes.ICS4Wrapper
     keeper      *keeper.Keeper
 }
 
-/ NewIBCMiddleware creates a new IBCMiddleware given the keeper.
-/ The underlying app and ICS4Wrapper are set later by IBCStackBuilder.
+// NewIBCMiddleware creates a new IBCMiddleware given the keeper.
+// The underlying app and ICS4Wrapper are set later by IBCStackBuilder.
 func NewIBCMiddleware(k *keeper.Keeper) *IBCMiddleware {
     return &IBCMiddleware{
         keeper: k,
     }
 }
 
-/ SetUnderlyingApplication sets the underlying IBC module.
+// SetUnderlyingApplication sets the underlying IBC module.
 func (im *IBCMiddleware) SetUnderlyingApplication(app porttypes.IBCModule) {
     if im.app != nil {
         panic("underlying application already set")
@@ -64,7 +64,7 @@ func (im *IBCMiddleware) SetUnderlyingApplication(app porttypes.IBCModule) {
     im.app = app
 }
 
-/ SetICS4Wrapper sets the ICS4Wrapper.
+// SetICS4Wrapper sets the ICS4Wrapper.
 func (im *IBCMiddleware) SetICS4Wrapper(wrapper porttypes.ICS4Wrapper) {
     if wrapper == nil {
         panic("ICS4Wrapper cannot be nil")
@@ -123,14 +123,14 @@ OnChanOpenInit(
   version string,
 ) (string, error) {
     if version != "" {
-    / try to unmarshal JSON-encoded version string and pass
-    / the app-specific version to app callback.
-    / otherwise, pass version directly to app callback.
+    // try to unmarshal JSON-encoded version string and pass
+    // the app-specific version to app callback.
+    // otherwise, pass version directly to app callback.
     metadata, err := Unmarshal(version)
     if err != nil {
-      / Since it is valid for fee version to not be specified,
-      / the above middleware version may be for another middleware.
-      / Pass the entire version string onto the underlying application.
+      // Since it is valid for fee version to not be specified,
+      // the above middleware version may be for another middleware.
+      // Pass the entire version string onto the underlying application.
       return im.app.OnChanOpenInit(
         ctx,
         order,
@@ -144,9 +144,9 @@ OnChanOpenInit(
 
 else {
     metadata = {
-        / set middleware version to default value
+        // set middleware version to default value
         MiddlewareVersion: defaultMiddlewareVersion,
-        / allow application to return its default version
+        // allow application to return its default version
         AppVersion: "",
 }
  
@@ -156,8 +156,8 @@ else {
 
 doCustomLogic()
 
-  / if the version string is empty, OnChanOpenInit is expected to return
-  / a default version string representing the version(s)
+  // if the version string is empty, OnChanOpenInit is expected to return
+  // a default version string representing the version(s)
 
 it supports
   appVersion, err := im.app.OnChanOpenInit(
@@ -167,7 +167,7 @@ it supports
     portID,
     channelID,
     counterparty,
-    metadata.AppVersion, / note we only pass app version here
+    metadata.AppVersion, // note we only pass app version here
   )
     if err != nil {
     return "", err
@@ -194,9 +194,9 @@ OnChanOpenTry(
   counterparty channeltypes.Counterparty,
   counterpartyVersion string,
 ) (string, error) {
-  / try to unmarshal JSON-encoded version string and pass
-  / the app-specific version to app callback.
-  / otherwise, pass version directly to app callback.
+  // try to unmarshal JSON-encoded version string and pass
+  // the app-specific version to app callback.
+  // otherwise, pass version directly to app callback.
   cpMetadata, err := Unmarshal(counterpartyVersion)
     if err != nil {
     return app.OnChanOpenTry(
@@ -212,8 +212,8 @@ OnChanOpenTry(
 
 doCustomLogic()
 
-  / Call the underlying application's OnChanOpenTry callback.
-  / The try callback must select the final app-specific version string and return it.
+  // Call the underlying application's OnChanOpenTry callback.
+  // The try callback must select the final app-specific version string and return it.
   appVersion, err := app.OnChanOpenTry(
     ctx,
     order,
@@ -221,13 +221,13 @@ doCustomLogic()
     portID,
     channelID,
     counterparty,
-    cpMetadata.AppVersion, / note we only pass counterparty app version here
+    cpMetadata.AppVersion, // note we only pass counterparty app version here
   )
     if err != nil {
     return "", err
 }
 
-  / negotiate final middleware version
+  // negotiate final middleware version
     middlewareVersion := negotiateMiddlewareVersion(cpMetadata.MiddlewareVersion)
     version := constructVersion(middlewareVersion, appVersion)
 
@@ -251,9 +251,9 @@ OnChanOpenAck(
 )
 
 error {
-  / try to unmarshal JSON-encoded version string and pass
-  / the app-specific version to app callback.
-  / otherwise, pass version directly to app callback.
+  // try to unmarshal JSON-encoded version string and pass
+  // the app-specific version to app callback.
+  // otherwise, pass version directly to app callback.
   cpMetadata, err = UnmarshalJSON(counterpartyVersion)
     if err != nil {
     return app.OnChanOpenAck(ctx, portID, channelID, counterpartyChannelID, counterpartyVersion)
@@ -264,7 +264,7 @@ error {
 
 doCustomLogic()
 
-  / call the underlying application's OnChanOpenTry callback
+  // call the underlying application's OnChanOpenTry callback
   return app.OnChanOpenAck(ctx, portID, channelID, counterpartyChannelID, cpMetadata.AppVersion)
 }
 ```
@@ -345,7 +345,7 @@ ibcexported.Acknowledgement {
     doCustomLogic(packet)
     ack := app.OnRecvPacket(ctx, channelVersion, packet, relayer)
 
-doCustomLogic(ack) / middleware may modify outgoing ack
+doCustomLogic(ack) // middleware may modify outgoing ack
     
   return ack
 }
@@ -421,9 +421,9 @@ For stateless middleware, the `ics4Wrapper` can be passed on directly without ha
 [The interface](https://github.com/cosmos/ibc-go/blob/main/modules/core/05-port/types/module.go#L119-L143) looks as follows:
 
 ```go expandable
-/ This is implemented by ICS4 and all middleware that are wrapping base application.
-/ The base application will call `sendPacket` or `writeAcknowledgement` of the middleware directly above them
-/ which will call the next middleware until it reaches the core IBC handler.
+// This is implemented by ICS4 and all middleware that are wrapping base application.
+// The base application will call `sendPacket` or `writeAcknowledgement` of the middleware directly above them
+// which will call the next middleware until it reaches the core IBC handler.
 type ICS4Wrapper interface {
     SendPacket(
     ctx sdk.Context,
@@ -465,7 +465,7 @@ func SendPacket(
   timeoutTimestamp uint64,
   appData []byte,
 ) (uint64, error) {
-  / middleware may modify data
+  // middleware may modify data
   data = doCustomLogic(appData)
 
 return ics4Wrapper.SendPacket(
@@ -484,7 +484,7 @@ See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc
 ### `WriteAcknowledgement`
 
 ```go expandable
-/ only called for async acks
+// only called for async acks
 func WriteAcknowledgement(
   ctx sdk.Context,
   packet exported.PacketI,
@@ -492,7 +492,7 @@ func WriteAcknowledgement(
 )
 
 error {
-  / middleware may modify acknowledgement
+  // middleware may modify acknowledgement
   ack_bytes = doCustomLogic(ack)
 
 return ics4Wrapper.WriteAcknowledgement(packet, ack_bytes)
@@ -504,7 +504,7 @@ See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc
 ### `GetAppVersion`
 
 ```go expandable
-/ middleware must return the underlying application version
+// middleware must return the underlying application version
 func GetAppVersion(
   ctx sdk.Context,
   portID,
@@ -518,7 +518,7 @@ func GetAppVersion(
     return version, true
 }
 
-  / unwrap channel version
+  // unwrap channel version
   metadata, err := Unmarshal(version)
     if err != nil {
     panic(fmt.Errof("unable to unmarshal version: %w", err))
@@ -535,17 +535,17 @@ See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc
 Middleware must also implement the following functions so that they can be called in the stack builder in order to correctly wire the application stack together: `SetUnderlyingApplication` and `SetICS4Wrapper`.
 
 ```go expandable
-/ SetUnderlyingModule sets the underlying IBC module. This function may be used after
-/ the middleware's initialization to set the ibc module which is below this middleware.
+// SetUnderlyingModule sets the underlying IBC module. This function may be used after
+// the middleware's initialization to set the ibc module which is below this middleware.
 SetUnderlyingApplication(IBCModule)
 
-/ SetICS4Wrapper sets the ICS4Wrapper. This function may be used after
-/ the module's initialization to set the middleware which is above this
-/ module in the IBC application stack.
-/ The ICS4Wrapper **must** be used for sending packets and writing acknowledgements
-/ to ensure that the middleware can intercept and process these calls.
-/ Do not use the channel keeper directly to send packets or write acknowledgements
-/ as this will bypass the middleware.
+// SetICS4Wrapper sets the ICS4Wrapper. This function may be used after
+// the module's initialization to set the middleware which is above this
+// module in the IBC application stack.
+// The ICS4Wrapper **must** be used for sending packets and writing acknowledgements
+// to ensure that the middleware can intercept and process these calls.
+// Do not use the channel keeper directly to send packets or write acknowledgements
+// as this will bypass the middleware.
 SetICS4Wrapper(wrapper ICS4Wrapper)
 ```
 

--- a/ibc/next/ibc/middleware/develop.mdx
+++ b/ibc/next/ibc/middleware/develop.mdx
@@ -15,14 +15,14 @@ middleware developers must use the same serialization and deserialization method
 For middleware builders this means:
 
 ```go
-import transfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
+import transfertypes "github.com/cosmos/ibc-go/v11/modules/apps/transfer/types"
 transfertypes.ModuleCdc.[Must]MarshalJSON
 func MarshalAsIBCDoes(ack channeltypes.Acknowledgement) ([]byte, error) {
     return transfertypes.ModuleCdc.MarshalJSON(&ack)
 }
 ```
 
-The interfaces a middleware must implement are found [here](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/core/05-port/types/module.go).
+The interfaces a middleware must implement are found [here](https://github.com/cosmos/ibc-go/blob/main/modules/core/05-port/types/module.go).
 
 ```go
 / Middleware implements the ICS26 Module interface
@@ -36,30 +36,46 @@ type Middleware interface {
 }
 ```
 
-An `IBCMiddleware` struct implementing the `Middleware` interface, can be defined with its constructor as follows:
+An `IBCMiddleware` struct implementing the `Middleware` interface can be defined with its constructor as follows. Note that the constructor **does not** accept the underlying `app` or `ics4Wrapper` — those are wired up later by `IBCStackBuilder` via `SetUnderlyingApplication` and `SetICS4Wrapper`:
 
 ```go expandable
 / @ x/module_name/ibc_middleware.go
 
-/ IBCMiddleware implements the ICS26 callbacks and ICS4Wrapper for the fee middleware given the
-/ fee keeper and the underlying application.
+/ IBCMiddleware implements the ICS26 callbacks and ICS4Wrapper for the middleware given its keeper.
 type IBCMiddleware struct {
-    keeper *keeper.Keeper
+    app         porttypes.IBCModule
+    ics4Wrapper porttypes.ICS4Wrapper
+    keeper      *keeper.Keeper
 }
 
-/ NewIBCMiddleware creates a new IBCMiddleware given the keeper and underlying application
-func NewIBCMiddleware(k *keeper.Keeper)
-
-IBCMiddleware {
-    return IBCMiddleware{
-    keeper: k,
+/ NewIBCMiddleware creates a new IBCMiddleware given the keeper.
+/ The underlying app and ICS4Wrapper are set later by IBCStackBuilder.
+func NewIBCMiddleware(k *keeper.Keeper) *IBCMiddleware {
+    return &IBCMiddleware{
+        keeper: k,
+    }
 }
+
+/ SetUnderlyingApplication sets the underlying IBC module.
+func (im *IBCMiddleware) SetUnderlyingApplication(app porttypes.IBCModule) {
+    if im.app != nil {
+        panic("underlying application already set")
+    }
+    im.app = app
+}
+
+/ SetICS4Wrapper sets the ICS4Wrapper.
+func (im *IBCMiddleware) SetICS4Wrapper(wrapper porttypes.ICS4Wrapper) {
+    if wrapper == nil {
+        panic("ICS4Wrapper cannot be nil")
+    }
+    im.ics4Wrapper = wrapper
 }
 ```
 
 ## Implement `IBCModule` interface
 
-`IBCMiddleware` is a struct that implements the [ICS-26 `IBCModule` interface (`porttypes.IBCModule`)](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/core/05-port/types/module.go#L14-L107). It is recommended to separate these callbacks into a separate file `ibc_middleware.go`.
+`IBCMiddleware` is a struct that implements the [ICS-26 `IBCModule` interface (`porttypes.IBCModule`)](https://github.com/cosmos/ibc-go/blob/main/modules/core/05-port/types/module.go#L13-L118). It is recommended to separate these callbacks into a separate file `ibc_middleware.go`.
 
 > Note how this is analogous to implementing the same interfaces for IBC applications that act as base applications.
 
@@ -162,7 +178,7 @@ return version, nil
 }
 ```
 
-See [here](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/apps/29-fee/ibc_middleware.go#L36-L83) an example implementation of this callback for the ICS-29 Fee Middleware module.
+See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc_middleware.go#L314-L324) an example implementation of this callback for the Callbacks Middleware module.
 
 #### `OnChanOpenTry`
 
@@ -219,7 +235,7 @@ return version, nil
 }
 ```
 
-See [here](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/apps/29-fee/ibc_middleware.go#L88-L125) an example implementation of this callback for the ICS-29 Fee Middleware module.
+See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc_middleware.go#L327-L336) an example implementation of this callback for the Callbacks Middleware module.
 
 #### `OnChanOpenAck`
 
@@ -253,7 +269,7 @@ doCustomLogic()
 }
 ```
 
-See [here](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/apps/29-fee/ibc_middleware.go#L128-L153)) an example implementation of this callback for the ICS-29 Fee Middleware module.
+See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc_middleware.go#L339-L347) an example implementation of this callback for the Callbacks Middleware module.
 
 #### `OnChanOpenConfirm`
 
@@ -271,7 +287,7 @@ return app.OnChanOpenConfirm(ctx, portID, channelID)
 }
 ```
 
-See [here](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/apps/29-fee/ibc_middleware.go#L156-L163) an example implementation of this callback for the ICS-29 Fee Middleware module.
+See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc_middleware.go#L350-L352) an example implementation of this callback for the Callbacks Middleware module.
 
 #### `OnChanCloseInit`
 
@@ -289,7 +305,7 @@ return app.OnChanCloseInit(ctx, portID, channelID)
 }
 ```
 
-See [here](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/apps/29-fee/ibc_middleware.go#L166-L188) an example implementation of this callback for the ICS-29 Fee Middleware module.
+See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc_middleware.go#L355-L357) an example implementation of this callback for the Callbacks Middleware module.
 
 #### `OnChanCloseConfirm`
 
@@ -307,7 +323,7 @@ return app.OnChanCloseConfirm(ctx, portID, channelID)
 }
 ```
 
-See [here](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/apps/29-fee/ibc_middleware.go#L191-L213) an example implementation of this callback for the ICS-29 Fee Middleware module.
+See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc_middleware.go#L360-L362) an example implementation of this callback for the Callbacks Middleware module.
 
 ### Packet callbacks
 
@@ -320,13 +336,14 @@ func (im IBCMiddleware)
 
 OnRecvPacket(
   ctx sdk.Context,
+  channelVersion string,
   packet channeltypes.Packet,
   relayer sdk.AccAddress,
 )
 
 ibcexported.Acknowledgement {
     doCustomLogic(packet)
-    ack := app.OnRecvPacket(ctx, packet, relayer)
+    ack := app.OnRecvPacket(ctx, channelVersion, packet, relayer)
 
 doCustomLogic(ack) / middleware may modify outgoing ack
     
@@ -334,7 +351,7 @@ doCustomLogic(ack) / middleware may modify outgoing ack
 }
 ```
 
-See [here](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/apps/29-fee/ibc_middleware.go#L217-L238) an example implementation of this callback for the ICS-29 Fee Middleware module.
+See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc_middleware.go#L225-L265) an example implementation of this callback for the Callbacks Middleware module.
 
 #### `OnAcknowledgementPacket`
 
@@ -343,6 +360,7 @@ func (im IBCMiddleware)
 
 OnAcknowledgementPacket(
   ctx sdk.Context,
+  channelVersion string,
   packet channeltypes.Packet,
   acknowledgement []byte,
   relayer sdk.AccAddress,
@@ -351,11 +369,11 @@ OnAcknowledgementPacket(
 error {
     doCustomLogic(packet, ack)
 
-return app.OnAcknowledgementPacket(ctx, packet, ack, relayer)
+return app.OnAcknowledgementPacket(ctx, channelVersion, packet, ack, relayer)
 }
 ```
 
-See [here](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/apps/29-fee/ibc_middleware.go#L242-L293) an example implementation of this callback for the ICS-29 Fee Middleware module.
+See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc_middleware.go#L139-L180) an example implementation of this callback for the Callbacks Middleware module.
 
 #### `OnTimeoutPacket`
 
@@ -364,6 +382,7 @@ func (im IBCMiddleware)
 
 OnTimeoutPacket(
   ctx sdk.Context,
+  channelVersion string,
   packet channeltypes.Packet,
   relayer sdk.AccAddress,
 )
@@ -371,11 +390,11 @@ OnTimeoutPacket(
 error {
     doCustomLogic(packet)
 
-return app.OnTimeoutPacket(ctx, packet, relayer)
+return app.OnTimeoutPacket(ctx, channelVersion, packet, relayer)
 }
 ```
 
-See [here](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/apps/29-fee/ibc_middleware.go#L297-L335) an example implementation of this callback for the ICS-29 Fee Middleware module.
+See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc_middleware.go#L186-L218) an example implementation of this callback for the Callbacks Middleware module.
 
 ## ICS-04 wrappers
 
@@ -399,7 +418,7 @@ type Keeper struct {
 
 For stateless middleware, the `ics4Wrapper` can be passed on directly without having to instantiate a keeper struct for the middleware.
 
-[The interface](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/core/05-port/types/module.go#L110-L133) looks as follows:
+[The interface](https://github.com/cosmos/ibc-go/blob/main/modules/core/05-port/types/module.go#L119-L143) looks as follows:
 
 ```go expandable
 / This is implemented by ICS4 and all middleware that are wrapping base application.
@@ -460,7 +479,7 @@ return ics4Wrapper.SendPacket(
 }
 ```
 
-See [here](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/apps/29-fee/keeper/relay.go#L17-L27) an example implementation of this function for the ICS-29 Fee Middleware module.
+See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc_middleware.go#L92-L133) an example implementation of this function for the Callbacks Middleware module.
 
 ### `WriteAcknowledgement`
 
@@ -480,7 +499,7 @@ return ics4Wrapper.WriteAcknowledgement(packet, ack_bytes)
 }
 ```
 
-See [here](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/apps/29-fee/keeper/relay.go#L31-L55) an example implementation of this function for the ICS-29 Fee Middleware module.
+See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc_middleware.go#L272-L311) an example implementation of this function for the Callbacks Middleware module.
 
 ### `GetAppVersion`
 
@@ -509,7 +528,7 @@ return metadata.AppVersion, true
 }
 ```
 
-See [here](https://github.com/cosmos/ibc-go/blob/v7.0.0/modules/apps/29-fee/keeper/relay.go#L58-L74) an example implementation of this function for the ICS-29 Fee Middleware module.
+See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/ibc_middleware.go#L366-L368) an example implementation of this function for the Callbacks Middleware module.
 
 ## Wiring Interface Requirements
 

--- a/ibc/next/ibc/middleware/developIBCv2.mdx
+++ b/ibc/next/ibc/middleware/developIBCv2.mdx
@@ -36,19 +36,19 @@ The interfaces a middleware must implement are found in [core/api](https://githu
 An `IBCMiddleware` struct implementing the `Middleware` interface, can be defined with its constructor as follows:
 
 ```go expandable
-/ @ x/module_name/ibc_middleware.go
+// @ x/module_name/ibc_middleware.go
 
-/ IBCMiddleware implements the IBCv2 middleware interface
+// IBCMiddleware implements the IBCv2 middleware interface
 type IBCMiddleware struct {
-    app             api.PacketUnmarshalerModuleV2 / underlying app or middleware (must implement PacketUnmarshalerModuleV2)
-    writeAckWrapper api.WriteAcknowledgementWrapper / writes acknowledgement for an async acknowledgement
-    keeper          types.Keeper / required for stateful middleware
-    / Keeper may include middleware specific keeper and the ChannelKeeperV2
+    app             api.PacketUnmarshalerModuleV2 // underlying app or middleware (must implement PacketUnmarshalerModuleV2)
+    writeAckWrapper api.WriteAcknowledgementWrapper // writes acknowledgement for an async acknowledgement
+    keeper          types.Keeper // required for stateful middleware
+    // Keeper may include middleware specific keeper and the ChannelKeeperV2
 
-    / additional middleware specific fields
+    // additional middleware specific fields
 }
 
-/ NewIBCMiddleware creates a new IBCMiddleware given the keeper and underlying application
+// NewIBCMiddleware creates a new IBCMiddleware given the keeper and underlying application
 func NewIBCMiddleware(app api.IBCModule, 
 writeAckWrapper api.WriteAcknowledgementWrapper, 
 k types.Keeper
@@ -98,18 +98,18 @@ OnSendPacket(
 )
 
 error {
-	/ Middleware may choose to do custom preprocessing logic before calling the underlying app OnSendPacket
-	/ Middleware may return error early to reject the packet send
-	/ Middleware MUST NOT modify client identifiers and sequence
+	// Middleware may choose to do custom preprocessing logic before calling the underlying app OnSendPacket
+	// Middleware may return error early to reject the packet send
+	// Middleware MUST NOT modify client identifiers and sequence
 	doCustomPreProcessLogic()
 
-	/ call underlying app OnSendPacket
+	// call underlying app OnSendPacket
 	err := im.app.OnSendPacket(ctx, sourceClient, destinationClient, sequence, payload, signer)
 	if err != nil {
 		return err
 	}
 
-	/ may perform some post send logic and return error here
+	// may perform some post send logic and return error here
 	return doCustomPostProcessLogic()
 }
 ```
@@ -129,20 +129,20 @@ OnRecvPacket(
 )
 
 channeltypesv2.RecvPacketResult {
-	/ Middleware may choose to do custom preprocessing logic before calling the underlying app OnRecvPacket
-    / Middleware may choose to error early and return a RecvPacketResult Failure
-    / Middleware may choose to modify the payload before passing on to OnRecvPacket though this
-    / should only be done to support very advanced custom behavior
-    / Middleware MUST NOT modify client identifiers and sequence
+	// Middleware may choose to do custom preprocessing logic before calling the underlying app OnRecvPacket
+    // Middleware may choose to error early and return a RecvPacketResult Failure
+    // Middleware may choose to modify the payload before passing on to OnRecvPacket though this
+    // should only be done to support very advanced custom behavior
+    // Middleware MUST NOT modify client identifiers and sequence
     doCustomPreProcessLogic()
     
-	/ call underlying app OnRecvPacket
+	// call underlying app OnRecvPacket
     recvResult := im.app.OnRecvPacket(ctx, sourceClient, destinationClient, sequence, payload, relayer)
     if recvResult.Status == channeltypesv2.PacketStatus_Async || recvResult.Status == channeltypesv2.PacketStatus_Failure {
     return recvResult
 }
 
-doCustomPostProcessLogic(recvResult) / middleware may modify recvResult
+doCustomPostProcessLogic(recvResult) // middleware may modify recvResult
     
     return recvResult
 }
@@ -166,19 +166,19 @@ OnAcknowledgementPacket(
 )
 
 error {
-	/ preprocessing logic may modify the acknowledgement before passing to 
-	/ the underlying app though this should only be done in advanced cases
-	/ Middleware may return error early
-	/ it MUST NOT change the identifiers of the clients or the sequence
+	// preprocessing logic may modify the acknowledgement before passing to 
+	// the underlying app though this should only be done in advanced cases
+	// Middleware may return error early
+	// it MUST NOT change the identifiers of the clients or the sequence
 	doCustomPreProcessLogic(payload, acknowledgement)
 
-	/ call underlying app OnAcknowledgementPacket
+	// call underlying app OnAcknowledgementPacket
 	err := im.app.OnAcknowledgementPacket(ctx, sourceClient, destinationClient, sequence, acknowledgement, payload, relayer)
     if err != nil {
     return err
 }
 
-	/ may perform some post acknowledgement logic and return error here
+	// may perform some post acknowledgement logic and return error here
 	return doCustomPostProcessLogic()
 }
 ```
@@ -200,17 +200,17 @@ OnTimeoutPacket(
 )
 
 error {
-	/ Middleware may choose to do custom preprocessing logic before calling the underlying app OnTimeoutPacket
-	/ Middleware may return error early
+	// Middleware may choose to do custom preprocessing logic before calling the underlying app OnTimeoutPacket
+	// Middleware may return error early
 	doCustomPreProcessLogic(payload)
 
-	/ call underlying app OnTimeoutPacket
+	// call underlying app OnTimeoutPacket
 	err := im.app.OnTimeoutPacket(ctx, sourceClient, destinationClient, sequence, payload, relayer)
     if err != nil {
     return err
 }
 
-	/ may perform some post timeout logic and return error here
+	// may perform some post timeout logic and return error here
 	return doCustomPostProcessLogic()
 }
 ```
@@ -222,14 +222,14 @@ See [here](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/v2/
 Middleware must also wrap the `WriteAcknowledgement` interface so that any acknowledgement written by the application passes through the middleware first. This allows middleware to modify or delay writing an acknowledgment before committed to the IBC store.
 
 ```go
-/ WithWriteAckWrapper sets the WriteAcknowledgementWrapper for the middleware.
+// WithWriteAckWrapper sets the WriteAcknowledgementWrapper for the middleware.
 func (im *IBCMiddleware)
 
 WithWriteAckWrapper(writeAckWrapper api.WriteAcknowledgementWrapper) {
     im.writeAckWrapper = writeAckWrapper
 }
 
-/ GetWriteAckWrapper returns the WriteAckWrapper
+// GetWriteAckWrapper returns the WriteAckWrapper
 func (im *IBCMiddleware)
 
 GetWriteAckWrapper()
@@ -244,9 +244,9 @@ api.WriteAcknowledgementWrapper {
 This is where the middleware acknowledgement handling is finalised. An example is shown in the [callbacks middleware](https://github.com/cosmos/ibc-go/blob/main/modules/apps/callbacks/v2/ibc_middleware.go#L369-L454)
 
 ```go expandable
-/ WriteAcknowledgement facilitates acknowledgment being written asynchronously
-/ The call stack flows from the IBC application to the IBC core handler
-/ Thus this function is called by the IBC app or a lower-level middleware
+// WriteAcknowledgement facilitates acknowledgment being written asynchronously
+// The call stack flows from the IBC application to the IBC core handler
+// Thus this function is called by the IBC app or a lower-level middleware
 func (im IBCMiddleware)
 
 WriteAcknowledgement(
@@ -257,7 +257,7 @@ WriteAcknowledgement(
 )
 
 error {
-    doCustomPreProcessLogic() / may modify acknowledgement
+    doCustomPreProcessLogic() // may modify acknowledgement
 
 	return im.writeAckWrapper.WriteAcknowledgement(
 		ctx, clientID, sequence, ack,
@@ -276,18 +276,18 @@ The order of middleware **matters**, function calls from IBC to the application 
 The example integration is detailed for an IBC v2 stack using transfer and the callbacks middleware.
 
 ```go expandable
-/ Middleware Stacks
-/ initialising callbacks middleware  
+// Middleware Stacks
+// initialising callbacks middleware  
     maxCallbackGas := uint64(10_000_000)
     wasmStackIBCHandler := wasm.NewIBCHandler(app.WasmKeeper, app.IBCKeeper.ChannelKeeper, app.IBCKeeper.ChannelKeeper)
 
-/ Create the transferv2 stack with transfer and callbacks middleware
+// Create the transferv2 stack with transfer and callbacks middleware
   var ibcv2TransferStack ibcapi.IBCModule
 	ibcv2TransferStack = transferv2.NewIBCModule(app.TransferKeeper)
 
 ibcv2TransferStack = ibccallbacksv2.NewIBCMiddleware(ibcv2TransferStack, app.IBCKeeper.ChannelKeeperV2, wasmStackIBCHandler, app.IBCKeeper.ChannelKeeperV2, maxCallbackGas)
 
-/ Create static IBC v2 router, add app routes, then set and seal it
+// Create static IBC v2 router, add app routes, then set and seal it
   ibcRouterV2 := ibcapi.NewRouter()
 
 ibcRouterV2.AddRoute(ibctransfertypes.PortID, ibcv2TransferStack)

--- a/ibc/next/ibc/middleware/developIBCv2.mdx
+++ b/ibc/next/ibc/middleware/developIBCv2.mdx
@@ -24,7 +24,7 @@ middleware developers must use the same serialization and deserialization method
 For middleware builders this means:
 
 ```go
-import transfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
+import transfertypes "github.com/cosmos/ibc-go/v11/modules/apps/transfer/types"
 transfertypes.ModuleCdc.[Must]MarshalJSON
 func MarshalAsIBCDoes(ack channeltypes.Acknowledgement) ([]byte, error) {
     return transfertypes.ModuleCdc.MarshalJSON(&ack)
@@ -40,13 +40,12 @@ An `IBCMiddleware` struct implementing the `Middleware` interface, can be define
 
 / IBCMiddleware implements the IBCv2 middleware interface
 type IBCMiddleware struct {
-    app                   api.IBCModule / underlying app or middleware
-  writeAckWrapper       api. WriteAcknowledgementWrapper / writes acknowledgement for an async acknowledgement
-  PacketDataUnmarshaler api.PacketDataUnmarshaler / optional interface
-  keeper                types.Keeper / required for stateful middleware
-  / Keeper may include middleware specific keeper and the ChannelKeeperV2
+    app             api.PacketUnmarshalerModuleV2 / underlying app or middleware (must implement PacketUnmarshalerModuleV2)
+    writeAckWrapper api.WriteAcknowledgementWrapper / writes acknowledgement for an async acknowledgement
+    keeper          types.Keeper / required for stateful middleware
+    / Keeper may include middleware specific keeper and the ChannelKeeperV2
 
-  / additional middleware specific fields
+    / additional middleware specific fields
 }
 
 / NewIBCMiddleware creates a new IBCMiddleware given the keeper and underlying application
@@ -84,6 +83,37 @@ The `IBCModule` interface consists of the packet callbacks where cutom logic is 
 
 The packet callbacks are where the middleware performs most of its custom logic. The middleware may read the packet flow data and perform some additional packet handling, or it may modify the incoming data before it reaches the underlying application. This enables a wide degree of usecases, as a simple base application like token-transfer can be transformed for a variety of usecases by combining it with custom middleware, for example acting as a filter for which tokens can be sent and recieved.
 
+#### `OnSendPacket`
+
+```go expandable
+func (im IBCMiddleware)
+
+OnSendPacket(
+  ctx sdk.Context,
+	sourceClient string,
+	destinationClient string,
+	sequence uint64,
+	payload channeltypesv2.Payload,
+	signer sdk.AccAddress,
+)
+
+error {
+	/ Middleware may choose to do custom preprocessing logic before calling the underlying app OnSendPacket
+	/ Middleware may return error early to reject the packet send
+	/ Middleware MUST NOT modify client identifiers and sequence
+	doCustomPreProcessLogic()
+
+	/ call underlying app OnSendPacket
+	err := im.app.OnSendPacket(ctx, sourceClient, destinationClient, sequence, payload, signer)
+	if err != nil {
+		return err
+	}
+
+	/ may perform some post send logic and return error here
+	return doCustomPostProcessLogic()
+}
+```
+
 #### `OnRecvPacket`
 
 ```go expandable
@@ -108,7 +138,7 @@ channeltypesv2.RecvPacketResult {
     
 	/ call underlying app OnRecvPacket
     recvResult := im.app.OnRecvPacket(ctx, sourceClient, destinationClient, sequence, payload, relayer)
-    if recvResult.Status == PACKET_STATUS_FAILURE {
+    if recvResult.Status == channeltypesv2.PacketStatus_Async || recvResult.Status == channeltypesv2.PacketStatus_Failure {
     return recvResult
 }
 
@@ -143,10 +173,7 @@ error {
 	doCustomPreProcessLogic(payload, acknowledgement)
 
 	/ call underlying app OnAcknowledgementPacket
-	err = im.app.OnAcknowledgementPacket(
-		sourceClient, destinationClient, sequence,
-		acknowledgement, payload, relayer
-	)
+	err := im.app.OnAcknowledgementPacket(ctx, sourceClient, destinationClient, sequence, acknowledgement, payload, relayer)
     if err != nil {
     return err
 }
@@ -178,10 +205,7 @@ error {
 	doCustomPreProcessLogic(payload)
 
 	/ call underlying app OnTimeoutPacket
-	err = im.app.OnTimeoutPacket(
-		sourceClient, destinationClient, sequence,
-		payload, relayer
-	)
+	err := im.app.OnTimeoutPacket(ctx, sourceClient, destinationClient, sequence, payload, relayer)
     if err != nil {
     return err
 }
@@ -236,7 +260,7 @@ error {
     doCustomPreProcessLogic() / may modify acknowledgement
 
 	return im.writeAckWrapper.WriteAcknowledgement(
-		ctx, clientId, sequence, ack,
+		ctx, clientID, sequence, ack,
 	)
 }
 ```
@@ -261,7 +285,7 @@ The example integration is detailed for an IBC v2 stack using transfer and the c
   var ibcv2TransferStack ibcapi.IBCModule
 	ibcv2TransferStack = transferv2.NewIBCModule(app.TransferKeeper)
 
-ibcv2TransferStack = ibccallbacksv2.NewIBCMiddleware(transferv2.NewIBCModule(app.TransferKeeper), app.IBCKeeper.ChannelKeeperV2, wasmStackIBCHandler, app.IBCKeeper.ChannelKeeperV2, maxCallbackGas)
+ibcv2TransferStack = ibccallbacksv2.NewIBCMiddleware(ibcv2TransferStack, app.IBCKeeper.ChannelKeeperV2, wasmStackIBCHandler, app.IBCKeeper.ChannelKeeperV2, maxCallbackGas)
 
 / Create static IBC v2 router, add app routes, then set and seal it
   ibcRouterV2 := ibcapi.NewRouter()

--- a/ibc/next/ibc/middleware/integration.mdx
+++ b/ibc/next/ibc/middleware/integration.mdx
@@ -16,17 +16,17 @@ The order of middleware **matters**, function calls from IBC to the application 
 ## Example integration
 
 ```go expandable
-/ app.go pseudocode
+// app.go pseudocode
 
-/ middleware 1 and middleware 3 are stateful and maintain their own state.
-/ Their keepers may accept channelKeeper for internal use (e.g. querying channels),
-/ but do NOT store it as the ICS4Wrapper — that is wired by IBCStackBuilder.
-mw1Keeper := mw1.NewKeeper(storeKey1, ...) / used in stack 1 & 3
-mw3Keeper1 := mw3.NewKeeper(storeKey3, ...) / used in stack 1
-mw3Keeper2 := mw3.NewKeeper(storeKey3, ...) / used in stack 2
+// middleware 1 and middleware 3 are stateful and maintain their own state.
+// Their keepers may accept channelKeeper for internal use (e.g. querying channels),
+// but do NOT store it as the ICS4Wrapper — that is wired by IBCStackBuilder.
+mw1Keeper := mw1.NewKeeper(storeKey1, ...) // used in stack 1 & 3
+mw3Keeper1 := mw3.NewKeeper(storeKey3, ...) // used in stack 1
+mw3Keeper2 := mw3.NewKeeper(storeKey3, ...) // used in stack 2
 
-/ Only create App Module **once** and register in module manager
-/ if the module maintains independent state and/or processes sdk.Msgs
+// Only create App Module **once** and register in module manager
+// if the module maintains independent state and/or processes sdk.Msgs
 app.moduleManager = module.NewManager(
   ...
   mw1.NewAppModule(mw1Keeper),
@@ -36,45 +36,45 @@ app.moduleManager = module.NewManager(
   custom.NewAppModule(customKeeper)
 )
 
-/ NOTE: IBC Modules may be initialized any number of times provided they use a separate
-/ Keeper and underlying port.
+// NOTE: IBC Modules may be initialized any number of times provided they use a separate
+// Keeper and underlying port.
 
 customKeeper1 := custom.NewKeeper(..., KeeperCustom1, ...)
 customKeeper2 := custom.NewKeeper(..., KeeperCustom2, ...)
 
-/ initialize base IBC applications
-/ if you want to create two different stacks with the same base application,
-/ they must be given different Keepers and assigned different ports.
+// initialize base IBC applications
+// if you want to create two different stacks with the same base application,
+// they must be given different Keepers and assigned different ports.
 transferIBCModule := transfer.NewIBCModule(transferKeeper)
 customIBCModule1 := custom.NewIBCModule(customKeeper1, "portCustom1")
 customIBCModule2 := custom.NewIBCModule(customKeeper2, "portCustom2")
 
-/ create IBC stacks using IBCStackBuilder.
-/ NewIBCStackBuilder takes the channel keeper as the top-level ICS4Wrapper.
-/ Base() sets the bottom application; Next() adds middleware above it (bottom to top).
-/ IBCStackBuilder wires SetUnderlyingApplication and SetICS4Wrapper automatically —
-/ do NOT pass app or ics4Wrapper into middleware constructors directly.
-/ NOTE: middleware2 is stateless so it does not require a Keeper.
-/ stack 1 (top to bottom): mw1 -> mw3 -> transfer
+// create IBC stacks using IBCStackBuilder.
+// NewIBCStackBuilder takes the channel keeper as the top-level ICS4Wrapper.
+// Base() sets the bottom application; Next() adds middleware above it (bottom to top).
+// IBCStackBuilder wires SetUnderlyingApplication and SetICS4Wrapper automatically —
+// do NOT pass app or ics4Wrapper into middleware constructors directly.
+// NOTE: middleware2 is stateless so it does not require a Keeper.
+// stack 1 (top to bottom): mw1 -> mw3 -> transfer
 stack1 := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper).
   Base(transferIBCModule).
   Next(mw3.NewIBCMiddleware(mw3Keeper1)).
   Next(mw1.NewIBCMiddleware(mw1Keeper)).
   Build()
-/ stack 2 (top to bottom): mw3 -> mw2 -> custom1
+// stack 2 (top to bottom): mw3 -> mw2 -> custom1
 stack2 := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper).
   Base(customIBCModule1).
   Next(mw2.NewIBCMiddleware()).
   Next(mw3.NewIBCMiddleware(mw3Keeper2)).
   Build()
-/ stack 3 (top to bottom): mw2 -> mw1 -> custom2
+// stack 3 (top to bottom): mw2 -> mw1 -> custom2
 stack3 := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper).
   Base(customIBCModule2).
   Next(mw1.NewIBCMiddleware(mw1Keeper)).
   Next(mw2.NewIBCMiddleware()).
   Build()
 
-/ associate each stack with the port name provided by the underlying application
+// associate each stack with the port name provided by the underlying application
 ibcRouter := porttypes.NewRouter()
 
 ibcRouter.AddRoute("transfer", stack1)

--- a/ibc/next/ibc/middleware/integration.mdx
+++ b/ibc/next/ibc/middleware/integration.mdx
@@ -18,17 +18,14 @@ The order of middleware **matters**, function calls from IBC to the application 
 ```go expandable
 / app.go pseudocode
 
-/ middleware 1 and middleware 3 are stateful middleware, 
-/ perhaps implementing separate sdk.Msg and Handlers
-/ NOTE: NewKeeper returns a pointer so that we can modify
-/ the keepers later after initialization
-/ They are all initialized to use the channelKeeper directly at the start
-mw1Keeper := mw1.NewKeeper(storeKey1, ..., channelKeeper) / in stack 1 & 3
-/ middleware 2 is stateless
-mw3Keeper1 := mw3.NewKeeper(storeKey3,..., channelKeeper) /  in stack 1
-mw3Keeper2 := mw3.NewKeeper(storeKey3,..., channelKeeper) /  in stack 2
+/ middleware 1 and middleware 3 are stateful and maintain their own state.
+/ Their keepers may accept channelKeeper for internal use (e.g. querying channels),
+/ but do NOT store it as the ICS4Wrapper — that is wired by IBCStackBuilder.
+mw1Keeper := mw1.NewKeeper(storeKey1, ...) / used in stack 1 & 3
+mw3Keeper1 := mw3.NewKeeper(storeKey3, ...) / used in stack 1
+mw3Keeper2 := mw3.NewKeeper(storeKey3, ...) / used in stack 2
 
-/ Only create App Module **once** and register in app module
+/ Only create App Module **once** and register in module manager
 / if the module maintains independent state and/or processes sdk.Msgs
 app.moduleManager = module.NewManager(
   ...
@@ -43,47 +40,45 @@ app.moduleManager = module.NewManager(
 / Keeper and underlying port.
 
 customKeeper1 := custom.NewKeeper(..., KeeperCustom1, ...)
-
 customKeeper2 := custom.NewKeeper(..., KeeperCustom2, ...)
 
 / initialize base IBC applications
 / if you want to create two different stacks with the same base application,
 / they must be given different Keepers and assigned different ports.
-    transferIBCModule := transfer.NewIBCModule(transferKeeper)
-
+transferIBCModule := transfer.NewIBCModule(transferKeeper)
 customIBCModule1 := custom.NewIBCModule(customKeeper1, "portCustom1")
-
 customIBCModule2 := custom.NewIBCModule(customKeeper2, "portCustom2")
 
-/ create IBC stacks by combining middleware with base application
-/ IBC Stack builders are initialized with the IBC ChannelKeeper which is the top-level ICS4Wrapper
-/ NOTE: since middleware2 is stateless it does not require a Keeper
-/ stack 1 contains mw1 -> mw3 -> transfer
-stack1 := porttypes.NewStackBuilder(ibcChannelKeeper).
+/ create IBC stacks using IBCStackBuilder.
+/ NewIBCStackBuilder takes the channel keeper as the top-level ICS4Wrapper.
+/ Base() sets the bottom application; Next() adds middleware above it (bottom to top).
+/ IBCStackBuilder wires SetUnderlyingApplication and SetICS4Wrapper automatically —
+/ do NOT pass app or ics4Wrapper into middleware constructors directly.
+/ NOTE: middleware2 is stateless so it does not require a Keeper.
+/ stack 1 (top to bottom): mw1 -> mw3 -> transfer
+stack1 := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper).
   Base(transferIBCModule).
-  Next(mw3).
-  Next(mw1).
+  Next(mw3.NewIBCMiddleware(mw3Keeper1)).
+  Next(mw1.NewIBCMiddleware(mw1Keeper)).
   Build()
-/ stack 2 contains mw3 -> mw2 -> custom1
-stack2 := porttypes.NewStackBuilder(ibcChannelKeeper).
+/ stack 2 (top to bottom): mw3 -> mw2 -> custom1
+stack2 := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper).
   Base(customIBCModule1).
-  Next(mw2).
-  Next(mw3).
+  Next(mw2.NewIBCMiddleware()).
+  Next(mw3.NewIBCMiddleware(mw3Keeper2)).
   Build()
-/ stack 3 contains mw2 -> mw1 -> custom2
-stack3 := porttypes.NewStackBuilder(ibcChannelKeeper).
+/ stack 3 (top to bottom): mw2 -> mw1 -> custom2
+stack3 := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper).
   Base(customIBCModule2).
-  Next(mw1).
-  Next(mw2).
+  Next(mw1.NewIBCMiddleware(mw1Keeper)).
+  Next(mw2.NewIBCMiddleware()).
   Build()
 
-/ associate each stack with the moduleName provided by the underlying Keeper
-    ibcRouter := porttypes.NewRouter()
+/ associate each stack with the port name provided by the underlying application
+ibcRouter := porttypes.NewRouter()
 
 ibcRouter.AddRoute("transfer", stack1)
-
 ibcRouter.AddRoute("custom1", stack2)
-
 ibcRouter.AddRoute("custom2", stack3)
 
 app.IBCKeeper.SetRouter(ibcRouter)

--- a/ibc/next/light-clients/wasm/governance.mdx
+++ b/ibc/next/light-clients/wasm/governance.mdx
@@ -20,8 +20,8 @@ import (
   authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
   govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-  ibcwasmkeeper "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10/keeper"
-  ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10/types"
+  ibcwasmkeeper "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v11/keeper"
+  ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v11/types"
   ...
 )
 

--- a/ibc/next/light-clients/wasm/governance.mdx
+++ b/ibc/next/light-clients/wasm/governance.mdx
@@ -12,7 +12,7 @@ Learn how to upload Wasm light client byte code on a chain, and how to migrate a
 Both the storage of Wasm light client byte code as well as the migration of an existing Wasm light client contract are permissioned (i.e. only allowed to an authority such as governance). The designated authority is specified when instantiating `08-wasm`'s keeper: both [`NewKeeperWithVM`](https://github.com/cosmos/ibc-go/blob/57fcdb9a9a9db9b206f7df2f955866dc4e10fef4/modules/light-clients/08-wasm/keeper/keeper.go#L39-L47) and [`NewKeeperWithConfig`](https://github.com/cosmos/ibc-go/blob/57fcdb9a9a9db9b206f7df2f955866dc4e10fef4/modules/light-clients/08-wasm/keeper/keeper.go#L88-L96) constructor functions accept an `authority` argument that must be the address of the authorized actor. For example, in `app.go`, when instantiating the keeper, you can pass the address of the governance module:
 
 ```go expandable
-/ app.go
+// app.go
 import (
     
   ...
@@ -25,12 +25,12 @@ import (
   ...
 )
 
-/ app.go
+// app.go
 app.WasmClientKeeper = ibcwasmkeeper.NewKeeperWithVM(
   appCodec,
   runtime.NewKVStoreService(keys[ibcwasmtypes.StoreKey]),
   app.IBCKeeper.ClientKeeper,
- 	authtypes.NewModuleAddress(govtypes.ModuleName).String(), / authority
+ 	authtypes.NewModuleAddress(govtypes.ModuleName).String(), // authority
   wasmVM,
   app.GRPCQueryRouter(),
 )

--- a/ibc/next/light-clients/wasm/integration.mdx
+++ b/ibc/next/light-clients/wasm/integration.mdx
@@ -21,7 +21,7 @@ go get github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v11
 The sample code below shows the relevant integration points in `app.go` required to set up the `08-wasm` module in a chain binary. Since `08-wasm` is a light client module itself, please check out as well the section [Integrating light clients](/ibc/next/ibc/integration#integrating-light-clients) for more information:
 
 ```go expandable
-/ app.go
+// app.go
 import (
 
   ...
@@ -37,7 +37,7 @@ import (
 
 ...
 
-/ Register the AppModule for the 08-wasm module
+// Register the AppModule for the 08-wasm module
 ModuleBasics = module.NewBasicManager(
   ...
   ibcwasm.AppModuleBasic{
@@ -45,7 +45,7 @@ ModuleBasics = module.NewBasicManager(
   ...
 )
 
-/ Add 08-wasm Keeper
+// Add 08-wasm Keeper
 type SimApp struct {
   ...
   WasmClientKeeper ibcwasmkeeper.Keeper
@@ -66,12 +66,12 @@ func NewSimApp(
     ibcwasmtypes.StoreKey,
   )
 
-  / Instantiate 08-wasm's keeper
-  / This sample code uses a constructor function that
-  / accepts a pointer to an existing instance of Wasm VM.
-  / This is the recommended approach when the chain
-  / also uses `x/wasm`, and then the Wasm VM instance
-  / can be shared.
+  // Instantiate 08-wasm's keeper
+  // This sample code uses a constructor function that
+  // accepts a pointer to an existing instance of Wasm VM.
+  // This is the recommended approach when the chain
+  // also uses `x/wasm`, and then the Wasm VM instance
+  // can be shared.
   app.WasmClientKeeper = ibcwasmkeeper.NewKeeperWithVM(
     appCodec,
     runtime.NewKVStoreService(keys[ibcwasmtypes.StoreKey]),
@@ -85,7 +85,7 @@ func NewSimApp(
 app.IBCKeeper.ClientKeeper.AddRoute(ibcwasmtypes.ModuleName, &wasmLightClientModule)
 
 app.ModuleManager = module.NewManager(
-    / SDK app modules
+    // SDK app modules
     ...
     ibcwasm.NewAppModule(app.WasmClientKeeper),
   )
@@ -112,11 +112,11 @@ app.ModuleManager.SetOrderInitGenesis(genesisModuleOrder...)
 app.ModuleManager.SetOrderExportGenesis(genesisModuleOrder...)
   ...
 
-  / initialize BaseApp
+  // initialize BaseApp
   app.SetInitChainer(app.InitChainer)
   ...
 
-  / must be before Loading version
+  // must be before Loading version
     if manager := app.SnapshotManager(); manager != nil {
     err := manager.RegisterExtensions(
       ibcwasmkeeper.NewWasmSnapshotter(app.CommitMultiStore(), &app.WasmClientKeeper),
@@ -132,7 +132,7 @@ app.ModuleManager.SetOrderExportGenesis(genesisModuleOrder...)
     ctx := app.BaseApp.NewUncachedContext(true, cmtproto.Header{
 })
 
-    / Initialize pinned codes in wasmvm as they are not persisted there
+    // Initialize pinned codes in wasmvm as they are not persisted there
     if err := app.WasmClientKeeper.InitializePinnedCodes(ctx); err != nil {
     cmtos.Exit(fmt.Sprintf("failed initialize pinned codes %s", err))
 }
@@ -159,7 +159,7 @@ In order to share the Wasm VM instance, please follow the guideline below. Pleas
 The code to set this up would look something like this:
 
 ```go expandable
-/ app.go
+// app.go
 import (
 
   ...
@@ -176,11 +176,11 @@ import (
 
 ...
 
-/ instantiate the Wasm VM with the chosen parameters
+// instantiate the Wasm VM with the chosen parameters
 wasmer, err := wasmvm.NewVM(
   dataDir,
   availableCapabilities,
-  contractMemoryLimit, / default of 32
+  contractMemoryLimit, // default of 32
   contractDebugMode,
   memoryCacheSize,
 )
@@ -188,14 +188,14 @@ wasmer, err := wasmvm.NewVM(
     panic(err)
 }
 
-/ create an Option slice (or append to an existing one)
-/ with the option to use a custom Wasm VM instance
+// create an Option slice (or append to an existing one)
+// with the option to use a custom Wasm VM instance
 wasmOpts = []wasmkeeper.Option{
     wasmkeeper.WithWasmEngine(wasmer),
 }
 
-/ the keeper will use the provided Wasm VM instance,
-/ instead of instantiating a new one
+// the keeper will use the provided Wasm VM instance,
+// instead of instantiating a new one
 app.WasmKeeper = wasmkeeper.NewKeeper(
   appCodec,
   keys[wasmtypes.StoreKey],
@@ -222,7 +222,7 @@ app.WasmClientKeeper = ibcwasmkeeper.NewKeeperWithVM(
   runtime.NewKVStoreService(keys[ibcwasmtypes.StoreKey]),
   app.IBCKeeper.ClientKeeper,
   authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-  wasmer, / pass the Wasm VM instance to `08-wasm` keeper constructor
+  wasmer, // pass the Wasm VM instance to `08-wasm` keeper constructor
   app.GRPCQueryRouter(),
 )
 ...
@@ -243,7 +243,7 @@ Another configuration parameter of the Wasm VM is the contract memory limit (in 
 The following sample code shows how the keeper would be constructed using this method:
 
 ```go expandable
-/ app.go
+// app.go
 import (
 
   ...
@@ -256,8 +256,8 @@ import (
 
 ...
 
-/ homePath is the path to the directory where the data
-/ directory for Wasm blobs and caches will be created
+// homePath is the path to the directory where the data
+// directory for Wasm blobs and caches will be created
     wasmConfig := ibcwasmtypes.WasmConfig{
     DataDir:               filepath.Join(homePath, "ibc_08-wasm_client_data"),
     SupportedCapabilities: []string{"iterator"
@@ -293,10 +293,10 @@ We first construct a [`QueryPlugins`](https://github.com/cosmos/ibc-go/blob/57fc
 ```go
 queryPlugins := ibcwasmtypes.QueryPlugins {
     Custom: MyCustomQueryPlugin(),
-  / `myAcceptList` is a `[]string` containing the list of gRPC query paths that the chain wants to allow for the `08-wasm` module to query.
-  / These queries must be registered in the chain's gRPC query router, be deterministic, and track their gas usage.
-  / The `AcceptListStargateQuerier` function will return a query plugin that will only allow queries for the paths in the `myAcceptList`.
-  / The query responses are encoded in protobuf unlike the implementation in `x/wasm`.
+  // `myAcceptList` is a `[]string` containing the list of gRPC query paths that the chain wants to allow for the `08-wasm` module to query.
+  // These queries must be registered in the chain's gRPC query router, be deterministic, and track their gas usage.
+  // The `AcceptListStargateQuerier` function will return a query plugin that will only allow queries for the paths in the `myAcceptList`.
+  // The query responses are encoded in protobuf unlike the implementation in `x/wasm`.
   Stargate: ibcwasmtypes.AcceptListStargateQuerier(myAcceptList),
 }
 ```
@@ -305,7 +305,7 @@ Note that the `Stargate` querier appends the user defined accept list of query r
 The `defaultAcceptList` defines a single query route: `"/ibc.core.client.v1.Query/VerifyMembership"`. This allows for light client smart contracts to delegate parts of their workflow to other light clients for auxiliary proof verification. For example, proof of inclusion of block and tx data by a data availability provider.
 
 ```go
-/ defaultAcceptList defines a set of default allowed queries made available to the Querier.
+// defaultAcceptList defines a set of default allowed queries made available to the Querier.
 var defaultAcceptList = []string{
   "/ibc.core.client.v1.Query/VerifyMembership",
 }
@@ -339,7 +339,7 @@ app.WasmClientKeeper = ibcwasmkeeper.NewKeeperWithVM(
   runtime.NewKVStoreService(keys[ibcwasmtypes.StoreKey]),
   app.IBCKeeper.ClientKeeper,
   authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-  wasmer, / pass the Wasm VM instance to `08-wasm` keeper constructor
+  wasmer, // pass the Wasm VM instance to `08-wasm` keeper constructor
   app.GRPCQueryRouter(),
 + querierOption,
 )
@@ -368,7 +368,7 @@ func CreateWasmUpgradeHandler(
 upgradetypes.UpgradeHandler {
     return func(goCtx context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
     ctx := sdk.UnwrapSDKContext(goCtx)
-    / explicitly update the IBC 02-client params, adding the wasm client type
+    // explicitly update the IBC 02-client params, adding the wasm client type
     params := clientKeeper.GetParams(ctx)
 
 params.AllowedClients = append(params.AllowedClients, ibcwasmtypes.Wasm)
@@ -399,7 +399,7 @@ RegisterUpgradeHandlers() {
 },
 }
 
-    / configure store loader that checks if version == upgradeHeight and applies store upgrades
+    // configure store loader that checks if version == upgradeHeight and applies store upgrades
     app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 }
 }

--- a/ibc/next/light-clients/wasm/integration.mdx
+++ b/ibc/next/light-clients/wasm/integration.mdx
@@ -13,7 +13,7 @@ Learn how to integrate the `08-wasm` module in a chain binary and about the reco
 `08-wasm` has no stable releases yet. To use it, you need to import the git commit that contains the module with the compatible versions of `ibc-go` and `wasmvm`. To do so, run the following command with the desired git commit in your project:
 
 ```sh
-go get github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10
+go get github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v11
 ```
 
 ## `app.go` setup
@@ -29,9 +29,9 @@ import (
 
   cmtos "github.com/cometbft/cometbft/libs/os"
 
-  ibcwasm "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10"
-  ibcwasmkeeper "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10/keeper"
-  ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10/types"
+  ibcwasm "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v11"
+  ibcwasmkeeper "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v11/keeper"
+  ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v11/types"
   ...
 )
 
@@ -169,8 +169,8 @@ import (
   wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
   wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
-  ibcwasmkeeper "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10/keeper"
-  ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10/types"
+  ibcwasmkeeper "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v11/keeper"
+  ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v11/types"
   ...
 )
 
@@ -249,8 +249,8 @@ import (
   ...
   "github.com/cosmos/cosmos-sdk/runtime"
 
-  ibcwasmkeeper "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10/keeper"
-  ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10/types"
+  ibcwasmkeeper "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v11/keeper"
+  ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v11/types"
   ...
 )
 
@@ -353,7 +353,7 @@ If the chain's 02-client submodule parameter `AllowedClients` contains the singl
 import (
 
   ...
-  ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10/types"
+  ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v11/types"
   ...
 )
 

--- a/ibc/next/migrations/v10-to-v11.mdx
+++ b/ibc/next/migrations/v10-to-v11.mdx
@@ -10,6 +10,8 @@ This guide provides instructions for migrating to a new version of ibc-go.
 Diff examples are shown after the list of overall changes:
 
 * Chains will need to remove the `ParamSubspace` arg from all calls to `Keeper` constructors
+* `MsgSubmitMisbehaviour` has been removed. Use `MsgUpdateClient` with a `ClientMessage` that implements `Misbehaviour` instead (deprecated since v7)
+* (08-wasm) The deprecated `Checksums` type has been removed. Remove any direct usage of `ibcwasmtypes.Checksums` from your code
 
 ```diff
   app.IBCKeeper = ibckeeper.NewKeeper(

--- a/ibc/v0.2.0/index.mdx
+++ b/ibc/v0.2.0/index.mdx
@@ -9,7 +9,7 @@ The Inter-Blockchain Communication Protocol (IBC) is a protocol for authenticati
 
 ## Overview
 
-This is the documentation for IBC v0.2.0. For the latest documentation, please see the [next version](/ibc/next/index).
+This is the documentation for IBC v0.2.0. For the latest documentation, please see the [next version](/ibc/next/intro).
 
 ### Key Features
 
@@ -22,7 +22,7 @@ This is the documentation for IBC v0.2.0. For the latest documentation, please s
 
 - **Version:** v0.2.0
 - **Status:** Archived
-- **For Latest Docs:** [IBC Next](/ibc/next/index)
+- **For Latest Docs:** [IBC Next](/ibc/next/intro)
 
 ## Resources
 
@@ -32,4 +32,4 @@ This is the documentation for IBC v0.2.0. For the latest documentation, please s
 
 ---
 
-*For the most up-to-date documentation, please refer to the [next version](/ibc/next/index).*
+*For the most up-to-date documentation, please refer to the [next version](/ibc/next/intro).*


### PR DESCRIPTION
### Summary

Updates all IBC developer documentation to reflect breaking API changes in ibc-go v11.

**`ibc/next/ibc/integration.mdx`**
- Bumped all import paths from `v10` → `v11`
- Fixed `TransferKeeper` field type to pointer (`*ibctransferkeeper.Keeper`)
- Removed `ParamSubspace` (`app.GetSubspace()`) from `IBCKeeper` and `TransferKeeper` constructors (#8476)
- Added `app.AccountKeeper.AddressCodec()` to `TransferKeeper` constructor (#8573)
- Replaced manual middleware wiring with `porttypes.NewIBCStackBuilder` pattern
- Corrected IBC v2 stack — was incorrectly showing callbacks/wasm middleware; now correctly shows `transferv2.NewIBCModule(app.TransferKeeper)` per simapp
- Added `sdk.ValidateAuthority` notice after keeper configuration (#8820)

**`ibc/next/ibc/middleware/integration.mdx`**
- Fixed `NewStackBuilder` → `NewIBCStackBuilder` (actual function name)
- Updated `Next()` call examples to show inline middleware instantiation
- Updated channel keeper reference to `app.IBCKeeper.ChannelKeeper`

**`ibc/next/ibc/apps/ibcmodule.mdx`**
- Added `counterpartyChannelID string` parameter to `OnChanOpenAck`
- Added `channelVersion string` parameter to `OnRecvPacket`, `OnAcknowledgementPacket`, `OnTimeoutPacket`
- Fixed return types for `OnAcknowledgementPacket` and `OnTimeoutPacket`: `(*sdk.Result, error)` → `error`
- Added `SetICS4Wrapper` documentation — now required on all `IBCModule` implementations

**`ibc/next/ibc/middleware/develop.mdx`**
- Bumped import paths from `v10` → `v11`; stale `v7.0.0` GitHub links → `main`
- Rewrote middleware constructor pattern: constructors no longer accept `app IBCModule` or `ics4Wrapper`; wiring is done by `IBCStackBuilder` via `SetUnderlyingApplication` / `SetICS4Wrapper`
- Updated `OnRecvPacket`, `OnAcknowledgementPacket`, `OnTimeoutPacket` signatures with `channelVersion string`
- Replaced all broken `modules/apps/29-fee` links (module removed from ibc-go) with equivalent links to `modules/apps/callbacks/ibc_middleware.go` with correct line numbers
- Fixed `modules/core/05-port/types/module.go` anchor links for `IBCModule` (`#L13-L118`) and `ICS4Wrapper` (`#L119-L143`) interfaces

**`ibc/next/ibc/middleware/developIBCv2.mdx`**
- Bumped import path from `v10` → `v11`
- Fixed `IBCMiddleware.app` field type: `api.IBCModule` → `api.PacketUnmarshalerModuleV2`; removed incorrect separate `PacketDataUnmarshaler` field
- Added missing `OnSendPacket` callback section
- Fixed `OnRecvPacket` status check: `PACKET_STATUS_FAILURE` → `channeltypesv2.PacketStatus_Failure`; added missing `PacketStatus_Async` check
- Fixed `OnAcknowledgementPacket` and `OnTimeoutPacket` inner calls: added missing `ctx` as first argument
- Fixed `clientId` → `clientID` in `WriteAcknowledgement`
- Fixed integration example to reuse `ibcv2TransferStack` variable instead of creating a duplicate transfer module instance

**`ibc/next/migrations/v10-to-v11.mdx`**
- Added `MsgSubmitMisbehaviour` removal note — fully removed in v11, previously deprecated since v7 (#8516)
- Added `ibcwasmtypes.Checksums` type removal note for chains using 08-wasm (#8511)
