### PR TITLE
WIP Ibc intro docs

### DIFF
--- a/ibc/latest/intro/how-ibc-works.mdx
+++ b/ibc/latest/intro/how-ibc-works.mdx
@@ -37,7 +37,7 @@ Every step requires cryptographic proof. If a proof is missing or invalid, that 
 
 The entire protocol is built around four events: a packet is sent, received, acknowledged, or timed out. Light clients, relayers, and IBC Core all exist to make those four events happen reliably between chains.
 
-The diagram above is a simplified version of how IBC works. The rest of this document goes deeper on each piece: the key components, how packets are structured, and how applications plug in. For a detailed look at the complete packet flow, see the [IBC Lifecycle](ibc/latest/intro/ibc-lifecycle) page.
+The diagram above is a simplified version of how IBC works. The rest of this document goes deeper on each piece: the key components, how packets are structured, and how applications plug in. For a detailed look at the complete packet flow, see the [IBC Lifecycle](/ibc/latest/intro/ibc-lifecycle) page.
 
 ## Packets
 

--- a/ibc/latest/intro/how-ibc-works.mdx
+++ b/ibc/latest/intro/how-ibc-works.mdx
@@ -6,7 +6,7 @@ This page explains how IBC works at a conceptual level, from the problem it solv
 
 In [What is IBC](ibc/latest/intro/what-is-ibc), you learned that IBC solves the chain isolation problem by letting blockchains exchange messages with cryptographic verification instead of solely relying on a centralized bridge or oracle. 
 
-IBC is flexible in how that verification works: each chain runs a light client to verify the other chain's state, and different light client types support different verification approaches. A consensus light client tracks block headers and validates them against the counterparty's consensus rules. An attestation light client relies on a trusted committee, oracle network, or existing signing infrastructure to attest to the counterparty's state. In either case, each chain performs its own verification independently rather than solely depending on a shared bridge operator.
+IBC is flexible in how that verification works: each chain runs a light client to verify the other chain's state, and different light client types support different verification approaches. A consensus light client tracks block headers and validates them against the counterparty's consensus rules. An attestation light client relies on a set of attestors to attest to the counterparty's state. In either case, each chain performs its own verification independently rather than solely depending on a shared bridge operator.
 
 Every cross-chain IBC message is wrapped in a packet. A packet contains routing information (which chains are involved, when it expires) and one or more payloads, where each payload is the actual application data: a token transfer, a contract call, or an arbitrary message. IBC itself is agnostic to the payload; it moves packets reliably and lets applications decide what to do with them.
 
@@ -47,7 +47,7 @@ A packet contains two things: routing information and one or more payloads.
 
 The routing information tells the protocol which chains are involved, which sequence number this packet is, and when it expires. This is what IBC Core (the on-chain IBC logic) uses to track the packet, verify proofs against it, and prevent replay.
 
-The payloads carry the actual message data: which ports are involved and the raw bytes of the message itself. IBC Core treats those bytes as opaque and passes them through untouched. A single packet can carry multiple payloads, which execute atomically (all succeed or all fail).
+The payloads carry the actual message data, which contains the ports are involved and the raw bytes of the message itself. IBC Core treats those bytes as opaque and passes them through untouched. A single packet can carry multiple payloads, which execute atomically (all succeed or all fail).
 
 Every packet has a timeout. If it is not delivered before the deadline, the sender can prove it was never received and the application rolls back. Packets are never silently lost, and every packet either completes or times out.
 

--- a/ibc/latest/intro/how-ibc-works.mdx
+++ b/ibc/latest/intro/how-ibc-works.mdx
@@ -94,7 +94,7 @@ The client router maps each incoming proof to the correct light client for verif
 
 The port router delivers verified payloads to the correct application. Each application registers under a port ID, and the port router matches the destination port in the payload to the registered application.
 
-For a detailed walkthrough of how a packet moves through these components from send to acknowledgement, see [IBC Lifecycle](ibc/latest/intro/ibc-lifecycle).
+For a detailed walkthrough of how a packet moves through these components from send to acknowledgement, see [IBC Lifecycle](/ibc/latest/intro/ibc-lifecycle).
 
 ## IBC Applications
 

--- a/ibc/latest/intro/how-ibc-works.mdx
+++ b/ibc/latest/intro/how-ibc-works.mdx
@@ -4,7 +4,7 @@ This page explains how IBC works at a conceptual level, from the problem it solv
 
 ## IBC Overview
 
-In [What is IBC](ibc/latest/intro/what-is-ibc), you learned that IBC solves the chain isolation problem by letting blockchains exchange messages with cryptographic verification instead of solely relying on a centralized bridge or oracle. 
+In [What is IBC](/ibc/latest/intro/what-is-ibc), you learned that IBC solves the chain isolation problem by letting blockchains exchange messages with cryptographic verification instead of solely relying on a centralized bridge or oracle. 
 
 IBC is flexible in how that verification works: each chain runs a light client to verify the other chain's state, and different light client types support different verification approaches. A consensus light client tracks block headers and validates them against the counterparty's consensus rules. An attestation light client relies on a set of attestors to attest to the counterparty's state. In either case, each chain performs its own verification independently rather than solely depending on a shared bridge operator.
 

--- a/ibc/latest/intro/how-ibc-works.mdx
+++ b/ibc/latest/intro/how-ibc-works.mdx
@@ -1,0 +1,109 @@
+# How IBC works
+
+This page explains how IBC works at a conceptual level, from the problem it solves to the components that make cross-chain communication possible.
+
+## IBC Overview
+
+In [What is IBC](ibc/latest/intro/what-is-ibc), you learned that IBC solves the chain isolation problem by letting blockchains exchange messages with cryptographic verification instead of solely relying on a centralized bridge or oracle. 
+
+IBC is flexible in how that verification works: each chain runs a light client to verify the other chain's state, and different light client types support different verification approaches. A consensus light client tracks block headers and validates them against the counterparty's consensus rules. An attestation light client relies on a trusted committee, oracle network, or existing signing infrastructure to attest to the counterparty's state. In either case, each chain performs its own verification independently rather than solely depending on a shared bridge operator.
+
+Every cross-chain IBC message is wrapped in a packet. A packet contains routing information (which chains are involved, when it expires) and one or more payloads, where each payload is the actual application data: a token transfer, a contract call, or an arbitrary message. IBC itself is agnostic to the payload; it moves packets reliably and lets applications decide what to do with them.
+
+Packets are ferried between chains by a relayer, which is an off-chain process whose only job is to ensure that packets are flowing. Relayers carry no special trust: each chain independently verifies everything the relayer submits using its own local copy of the other chain's state (the light client). 
+
+Below is a high-level diagram of an IBC cross-chain token transfer:
+
+```
+      Chain A                 Relayer               Chain B
+         │                      │                      │
+  1. User sends packet          │                      │
+     tokens locked/burned       │                      │
+     packet recorded            │                      │
+         ├─────────────────────>│                      │
+         │               2. relay packet and proof ───>│
+         │                      │                      │ 3. Chain B verifies proof
+         │                      │                      │    via light client of A
+         │                      │                      │ 4. Tokens minted on Chain B
+         │                      │                      │    result recorded
+         │                      │<─────────────────────┤
+         │<──────────── 5. relay result ───────────────┤
+         │ 6. Chain A verifies  │                      │
+         │    result via        │                      │
+         │    light client of B │                      │
+```
+
+Every step requires cryptographic proof. If a proof is missing or invalid, that step is rejected and the packet remains pending. If valid delivery never arrives before the deadline, the packet times out and the send rolls back on Chain A. Packets are never dropped. They either finish end-to-end with valid proofs, or they are rolled back.
+
+The entire protocol is built around four events: a packet is sent, received, acknowledged, or timed out. Light clients, relayers, and IBC Core all exist to make those four events happen reliably between chains.
+
+The diagram above is a simplified version of how IBC works. The rest of this document goes deeper on each piece: the key components, how packets are structured, and how applications plug in. For a detailed look at the complete packet flow, see the [IBC Lifecycle](ibc/latest/intro/ibc-lifecycle) page.
+
+## Packets
+
+A packet is the unit of communication in IBC. Every cross-chain action (a token transfer, a contract call, an arbitrary message) is wrapped in a packet and sent through the protocol.
+
+A packet contains two things: routing information and one or more payloads.
+
+The routing information tells the protocol which chains are involved, which sequence number this packet is, and when it expires. This is what IBC Core (the on-chain IBC logic) uses to track the packet, verify proofs against it, and prevent replay.
+
+The payloads carry the actual message data: which ports are involved and the raw bytes of the message itself. IBC Core treats those bytes as opaque and passes them through untouched. A single packet can carry multiple payloads, which execute atomically (all succeed or all fail).
+
+Every packet has a timeout. If it is not delivered before the deadline, the sender can prove it was never received and the application rolls back. Packets are never silently lost, and every packet either completes or times out.
+
+## Light Clients
+
+Unlike a traditional bridge, IBC does not depend on a single trusted operator. Instead, each chain maintains a light client: an on-chain program that verifies the counterparty chain's state. Light clients come in different forms depending on the chains and information involved.
+
+A consensus light client tracks the counterparty's block headers and validates them against its consensus rules, using validator signatures or ZK proofs. Because each block header commits to a cryptographic root of the chain's state, any specific fact about that state can be proven with a Merkle proof. When a packet arrives on Chain B, Chain B's consensus light client of Chain A verifies that the packet was actually committed on Chain A, without replaying Chain A's transactions or trusting anyone to report it honestly.
+
+An attestation light client does not track block headers directly. Instead, it relies on a configured set of trusted attestors to attest to the state of the counterparty chain, making IBC usable in contexts where full consensus verification is not practical. In this model, Attestors query the state of the source chain at a specific block height, locate the relevant packet commitment, and produce a signed hash of that commitment. These signatures are collected and bundled before being relayed to the destination chain. The attestation light client then verifies that the bundle contains enough valid signatures from registered attestors to meet the quorum threshold, and that all signatures attest to the same commitment. If quorum is met, the packet is accepted.
+
+To connect two chains, Chain A creates a light client of Chain B, and Chain B creates a light client of Chain A. Each chain then registers the other's light client ID as its counterparty. Once both sides are registered, the two chains can exchange packets.
+
+## Relayers
+
+A relayer is an off-chain process that watches for events on one chain and submits the corresponding transactions on the other.
+
+When a packet is committed on Chain A:
+
+1. The relayer fetches a Merkle proof of that commitment from Chain A.
+2. It submits the packet data and proof to Chain B.
+3. Chain B verifies the proof against its light client of Chain A.
+4. The packet is processed and an acknowledgement is written on Chain B.
+5. The relayer relays the acknowledgement back to Chain A the same way.
+6. If the packet is not delivered before its timeout, the relayer proves non-receipt to Chain A instead and the send is rolled back.
+
+Relayers also keep light clients current. Before submitting a packet, a relayer first submits a new block header from the source chain so the light client has a recent enough state root to prove against. If a light client is not updated within its trusting period, it expires and can no longer verify proofs.
+
+Relayers carry no trust. They cannot forge or alter packets, because every proof they submit is verified by the receiving chain's light client. A malicious or faulty relayer can delay delivery, but it cannot cause Chain B to process a packet that was never sent, or change the contents of one that was. Because relayers do not need any special trust, there is no permissioning or registration required for them.
+
+The above describes relaying with Tendermint light clients, used for Cosmos-to-Cosmos IBC. For Cosmos-to-EVM connections using attestation light clients, the model differs: rather than fetching Merkle proofs and submitting block headers, the relayer delegates proof construction entirely to a Proof API, which queries the attestor set and assembles the relay transaction. The trust guarantees remain the same, as the relayer cannot forge attestation signatures it does not hold.
+
+## IBC Core
+
+IBC Core is the shared protocol layer that runs on each chain. It exists so that applications never have to deal with proof verification, packet sequencing, replay prevention, or timeout enforcement directly. Applications hand off payloads to IBC Core when sending and receive verified payloads from IBC Core when packets arrive. IBC Core handles everything in between.
+
+It is implemented as a native module on Cosmos chains or as smart contracts on other chains. It has three main components: the IBC store, the client router, and the port router.
+
+The IBC store records three things for every packet: a commitment written when a packet is sent, a receipt written when it is received, and an acknowledgement written after it is processed. This committed state is what light clients on the counterparty chain prove against. The store does not hold the packet payload; only a hash of the packet is committed. The full packet data is emitted as an event on the source chain, which the relayer reads and submits to the destination alongside the proof.
+
+The receipt is what prevents replay attacks: if a relayer submits the same packet twice, the receiving chain checks its store, finds the receipt, and rejects it. When Chain A receives the acknowledgement, it deletes the original commitment, preventing the same send from being acknowledged twice. Each packet also carries a sequence number so gaps or reordering can be detected.
+
+The client router maps each incoming proof to the correct light client for verification. When a relayer submits a packet from Chain A to Chain B, the client router looks up Chain B's light client of Chain A and uses it to verify the proof.
+
+The port router delivers verified payloads to the correct application. Each application registers under a port ID, and the port router matches the destination port in the payload to the registered application.
+
+For a detailed walkthrough of how a packet moves through these components from send to acknowledgement, see [IBC Lifecycle](ibc/latest/intro/ibc-lifecycle).
+
+## IBC Applications
+
+An IBC application is the on-chain logic that users actually interact with when doing something cross-chain. When a user bridges tokens from Chain A to Chain B, they are invoking an IBC application such as ICS-20 or IFT.
+
+IBC applications are typically deployed on both chains. Each side implements the same interface but plays a different role: one sends, the other receives and executes.
+
+Each IBC application defines what to do at each stage of the packet lifecycle. It specifies what to lock or validate when sending, what to execute when a packet arrives, what to do with the result, and how to roll back on timeout. The application never deals with packets, proofs, or headers directly. It only handles its own logic, and IBC Core handles the rest.
+
+Each application registers under a port ID. When IBC Core's port router receives a verified payload, it dispatches it to the application registered at the destination port. The sending application specifies both the source port and the destination port in the payload, so IBC Core can route it end-to-end without knowing anything about the payload's contents.
+
+The two most common IBC applications are ICS-20 (fungible token transfer) and IBC Hooks (arbitrary cross-chain message execution). Applications can also be layered: middleware wraps an existing application to add behavior such as fee handling or packet forwarding, without modifying the underlying application.

--- a/ibc/latest/intro/ibc-lifecycle.mdx
+++ b/ibc/latest/intro/ibc-lifecycle.mdx
@@ -1,0 +1,224 @@
+# IBC Lifecycle
+
+This page covers how IBC packets are structured, how they move through the protocol from send to acknowledgement or timeout, and a reference for the messages and callbacks involved at each stage.
+
+## Setup
+
+Before packets can flow between two chains, a one-time setup is required on each side. IBC Core must be running on both chains. On Cosmos chains it is a native module; on other chains it may be deployed as smart contracts.
+
+Each chain creates a light client of the other using `MsgCreateClient`. The light client type depends on the chains involved: a consensus light client for Cosmos-to-Cosmos connections, or an attestation light client for connections to chains where full consensus verification is not practical.
+
+Finally, each chain registers the other's light client ID as its counterparty using `MsgRegisterCounterparty`. This links the two clients so IBC Core knows which remote client to verify proofs against. Once both sides have registered each other, packets can flow.
+
+## Packets
+
+A packet is the unit of communication in IBC. It is how one chain sends a message to another. Every cross-chain action, whether it is a token transfer, a contract call, or any other application message, is wrapped in a packet and sent through the IBC protocol.
+
+A packet contains routing information (which clients are involved, what sequence number it has, when it expires) and one or more **payloads**. Each payload carries the actual application data: which ports are involved, what version and encoding the data uses, and the raw bytes of the message itself. Multiple payloads in a single packet execute atomically, which makes it possible to bundle cross-chain operations together.
+
+### Packet and payload structure
+
+The following is the basic structure of a packet. These fields are what IBC Core reads when routing, verifying, and tracking a packet through its lifecycle.
+
+```
+Packet {
+  sequence            uint64     // assigned by protocol
+  source_client       string     // light client ID on sending chain
+  destination_client  string     // light client ID on receiving chain
+  timeout_timestamp   uint64     // unix seconds; must be > now and <= now + 24h
+  payloads            []Payload  // one or more application messages
+}
+
+Payload {
+  source_port       string   // sending application's port ID
+  destination_port  string   // receiving application's port ID
+  version           string   // app protocol version (per-payload)
+  encoding          string   // e.g. "application/json", "application/x-protobuf"
+  value             []byte   // raw application data
+}
+```
+
+The `timeout_timestamp` is a Unix timestamp in seconds. If the packet is not received before that time, it can be timed out and the sending application can roll back. It must be set in the future but not more than 24 hours out.
+
+`version` and `encoding` are per-payload, not per-packet. This means two different applications can share a single packet while using completely different protocol versions and data formats.
+
+`value` is the actual content of the message. It is an encoded byte slice whose structure is entirely defined by the application. IBC Core treats it as opaque and passes it through untouched. The receiving application uses `encoding` to decode it and `version` to know which schema to expect. 
+
+Each application defines its own `value` format. Here are two examples of what a real payload's `value` contains:
+
+- An ICS-20 transfer payload encodes a struct containing the sender address, receiver address, token denomination, amount, and an optional memo. The receiver's transfer module decodes this and mints or unlocks the corresponding tokens.
+- A GMP payload encodes a struct containing a sender, a receiver address on the destination chain, a salt for replay protection, an inner payload (arbitrary contract call data), and a memo. The GMP module on the destination routes the inner payload to the target contract.
+
+Because `value` is just bytes, any application can define its own message format and encoding. The supported encodings across the codebase are JSON (`application/json`), Protobuf (`application/x-protobuf`), and Solidity ABI (`application/x-solidity-abi`).
+
+Multiple payloads in a single packet execute atomically: all succeed or all fail. If any payload's `OnRecvPacket` returns a failure, the state changes from all payloads are discarded.
+
+### Packet identifiers
+
+The main information used to identify a packet are two client IDs and a sequence number.
+
+- `source_client` is the light client ID on the sending chain. `destination_client` is the light client ID on the receiving chain. Together they identify which two chains are communicating.
+
+- `sequence` is a monotonically increasing integer per source client, starting at 1. The protocol assigns it when `sendPacket()` is called and returns it to the calling application. A packet is uniquely located on the source chain by `(source_client, sequence)` and on the destination chain by `(destination_client, sequence)`. To ask a relayer to relay a specific packet, you give it the source client ID and sequence number so it can find the commitment in the IBC store.
+
+
+## Packet lifecycle
+
+Every packet follows the same lifecycle regardless of the application that sent it. There are validation steps at each stage that assert the packet is well-formed and proofs are valid. The steps below describe what happens when all validations pass.
+
+```
+Source chain                                   Destination chain
+    |                                                  |
+    |---- MsgSendPacket ------------------------------>|
+    |     (write commitment)                           |
+    |                                                  |
+    |          +---- relayer: MsgUpdateClient -------->|
+    |          |     (advance light client)            |
+    |          |                                       |
+    |          +---- relayer: MsgRecvPacket ---------->|
+    |                         (verify + write receipt + write ack)
+    |                                                  |
+    |<---- relayer: MsgUpdateClient ----------+        |
+    |      (advance light client)             |        |
+    |                                         |        |
+    |<---- relayer: MsgAcknowledgement -------+        |
+    |     (verify ack + delete commitment)             |
+    |                                                  |
+    |- - - - - - OR if never received - - - - - - - - -|
+    |                                                  |
+    |<---- relayer: MsgUpdateClient ----------+        |
+    |      (advance light client)             |        |
+    |                                         |        |
+    |<---- relayer: MsgTimeout ---------------+        |
+    |     (prove absence + delete commitment)          |
+```
+
+Each IBC message triggers a callback on the application. `MsgSendPacket` calls `OnSendPacket` on the source chain so the application can validate and lock state. `MsgRecvPacket` calls `OnRecvPacket` on the destination chain so the application can execute and return an acknowledgement. `MsgAcknowledgement` calls `OnAcknowledgementPacket` on the source chain so the application can handle success or roll back on failure. `MsgTimeout` calls `OnTimeoutPacket` on the source chain so the application can roll back if the packet was never delivered.
+
+### Send packet (source chain)
+
+This is where a cross-chain message begins. The user triggers an IBC application, which constructs a packet, commits it on the source chain, and gets back a sequence number.
+
+```
+User -> IBCApp -> sendPacket() -> CommitPacket() -> OnSendPacket() -> return sequence number to IBCApp -> return sequence number to User
+```
+
+1. The user interacts with an IBC application, for example initiating a token transfer.
+2. The application calls `MsgSendPacket` with the source client ID, timeout timestamp, and one or more payloads.
+3. IBC Core looks up the `CounterpartyInfo` for the source client to get the destination client ID.
+4. The timeout is validated: it must be after the current block time, and the latest timestamp the light client has seen on the destination chain must not already be past it.
+5. The next sequence number for this source client is read and incremented.
+6. The packet is constructed and hashed with `CommitPacket()`. That commitment hash is written to the IBC store.
+7. `OnSendPacket()` is called on each payload's source port application. If any app returns an error, the entire transaction reverts.
+8. The sequence number is returned to the caller in `MsgSendPacketResponse`.
+
+### Receive packet (destination chain)
+
+The relayer delivers the packet to the destination chain. The destination chain verifies the packet was actually sent, executes the application logic, and writes the result.
+
+```
+Relayer -> MsgUpdateClient()     (separate tx, advances light client to proof height)
+Relayer -> MsgRecvPacket()
+  -> verifyMembership()          (proves packet commitment exists on source chain)
+  -> setPacketReceipt()
+  -> onRecvPacket()              (routes each payload to the correct app)
+  -> CommitAcknowledgement()     (writes ack hash to store)
+```
+
+1. The relayer first submits `MsgUpdateClient` to advance Chain B's light client of Chain A to the block height where the packet commitment exists. This is a separate transaction that must land before `MsgRecvPacket`.
+2. The relayer submits `MsgRecvPacket` with the packet, a Merkle proof of the commitment, and the proof height.
+3. If the destination client has an allowed-relayers config set, IBC Core checks the relayer is authorized.
+4. IBC Core verifies the packet's `source_client` matches the counterparty registered for the `destination_client`, confirming the packet came from the expected chain.
+5. If the current block time is already past `timeout_timestamp`, the receive fails.
+6. If a receipt already exists at `(destinationClient, sequence)`, the message returns `NOOP` rather than an error, allowing relayers to retry safely.
+7. IBC Core calls `VerifyMembership()` on the light client, proving that `CommitPacket(packet)` exists at the expected key in Chain A's IBC store.
+8. A receipt is written to prevent future replay.
+9. The port router calls `OnRecvPacket()` on each payload's destination port application. Each app returns a `RecvPacketResult` with a status (`PacketStatus_Success`, `PacketStatus_Failure`, or `PacketStatus_Async`) and an acknowledgement.
+10. If all payloads succeed, the app acknowledgements are collected into one `Acknowledgement` struct and committed to the store via `CommitAcknowledgement()`. If any payload fails, all state changes are discarded and the entire acknowledgement is replaced with the sentinel error acknowledgement.
+
+### Acknowledgement (source chain)
+
+Once the packet is processed on the destination chain, the relayer brings the result back to the source chain so the application can confirm success or handle a failure.
+
+```
+Relayer -> MsgUpdateClient()         (advance source chain's light client of destination)
+Relayer -> MsgAcknowledgement()
+  -> verifyMembership()              (proves ack was written on destination)
+  -> deletePacketCommitment()
+  -> onAcknowledgementPacket()       (routes each payload's ack to the correct app)
+```
+
+1. The relayer submits `MsgAcknowledgement` with the packet, the acknowledgement, and a Merkle proof that the ack was written to Chain B's store.
+2. If the packet commitment on Chain A has already been deleted, the message returns `NOOP`.
+3. IBC Core calls `VerifyMembership()` to prove the acknowledgement hash exists in Chain B's IBC store.
+4. The packet commitment is deleted from Chain A's store.
+5. For each payload, the port router calls `OnAcknowledgementPacket()` on the source port application. If the receive succeeded, each app gets its own per-payload ack bytes. If the receive failed, every app gets the sentinel error ack bytes and is responsible for any refund or rollback logic.
+
+An error acknowledgement means the packet reached the destination chain but could not be processed there. The application handles it the same way it handles a timeout.
+
+### Timeout (source chain)
+
+If a packet is never delivered before its deadline, the source chain can prove it was never received and roll back the send as if it never happened.
+
+```
+Relayer -> MsgUpdateClient()     (advance source chain's light client past the timeout)
+Relayer -> MsgTimeout()
+  -> verifyNonMembership()       (proves receipt is absent on destination)
+  -> deletePacketCommitment()
+  -> onTimeoutPacket()           (routes each payload to the correct app for rollback)
+```
+
+Timeouts happen on the source chain when a packet was not delivered before its `timeout_timestamp`.
+
+1. The relayer submits `MsgTimeout` with the packet and a proof that the receipt key is absent from Chain B's store at a height after the timeout deadline.
+2. IBC Core verifies the proof height's timestamp is at or past the `timeout_timestamp`.
+3. If the packet commitment has already been deleted, the message returns `NOOP`.
+4. IBC Core calls `VerifyNonMembership()`, proving the receipt key does not exist in Chain B's store. If a receipt exists (meaning the packet was actually delivered), the timeout is rejected.
+5. The packet commitment is deleted.
+6. For each payload, the port router calls `OnTimeoutPacket()` on the source port application so it can execute rollback logic, for example releasing escrowed tokens.
+
+## IBC Messages Reference
+
+The following is a reference for the messages and callbacks involved in the IBC packet lifecycle.
+
+### Setup Messages
+
+Done once by chain operators or governance before packets can flow.
+
+| Message | Description |
+| --- | --- |
+| `MsgCreateClient` | Creates a light client on a chain |
+| `MsgRegisterCounterparty` | Links two light client IDs so they can exchange packets |
+| `MsgUpgradeClient` | Upgrades a light client after a chain upgrade |
+
+### Packet messages
+
+Sent per packet during normal operation.
+
+| Message | Who | Description | Triggers |
+| --- | --- | --- | --- |
+| `MsgSendPacket` | User/App | Sends a packet from the source chain | `OnSendPacket` |
+| `MsgUpdateClient` | Relayer | Submits a new block header to advance the light client | |
+| `MsgRecvPacket` | Relayer | Delivers packet + proof to the destination | `OnRecvPacket` |
+| `MsgAcknowledgement` | Relayer | Delivers ack + proof back to source | `OnAcknowledgementPacket` |
+| `MsgTimeout` | Relayer | Proves non-receipt to source | `OnTimeoutPacket` |
+
+### Callbacks
+
+| Callback | Chain | Description |
+| --- | --- | --- |
+| `OnSendPacket` | Source | App validates and locks state when a packet is being sent |
+| `OnRecvPacket` | Destination | App executes and returns an ack when a verified packet arrives |
+| `OnAcknowledgementPacket` | Source | App handles success or failure when the ack is delivered |
+| `OnTimeoutPacket` | Source | App rolls back if the packet was never delivered |
+
+### Full flow
+
+Setup once: `MsgCreateClient` + `MsgRegisterCounterparty`
+
+Per packet:
+
+1. User: `MsgSendPacket` triggers `OnSendPacket`
+2. Relayer: `MsgUpdateClient` + `MsgRecvPacket` triggers `OnRecvPacket`
+3a. Relayer: `MsgUpdateClient` + `MsgAcknowledgement` triggers `OnAcknowledgementPacket`
+3b. Relayer (if there is a timeout): `MsgTimeout` triggers `OnTimeoutPacket`

--- a/ibc/latest/intro/what-is-ibc.mdx
+++ b/ibc/latest/intro/what-is-ibc.mdx
@@ -42,4 +42,4 @@ IBC was designed for flexibility and extensibility. Because the layers have defi
 
 Any cross-chain action is wrapped in a packet and sent through the protocol. IBC is agnostic to the content: the same infrastructure that moves tokens can also trigger contract calls or pass arbitrary messages. A single packet can carry multiple payloads from different applications, and they all execute atomically.
 
-For a detailed look at how the components work, see [How IBC Works]( ibc/latest/intro/how-ibc-works). For the full packet flow from send to acknowledgement, see [IBC Lifecycle](ibc/latest/intro/ibc-lifecycle).
+For a detailed look at how the components work, see [How IBC Works](/ibc/latest/intro/how-ibc-works). For the full packet flow from send to acknowledgement, see [IBC Lifecycle](/ibc/latest/intro/ibc-lifecycle).

--- a/ibc/latest/intro/what-is-ibc.mdx
+++ b/ibc/latest/intro/what-is-ibc.mdx
@@ -32,9 +32,9 @@ IBC is organized into three layers that can be swapped independently:
 +--------------------------------------------------+
 ```
 
-- The verification layer handles how cross-chain state is proven. This is where light clients live, and different client types (consensus, attestation) can be swapped in without affecting the layers above.
+- The application layer is where users and cross-chain actions interact. IBC applications can be anything: token transfers, contract calls, arbitrary messaging, or custom logic built for a specific use case.
 - The core layer manages the packet lifecycle: sequencing, replay prevention, timeout enforcement, and proof verification. Applications never deal with this directly.
-- The application layer is where users and developers interact. IBC applications can be anything: token transfers, contract calls, arbitrary messaging, or custom logic built for a specific use case.
+- The verification layer handles how cross-chain state is proven. This is where light clients live, and different client types (consensus, attestation) can be swapped in without affecting the layers above.
 
 IBC was designed for flexibility and extensibility. Because the layers have defined interfaces, a new light client type or application can be added without changing the others.
 

--- a/ibc/latest/intro/what-is-ibc.mdx
+++ b/ibc/latest/intro/what-is-ibc.mdx
@@ -1,0 +1,45 @@
+# What is IBC?
+
+IBC (Inter-Blockchain Communication) is a protocol that lets independent blockchains exchange messages with cryptographic verification. A chain running IBC can send tokens, trigger contract calls, or pass arbitrary data to any other chain that also runs IBC, without relying on a centralized bridge operator.
+
+## The Interoperability Solution
+
+Blockchains are isolated by design. Chain A has no access to Chain B's state, and they cannot call each other the way web services can. Connecting them traditionally meant trusting a third party to relay information honestly, which introduces a single point of failure and requires ongoing trust in an external operator.
+
+IBC is the solution to this problem: it replaces trusted operators with cryptographic proofs. Each chain runs a light client that tracks the counterparty chain's state. When a message arrives on Chain B, Chain B's light client verifies that it was actually committed on Chain A. IBC is also permissionless. Anyone can submit proofs to either chain, and each chain verifies them independently.
+
+IBC is flexible in how that verification works. A consensus light client tracks block headers and validates them against the counterparty's consensus rules. An attestation light client relies on a committee, oracle network, or existing signing infrastructure instead. Chains choose the verification approach that fits their security model.
+
+## IBC Layers
+
+IBC is organized into three layers that can be swapped independently:
+
+```
++--------------------------------------------------+
+|  Application Layer                               |
+|  Token transfers, contract calls, messages       |
++--------------------------------------------------+
+                         ↑↓
++--------------------------------------------------+
+|  Core Layer                                      |
+|  Packet lifecycle, error handling,               |
+|  data consistency                                |
++--------------------------------------------------+
+                         ↑↓
++--------------------------------------------------+
+|  Verification Layer                              |
+|  Light clients: consensus, attestation           |
++--------------------------------------------------+
+```
+
+- The verification layer handles how cross-chain state is proven. This is where light clients live, and different client types (consensus, attestation) can be swapped in without affecting the layers above.
+- The core layer manages the packet lifecycle: sequencing, replay prevention, timeout enforcement, and proof verification. Applications never deal with this directly.
+- The application layer is where users and developers interact. IBC applications can be anything: token transfers, contract calls, arbitrary messaging, or custom logic built for a specific use case.
+
+IBC was designed for flexibility and extensibility. Because the layers have defined interfaces, a new light client type or application can be added without changing the others.
+
+## What you can do with IBC
+
+Any cross-chain action is wrapped in a packet and sent through the protocol. IBC is agnostic to the content: the same infrastructure that moves tokens can also trigger contract calls or pass arbitrary messages. A single packet can carry multiple payloads from different applications, and they all execute atomically.
+
+For a detailed look at how the components work, see [How IBC Works]( ibc/latest/intro/how-ibc-works). For the full packet flow from send to acknowledgement, see [IBC Lifecycle](ibc/latest/intro/ibc-lifecycle).


### PR DESCRIPTION
## Add IBC intro section (what-is-ibc, how-ibc-works, ibc-lifecycle)

Adds three new conceptual overview pages to `ibc/latest/intro/`:

- **What is IBC** — introduces the chain isolation problem, how IBC replaces trusted operators with cryptographic proofs, the three-layer architecture (verification, core, application), and what the protocol can carry.
- **How IBC works** — explains each component in depth: packets and payloads, consensus vs. attestation light clients, relayer responsibilities, IBC Core internals (IBC store, client router, port router), and how IBC applications plug in.
- **IBC lifecycle** — step-by-step walkthrough of the full packet flow from setup through send, receive, acknowledgement, and timeout, including packet/payload field definitions, sequence diagrams, and a message/callback reference table.
