### PR TITLE
docs: sync example tutorials from cosmos/example

### DIFF
--- a/sdk/next/tutorials/example/03-build-a-module.mdx
+++ b/sdk/next/tutorials/example/03-build-a-module.mdx
@@ -13,7 +13,7 @@ Before continuing, you must follow the [Prerequisites guide](/sdk/next/tutorials
 
 ## Making modules
 
-The Cosmos SDK makes it easy to build custom business logic directly into your chain through modules. Every module follows the same overall pattern:
+The Cosmos SDK makes it easy to build custom business logic directly into your chain through modules. Every module follows the same overall pattern: 
 
 ```text
 proto files → code generation → keeper → msg server → query server → module.go → app wiring


### PR DESCRIPTION
Auto-synced from cosmos/example. Transforms docs/*.md to sdk/next/tutorials/example/*.mdx. Do not edit these files directly — edit the source in cosmos/example and let the sync bot update them.