### PR TITLE
Add EVM v0.7 upgrade guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2306,11 +2306,12 @@
                   {
                     "group": "Migrations",
                     "pages": [
-                      "evm/latest/documentation/migrations/migration-v0.5-to-v0.6",
+                      "evm/latest/documentation/migrations/migration-v0.6-to-v0.7",
                       {
                         "group": "Previous Versions",
                         "collapsed": true,
                         "pages": [
+                          "evm/latest/documentation/migrations/migration-v0.5-to-v0.6",
                           "evm/latest/documentation/migrations/migration-v0.4-to-v0.5",
                           "evm/latest/documentation/migrations/migration-v0.3-to-v0.4",
                           "evm/latest/documentation/migrations/erc20-precompiles-migration"
@@ -2439,11 +2440,12 @@
                   {
                     "group": "Migrations",
                     "pages": [
-                      "evm/next/documentation/migrations/migration-v0.5-to-v0.6",
+                      "evm/next/documentation/migrations/migration-v0.6-to-v0.7",
                       {
                         "group": "Previous Versions",
                         "collapsed": true,
                         "pages": [
+                          "evm/next/documentation/migrations/migration-v0.5-to-v0.6",
                           "evm/next/documentation/migrations/migration-v0.4-to-v0.5",
                           "evm/next/documentation/migrations/migration-v0.3-to-v0.4",
                           "evm/next/documentation/migrations/erc20-precompiles-migration"

--- a/evm/latest/documentation/migrations/migration-v0.6-to-v0.7.mdx
+++ b/evm/latest/documentation/migrations/migration-v0.6-to-v0.7.mdx
@@ -1,0 +1,3 @@
+---
+title: "Migration: v0.6.0 to v0.7.0"
+---

--- a/evm/next/documentation/migrations/migration-v0.6-to-v0.7.mdx
+++ b/evm/next/documentation/migrations/migration-v0.6-to-v0.7.mdx
@@ -1,0 +1,3 @@
+---
+title: "Migration: v0.6.0 to v0.7.0"
+---


### PR DESCRIPTION
Placeholder for evm v0.7 upgrade guide

[] Upgrade guide will need to be added to the blank pages in this PR (in evm/latest and copied to evm/next)