### PR TITLE
docs: sync example tutorials from cosmos/example

### DIFF
--- a/sdk/next/tutorials/example/01-prerequisites.mdx
+++ b/sdk/next/tutorials/example/01-prerequisites.mdx
@@ -3,7 +3,7 @@ title: Prerequisites
 description: Install dependencies
 ---
 
-Before starting the tutorial, make sure you have the following tools installed.
+Before starting the tutorial, make sure you have the following tools installed on your machine.
 
 <Warning>
 This tutorial is intended for macOS and Linux systems. Other systems may have additional requirements.

--- a/sdk/next/tutorials/example/03-build-a-module.mdx
+++ b/sdk/next/tutorials/example/03-build-a-module.mdx
@@ -5,7 +5,7 @@ description: Build a simple counter module from scratch in minutes
 
 In [quickstart](/sdk/next/tutorials/example/02-quickstart), you started a chain and submitted a transaction to increase the counter. In this tutorial, you'll build a simple counter module from scratch. It follows the same overall structure as the full `x/counter`, but uses a stripped-down version so you can focus on the core steps of building and wiring a module yourself.
 
-By the end, you'll have built a working module and wired it into a running chain. For a deeper dive into how modules work in the Cosmos SDK, see [Intro to Modules](/sdk/next/learn/concepts/modules). 
+By the end, you'll have built a working module and wired it into a running chain. For a deeper dive into how modules work in the Cosmos SDK, see [Intro to Modules](/sdk/next/learn/concepts/modules).
 
 <Note>
 Before continuing, you must follow the [Prerequisites guide](/sdk/next/tutorials/example/01-prerequisites) to make sure everything is installed.


### PR DESCRIPTION
Auto-synced from cosmos/example. Transforms docs/*.md to sdk/next/tutorials/example/*.mdx. Do not edit these files directly — edit the source in cosmos/example and let the sync bot update them.