### PR TITLE
Add Release Family page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -283,6 +283,7 @@
                     "icon": "book-open",
                     "pages": [
                       "sdk/latest/learn/intro/cosmos-stack",
+                      "sdk/latest/release-family",
                       "sdk/latest/learn/intro/overview",
                       "sdk/latest/learn/intro/blockchain-basics",
                       "sdk/latest/learn/intro/sdk-app-architecture"
@@ -602,6 +603,7 @@
                     "icon": "book-open",
                     "pages": [
                       "sdk/next/learn/intro/cosmos-stack",
+                      "sdk/next/release-family",
                       "sdk/next/learn/intro/overview",
                       "sdk/next/learn/intro/blockchain-basics",
                       "sdk/next/learn/intro/sdk-app-architecture"

--- a/docs.json
+++ b/docs.json
@@ -283,7 +283,6 @@
                     "icon": "book-open",
                     "pages": [
                       "sdk/latest/learn/intro/cosmos-stack",
-                      "sdk/latest/release-family",
                       "sdk/latest/learn/intro/overview",
                       "sdk/latest/learn/intro/blockchain-basics",
                       "sdk/latest/learn/intro/sdk-app-architecture"
@@ -319,7 +318,8 @@
                           "sdk/latest/learn/concepts/cli-grpc-rest",
                           "sdk/latest/learn/concepts/testing"
                         ]
-                      }
+                      },
+                      "sdk/latest/release-family"
                     ]
                   },
                   {
@@ -603,7 +603,6 @@
                     "icon": "book-open",
                     "pages": [
                       "sdk/next/learn/intro/cosmos-stack",
-                      "sdk/next/release-family",
                       "sdk/next/learn/intro/overview",
                       "sdk/next/learn/intro/blockchain-basics",
                       "sdk/next/learn/intro/sdk-app-architecture"
@@ -639,7 +638,8 @@
                           "sdk/next/learn/concepts/cli-grpc-rest",
                           "sdk/next/learn/concepts/testing"
                         ]
-                      }
+                      },
+                      "sdk/next/release-family"
                     ]
                   },
                   {

--- a/sdk/latest/release-family.mdx
+++ b/sdk/latest/release-family.mdx
@@ -1,0 +1,62 @@
+---
+title: "Release Families"
+description: "What release families are, what they contain, and how upgrades work."
+---
+
+## Overview
+
+A release family is a curated set of component versions across the Cosmos Stack that are tested for compatibility with one another. Cosmos Labs provides maintenance and bug fixes only for active families. For lifecycle policy and maintenance windows, see the [Security and Maintenance Policy](/sdk/latest/security/security-policy).
+
+## What a Release Family Contains
+
+Each release family includes pinned versions of the following components:
+
+- CometBFT
+- Cosmos SDK
+- Cosmos EVM
+- IBC (ibc-go)
+{/* todo: add other components here.  */}
+
+The goal is to guarantee that every version listed in a family is compatible with every other version in that family.
+
+Certain packages within the SDK may not be listed as Cosmos Labs consolidates separate Go modules over time.
+
+## Current Release Families
+
+{/* todo: add current release families here.  */}
+
+## Upgrades and Support
+
+Supported versions within a release family are updated over time, and upgrade paths are provided where generalized upgrades make sense.
+
+New release families include breaking changes from the previous family. New features are only considered for backporting to the most recent release family, and only when they are non-breaking.
+
+Cosmos Labs supports up to two release families at a time. For full lifecycle and retirement details, see the [Security and Maintenance Policy](/sdk/latest/security/security-policy).
+
+### Connectivity upgrades
+
+Connectivity-only upgrades on patch and minor versions are zero-downtime upgrades. An upgrade such as `0.0.1` to `0.0.5` requires intermediate upgrades: `0.0.2`, `0.0.3`, `0.0.4`.
+
+## Examples
+
+An example release family might look like:
+
+| Component | Version |
+| --------- | ------- |
+| Cosmos SDK | 0.54.0 |
+| CometBFT | 0.39.0 |
+| ibc-go | v11.0.0 |
+| solidity-ibc-eureka | 0.1.0 |
+| Relayer | 0.1.0 |
+| attestor | 0.1.0 |
+
+Upgrades that would update versions within this family without creating a new one:
+
+- SDK 0.54.0 to 0.54.1
+- Relayer 0.1.0 to 0.1.1
+
+Upgrades that would require a new release family:
+
+- SDK 0.54.x to 0.55.0
+- CometBFT 0.39.x to 0.40.x
+- Relayer 0.1.x to 1.0.0

--- a/sdk/latest/release-family.mdx
+++ b/sdk/latest/release-family.mdx
@@ -11,11 +11,13 @@ A release family is a curated set of component versions across the Cosmos Stack 
 
 Each release family includes pinned versions of the following components:
 
-- CometBFT
-- Cosmos SDK
-- Cosmos EVM
-- IBC (ibc-go)
-{/* todo: add other components here.  */}
+- [CometBFT](https://github.com/cometbft/cometbft)
+- [Cosmos SDK](https://github.com/cosmos/cosmos-sdk)
+- [Cosmos EVM](https://github.com/cosmos/evm)
+- [IBC (ibc-go)](https://github.com/cosmos/ibc-go)
+- [solidity-ibc-eureka](https://github.com/cosmos/solidity-ibc-eureka)
+- [Relayer](https://github.com/cosmos/ibc-relayer)
+- [attestor](https://github.com/cosmos/ibc-attestor)
 
 The goal is to guarantee that every version listed in a family is compatible with every other version in that family.
 
@@ -23,7 +25,26 @@ Certain packages within the SDK may not be listed as Cosmos Labs consolidates se
 
 ## Current Release Families
 
-{/* todo: add current release families here.  */}
+### 2026.1
+
+| Component | Version |
+| --------- | ------- |
+| [Cosmos SDK](https://github.com/cosmos/cosmos-sdk) | 0.54.x |
+| [Enterprise Groups](https://github.com/cosmos/cosmos-sdk/tree/main/enterprise/group) | 1.x.y |
+| [Enterprise PoA](https://github.com/cosmos/cosmos-sdk/tree/main/enterprise/poa) | 1.x.y |
+| [CometBFT](https://github.com/cometbft/cometbft) | 0.39.x |
+| [ibc-go](https://github.com/cosmos/ibc-go) | v11.x.y |
+| [solidity-ibc-eureka](https://github.com/cosmos/solidity-ibc-eureka) | 0.1.x |
+| [Relayer](https://github.com/cosmos/ibc-relayer) | 0.1.x |
+| [attestor](https://github.com/cosmos/ibc-attestor) | 0.1.x |
+
+### 2025.1
+
+| Component | Version |
+| --------- | ------- |
+| [Cosmos SDK](https://github.com/cosmos/cosmos-sdk) | 0.53.x |
+| [CometBFT](https://github.com/cometbft/cometbft) | 0.38.x |
+| [ibc-go](https://github.com/cosmos/ibc-go) | v10.x.y |
 
 ## Upgrades and Support
 

--- a/sdk/next/release-family.mdx
+++ b/sdk/next/release-family.mdx
@@ -1,0 +1,62 @@
+---
+title: "Release Families"
+description: "What release families are, what they contain, and how upgrades work."
+---
+
+## Overview
+
+A release family is a curated set of component versions across the Cosmos Stack that are tested for compatibility with one another. Cosmos Labs provides maintenance and bug fixes only for active families. For lifecycle policy and maintenance windows, see the [Security and Maintenance Policy](/sdk/next/security/security-policy).
+
+## What a Release Family Contains
+
+Each release family includes pinned versions of the following components:
+
+- CometBFT
+- Cosmos SDK
+- Cosmos EVM
+- IBC (ibc-go)
+{/* todo: add other components here.  */}
+
+The goal is to guarantee that every version listed in a family is compatible with every other version in that family.
+
+Certain packages within the SDK may not be listed as Cosmos Labs consolidates separate Go modules over time.
+
+## Current Release Families
+
+{/* todo: add current release families here.  */}
+
+## Upgrades and Support
+
+Supported versions within a release family are updated over time, and upgrade paths are provided where generalized upgrades make sense.
+
+New release families include breaking changes from the previous family. New features are only considered for backporting to the most recent release family, and only when they are non-breaking.
+
+Cosmos Labs supports up to two release families at a time. For full lifecycle and retirement details, see the [Security and Maintenance Policy](/sdk/next/security/security-policy).
+
+### Connectivity upgrades
+
+Connectivity-only upgrades on patch and minor versions are zero-downtime upgrades. An upgrade such as `0.0.1` to `0.0.5` requires intermediate upgrades: `0.0.2`, `0.0.3`, `0.0.4`.
+
+## Examples
+
+An example release family might look like:
+
+| Component | Version |
+| --------- | ------- |
+| Cosmos SDK | 0.54.0 |
+| CometBFT | 0.39.0 |
+| ibc-go | v11.0.0 |
+| solidity-ibc-eureka | 0.1.0 |
+| Relayer | 0.1.0 |
+| attestor | 0.1.0 |
+
+Upgrades that would update versions within this family without creating a new one:
+
+- SDK 0.54.0 to 0.54.1
+- Relayer 0.1.0 to 0.1.1
+
+Upgrades that would require a new release family:
+
+- SDK 0.54.x to 0.55.0
+- CometBFT 0.39.x to 0.40.x
+- Relayer 0.1.x to 1.0.0

--- a/sdk/next/release-family.mdx
+++ b/sdk/next/release-family.mdx
@@ -11,11 +11,13 @@ A release family is a curated set of component versions across the Cosmos Stack 
 
 Each release family includes pinned versions of the following components:
 
-- CometBFT
-- Cosmos SDK
-- Cosmos EVM
-- IBC (ibc-go)
-{/* todo: add other components here.  */}
+- [CometBFT](https://github.com/cometbft/cometbft)
+- [Cosmos SDK](https://github.com/cosmos/cosmos-sdk)
+- [Cosmos EVM](https://github.com/cosmos/evm)
+- [IBC (ibc-go)](https://github.com/cosmos/ibc-go)
+- [solidity-ibc-eureka](https://github.com/cosmos/solidity-ibc-eureka)
+- [Relayer](https://github.com/cosmos/ibc-relayer)
+- [attestor](https://github.com/cosmos/ibc-attestor)
 
 The goal is to guarantee that every version listed in a family is compatible with every other version in that family.
 
@@ -23,7 +25,26 @@ Certain packages within the SDK may not be listed as Cosmos Labs consolidates se
 
 ## Current Release Families
 
-{/* todo: add current release families here.  */}
+### 2026.1
+
+| Component | Version |
+| --------- | ------- |
+| [Cosmos SDK](https://github.com/cosmos/cosmos-sdk) | 0.54.x |
+| [Enterprise Groups](https://github.com/cosmos/cosmos-sdk/tree/main/enterprise/group) | 1.x.y |
+| [Enterprise PoA](https://github.com/cosmos/cosmos-sdk/tree/main/enterprise/poa) | 1.x.y |
+| [CometBFT](https://github.com/cometbft/cometbft) | 0.39.x |
+| [ibc-go](https://github.com/cosmos/ibc-go) | v11.x.y |
+| [solidity-ibc-eureka](https://github.com/cosmos/solidity-ibc-eureka) | 0.1.x |
+| [Relayer](https://github.com/cosmos/ibc-relayer) | 0.1.x |
+| [attestor](https://github.com/cosmos/ibc-attestor) | 0.1.x |
+
+### 2025.1
+
+| Component | Version |
+| --------- | ------- |
+| [Cosmos SDK](https://github.com/cosmos/cosmos-sdk) | 0.53.x |
+| [CometBFT](https://github.com/cometbft/cometbft) | 0.38.x |
+| [ibc-go](https://github.com/cosmos/ibc-go) | v10.x.y |
 
 ## Upgrades and Support
 


### PR DESCRIPTION
- Adds release families page to SDK Overview in latest and next
- Covers full component list including connectivity layer (Relayer, attestor, solidity-ibc-eureka)
- Links to security policy for lifecycle details rather than duplicating them

TODO:

Current families table has a TODO pending Alex's input
@aljo242 can you add in the info about the current release families in the todo?