### PR TITLE
fix: correct 18 API inaccuracies in CosmJS v0.38.x docs

### DIFF
--- a/cosmjs/v0.38.x/api-reference/cosmwasm.mdx
+++ b/cosmjs/v0.38.x/api-reference/cosmwasm.mdx
@@ -296,8 +296,8 @@ interface SigningCosmWasmClientOptions extends CosmWasmClientOptions {
 | `setupWasmExtension` | `base: QueryClient` | `WasmExtension` |
 | `createWasmAminoConverters` | — | `AminoConverters` |
 | `instantiate2Address` | `checksum: Uint8Array`, `creator: string`, `salt: Uint8Array`, `prefix: string` | `string` |
-| `toBinary` | `obj: JsonObject` | `string` |
-| `fromBinary` | `binary: string` | `JsonObject` |
+| `toBinary` | `obj: any` | `string` |
+| `fromBinary` | `binary: string` | `any` |
 
 ## Encode Objects
 

--- a/cosmjs/v0.38.x/api-reference/math.mdx
+++ b/cosmjs/v0.38.x/api-reference/math.mdx
@@ -44,7 +44,7 @@ npm install @cosmjs/math
 
 ## Uint64
 
-64-bit unsigned integer. Uses string-based internal representation for values beyond JavaScript's safe integer range.
+64-bit unsigned integer. Uses `bigint` internal representation for values beyond JavaScript's safe integer range.
 
 | Method | Parameters | Returns |
 |--------|------------|---------|

--- a/cosmjs/v0.38.x/api-reference/proto-signing.mdx
+++ b/cosmjs/v0.38.x/api-reference/proto-signing.mdx
@@ -74,11 +74,11 @@ Single-key wallet for Protobuf Direct signing. Implements `OfflineDirectSigner`.
 
 ## DirectEthSecp256k1HdWallet
 
-HD wallet using Ethereum's secp256k1 curve for chains with EVM compatibility. Same API as `DirectSecp256k1HdWallet`.
+HD wallet using Ethereum's secp256k1 curve for chains with EVM compatibility. Supports `generate`, `fromMnemonic`, `getAccounts`, and `signDirect` like `DirectSecp256k1HdWallet`, but uses the Ethereum HD path `m/44'/60'/0'/0/0` by default and Keccak-256 for address derivation. Does not support wallet serialization (`serialize`/`deserialize`).
 
 ## DirectEthSecp256k1Wallet
 
-Single-key wallet using Ethereum's secp256k1 curve. Same API as `DirectSecp256k1Wallet`.
+Single-key wallet using Ethereum's secp256k1 curve. Supports `fromKey`, `getAccounts`, and `signDirect` like `DirectSecp256k1Wallet`, but reports `algo: "eth_secp256k1"` and uses Keccak-256 for signing.
 
 ## Registry
 
@@ -183,12 +183,13 @@ interface DecodedTxRaw {
 
 | Function | Parameters | Returns |
 |----------|------------|---------|
-| `makeAuthInfoBytes` | `signers: ReadonlyArray<{ pubkey: Any; sequence: bigint \| number }>`, `feeAmount: readonly Coin[]`, `gasLimit: number`, `feeGranter?: string`, `feePayer?: string`, `signMode?: SignMode` | `Uint8Array` |
+| `makeAuthInfoBytes` | `signers: ReadonlyArray<{ pubkey: Any; sequence: bigint \| number }>`, `feeAmount: readonly Coin[]`, `gasLimit: number`, `feeGranter: string \| undefined`, `feePayer: string \| undefined`, `signMode?: SignMode` | `Uint8Array` |
 | `makeSignDoc` | `bodyBytes: Uint8Array`, `authInfoBytes: Uint8Array`, `chainId: string`, `accountNumber: number` | `SignDoc` |
 | `makeSignBytes` | `signDoc: SignDoc` | `Uint8Array` |
 | `decodeTxRaw` | `tx: Uint8Array` | `DecodedTxRaw` |
 | `encodePubkey` | `pubkey: Pubkey` | `Any` |
-| `decodePubkey` | `pubkey: Any \| null` | `Pubkey \| null` |
+| `decodePubkey` | `pubkey: Any` | `Pubkey` |
+| `decodeOptionalPubkey` | `pubkey: Any \| null \| undefined` | `Pubkey \| null` |
 | `makeCosmoshubPath` | `account: number` | `HdPath` |
 | `coin` | `amount: number \| string`, `denom: string` | `Coin` |
 | `coins` | `amount: number \| string`, `denom: string` | `Coin[]` |

--- a/cosmjs/v0.38.x/api-reference/stargate.mdx
+++ b/cosmjs/v0.38.x/api-reference/stargate.mdx
@@ -163,7 +163,7 @@ Setup functions to add module-specific query methods:
 | `setupGovExtension` | `gov` | `proposals`, `proposal`, `deposits`, `votes`, `tally` |
 | `setupDistributionExtension` | `distribution` | `delegationRewards`, `delegationTotalRewards`, `communityPool` |
 | `setupMintExtension` | `mint` | `inflation`, `annualProvisions`, `params` |
-| `setupAuthExtension` | `auth` | `account`, `accounts` |
+| `setupAuthExtension` | `auth` | `account` |
 | `setupIbcExtension` | `ibc` | `channel.channel`, `channel.channels`, `transfer.denomTrace` |
 | `setupTxExtension` | `tx` | `getTx`, `simulate` |
 | `setupSlashingExtension` | `slashing` | `signingInfos`, `params` |

--- a/cosmjs/v0.38.x/api-reference/stream.mdx
+++ b/cosmjs/v0.38.x/api-reference/stream.mdx
@@ -59,7 +59,7 @@ const items = await toListPromise(stream, 5);
 | Function | Parameters | Returns |
 |----------|------------|---------|
 | `concat` | `...streams: Array<Stream<T>>` | `Stream<T>` |
-| `dropDuplicates` | `valueToKey?: (x: T) => string` | `SameTypeStreamOperator<T>` |
+| `dropDuplicates` | `valueToKey: (x: T) => string` | `SameTypeStreamOperator<T>` |
 
 
 ## Reducer

--- a/cosmjs/v0.38.x/api-reference/tendermint-rpc.mdx
+++ b/cosmjs/v0.38.x/api-reference/tendermint-rpc.mdx
@@ -24,9 +24,9 @@ const client = await connectComet("https://rpc.my-chain.network");
 const status = await client.status();
 ```
 
-## CometClient Interface
+## CometClient
 
-All version-specific clients (`Tendermint37Client`, `Comet38Client`, `Comet1Client`) implement this interface.
+`CometClient` is a union type of all version-specific clients: `Tendermint37Client | Comet38Client | Comet1Client`. They share these methods:
 
 | Method | Parameters | Returns |
 |--------|------------|---------|
@@ -90,7 +90,7 @@ Standard HTTP client for request/response RPC.
 
 | Method | Parameters | Returns |
 |--------|------------|---------|
-| `constructor` | `endpoint: string \| HttpEndpoint` | `HttpClient` |
+| `constructor` | `endpoint: string \| HttpEndpoint`, `timeout?: number` | `HttpClient` |
 | `execute` | `request: JsonRpcRequest` | `Promise<JsonRpcSuccessResponse>` |
 | `disconnect` | — | `void` |
 
@@ -100,7 +100,7 @@ Batches multiple RPC requests into a single HTTP call.
 
 | Method | Parameters | Returns |
 |--------|------------|---------|
-| `constructor` | `endpoint: string \| HttpEndpoint`, `options?: HttpBatchClientOptions` | `HttpBatchClient` |
+| `constructor` | `endpoint: string \| HttpEndpoint`, `options?: Partial<HttpBatchClientOptions>` | `HttpBatchClient` |
 | `execute` | `request: JsonRpcRequest` | `Promise<JsonRpcSuccessResponse>` |
 | `disconnect` | — | `void` |
 
@@ -121,7 +121,7 @@ WebSocket client for streaming subscriptions.
 |--------|------------|---------|
 | `constructor` | `endpoint: string`, `onError?: (err: any) => void` | `WebsocketClient` |
 | `execute` | `request: JsonRpcRequest` | `Promise<JsonRpcSuccessResponse>` |
-| `listen` | `request: JsonRpcRequest` | `Stream<JsonRpcEvent>` |
+| `listen` | `request: JsonRpcRequest` | `Stream<SubscriptionEvent>` |
 | `disconnect` | — | `void` |
 
 ## Key Types
@@ -161,9 +161,9 @@ enum BlockIdFlag {
 
 | Function | Parameters | Returns |
 |----------|------------|---------|
-| `fromRfc3339WithNanoseconds` | `str: string` | `ReadonlyDateWithNanoseconds` |
+| `fromRfc3339WithNanoseconds` | `str: string` | `DateWithNanoseconds` |
 | `toRfc3339WithNanoseconds` | `date: ReadonlyDateWithNanoseconds` | `string` |
-| `fromSeconds` | `seconds: number`, `nanos?: number` | `ReadonlyDateWithNanoseconds` |
+| `fromSeconds` | `seconds: number`, `nanos?: number` | `DateWithNanoseconds` |
 | `toSeconds` | `date: ReadonlyDateWithNanoseconds` | `{ seconds: number; nanos: number }` |
 
 ## Address Utilities

--- a/cosmjs/v0.38.x/concepts/clients/signing-clients.mdx
+++ b/cosmjs/v0.38.x/concepts/clients/signing-clients.mdx
@@ -56,7 +56,7 @@ const client = await SigningStargateClient.connectWithSigner(
 | `signAndBroadcast(address, messages, fee, memo?, timeoutHeight?)` | Sign, broadcast, and wait for inclusion |
 | `signAndBroadcastSync(address, messages, fee, memo?, timeoutHeight?)` | Sign and broadcast, return tx hash immediately |
 | `sign(address, messages, fee, memo, signerData?, timeoutHeight?)` | Sign without broadcasting (returns `TxRaw`) |
-| `simulate(address, messages, memo?)` | Estimate gas for a transaction |
+| `simulate(address, messages, memo)` | Estimate gas for a transaction (`memo` is `string \| undefined`, not optional — pass `undefined` explicitly) |
 
 ### Convenience Methods
 

--- a/cosmjs/v0.38.x/concepts/cosmos-evm/signing-client.mdx
+++ b/cosmjs/v0.38.x/concepts/cosmos-evm/signing-client.mdx
@@ -4,8 +4,15 @@ description: Connecting SigningStargateClient with EVM wallets in CosmJS.
 ---
 
 `SigningStargateClient` works with EVM wallets without any special configuration.
-The client inspects the `algo` field from the wallet's `AccountData` and
-automatically selects the correct pubkey encoding:
+When signing transactions, the client inspects the `algo` field from the wallet's
+`AccountData` and automatically selects the correct pubkey encoding.
+
+<Warning>
+Gas simulation (`simulate()`) always uses standard secp256k1 pubkey encoding
+regardless of the wallet's `algo` field. This means `"auto"` fees may produce
+incorrect simulations with EVM wallets. Use explicit `StdFee` values instead of
+`"auto"` when working with `DirectEthSecp256k1HdWallet`.
+</Warning>
 
 ```typescript
 import { SigningStargateClient, GasPrice } from "@cosmjs/stargate";

--- a/cosmjs/v0.38.x/concepts/errors/queries.mdx
+++ b/cosmjs/v0.38.x/concepts/errors/queries.mdx
@@ -7,7 +7,7 @@ These errors occur when querying accounts, contracts, or other on-chain resource
 
 ## Account / Resource Not Found
 
-Methods like `getAccount`, `getContract`, and `getDelegation` catch "not found"
+Methods like `getAccount` and `getDelegation` catch "not found"
 gRPC errors internally and return `null` instead of throwing:
 
 ```typescript
@@ -15,7 +15,10 @@ const account = await client.getAccount("cosmos1nonexistent...");
 // Returns null, does not throw
 ```
 
-However, `getSequence` throws if the account does not exist because a sequence
+`getContract` does not return `null` — it throws if no contract is found at the
+given address.
+
+`getSequence` also throws if the account does not exist because a sequence
 number is always required for signing:
 
 ```

--- a/cosmjs/v0.38.x/concepts/fees-gas/dynamic-gas-pricing.mdx
+++ b/cosmjs/v0.38.x/concepts/fees-gas/dynamic-gas-pricing.mdx
@@ -43,7 +43,7 @@ const result = await client.signAndBroadcast(address, messages, "auto");
 
 When `"auto"` fee is used with a `DynamicGasPriceConfig`:
 
-1. The chain's feemarket module is queried for the current base gas price
+1. The chain's fee module is queried for the current base gas price (Osmosis uses `/osmosis.txfees.v1beta1.Query/GetEipBaseFee`; other chains use Skip's `/feemarket.feemarket.v1.Query/GasPrices`)
 2. The `multiplier` is applied (default 1.3x) to stay above the minimum
 3. The result is clamped between `minGasPrice` and `maxGasPrice`
 4. If the query fails, `minGasPrice` is used as a fallback

--- a/cosmjs/v0.38.x/concepts/messages-encoding/protobuf-encoding.mdx
+++ b/cosmjs/v0.38.x/concepts/messages-encoding/protobuf-encoding.mdx
@@ -60,7 +60,9 @@ const authInfoBytes = makeAuthInfoBytes(
 Each signer entry includes:
 - **pubkey** — the signer's public key, encoded as `Any`
 - **sequence** — the account's current transaction counter
-- **signMode** — `SIGN_MODE_DIRECT` for Protobuf signing
+
+The `signMode` parameter is a single global setting (not per-signer) that
+defaults to `SIGN_MODE_DIRECT`.
 
 ## TxRaw
 


### PR DESCRIPTION
## Summary

Fixes 18 factual errors in the CosmJS v0.38.x documentation, all verified against the [cosmos/cosmjs](https://github.com/cosmos/cosmjs) `main` branch source code.

### API Reference Fixes (11 files)

- **stream.mdx**: `dropDuplicates` `valueToKey` parameter is required, not optional ([source](https://github.com/cosmos/cosmjs/blob/main/packages/stream/src/dropduplicates.ts#L27))
- **stargate.mdx**: Remove nonexistent `auth.accounts` method from `setupAuthExtension` ([source](https://github.com/cosmos/cosmjs/blob/main/packages/stargate/src/modules/auth/queries.ts#L7-L16))
- **tendermint-rpc.mdx**:
  - `CometClient` is a union type alias, not an interface ([source](https://github.com/cosmos/cosmjs/blob/main/packages/tendermint-rpc/src/tendermintclient.ts#L7))
  - `WebsocketClient.listen` returns `Stream<SubscriptionEvent>`, not `Stream<JsonRpcEvent>` (type does not exist) ([source](https://github.com/cosmos/cosmjs/blob/main/packages/tendermint-rpc/src/rpcclients/websocketclient.ts#L179))
  - `HttpClient` constructor missing `timeout?: number` parameter ([source](https://github.com/cosmos/cosmjs/blob/main/packages/tendermint-rpc/src/rpcclients/httpclient.ts#L30))
  - `HttpBatchClient` options type is `Partial<HttpBatchClientOptions>` ([source](https://github.com/cosmos/cosmjs/blob/main/packages/tendermint-rpc/src/rpcclients/httpbatchclient.ts#L41))
  - `fromRfc3339WithNanoseconds` and `fromSeconds` return `DateWithNanoseconds`, not `ReadonlyDateWithNanoseconds` ([source](https://github.com/cosmos/cosmjs/blob/main/packages/tendermint-rpc/src/dates.ts#L15))
- **proto-signing.mdx**:
  - `decodePubkey` accepts `Any` only (not `Any | null`); add separate `decodeOptionalPubkey` ([source](https://github.com/cosmos/cosmjs/blob/main/packages/proto-signing/src/pubkey.ts#L102))
  - `makeAuthInfoBytes` `feeGranter`/`feePayer` are required positional args (`string | undefined`), not optional ([source](https://github.com/cosmos/cosmjs/blob/main/packages/proto-signing/src/signing.ts#L33-L40))
  - `DirectEthSecp256k1HdWallet` is NOT "Same API" — lacks serialization methods, uses different HD path ([source](https://github.com/cosmos/cosmjs/blob/main/packages/proto-signing/src/directethsecp256k1hdwallet.ts))
- **math.mdx**: `Uint64` uses `bigint` internally, not "string-based" ([source](https://github.com/cosmos/cosmjs/blob/main/packages/math/src/integers.ts#L239))
- **cosmwasm.mdx**: `toBinary`/`fromBinary` use `any`, not `JsonObject` ([source](https://github.com/cosmos/cosmjs/blob/main/packages/cosmwasm/src/encoding.ts#L9-L18))

### Concept Page Fixes

- **errors/queries.mdx**: `getContract` throws on not-found, does not return `null` ([source](https://github.com/cosmos/cosmjs/blob/main/packages/cosmwasm/src/cosmwasmclient.ts#L416-L419))
- **cosmos-evm/signing-client.mdx**: Add warning that `simulate()` always uses secp256k1 pubkey encoding, breaking `"auto"` fees with EVM wallets ([source](https://github.com/cosmos/cosmjs/blob/main/packages/stargate/src/signingstargateclient.ts#L203))
- **protobuf-encoding.mdx**: `signMode` is a global parameter on `makeAuthInfoBytes`, not per-signer ([source](https://github.com/cosmos/cosmjs/blob/main/packages/proto-signing/src/signing.ts#L33-L40))
- **dynamic-gas-pricing.mdx**: Document that Osmosis uses a different query path (`/osmosis.txfees.v1beta1.Query/GetEipBaseFee`) ([source](https://github.com/cosmos/cosmjs/blob/main/packages/stargate/src/feemarket.ts#L108-L122))
- **signing-clients.mdx**: `simulate()` `memo` is `string | undefined` (required positional), not optional ([source](https://github.com/cosmos/cosmjs/blob/main/packages/stargate/src/signingstargateclient.ts#L191-L194))

## Test plan

- [ ] Run `npx mint dev` and verify all edited pages render correctly
- [ ] Verify no broken links with `npx mint broken-links`
- [ ] Cross-check each fix against the linked source files


Made with [Cursor](https://cursor.com)