### PR TITLE
Landing, nav, and style changes

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -19,6 +19,15 @@
       }
     }
   },
+  "navbar": {
+    "links": [
+      { "label": "Cosmos SDK", "href": "/sdk/latest/learn" },
+      { "label": "Cosmos EVM", "href": "/evm/latest/documentation/overview" },
+      { "label": "IBC", "href": "/ibc/latest/intro" },
+      { "label": "CometBFT", "href": "/cometbft/latest/docs/README" },
+      { "label": "Cosmos Enterprise", "href": "/enterprise/overview" }
+    ]
+  },
   "interaction": {
     "drilldown": false
   },

--- a/index.mdx
+++ b/index.mdx
@@ -67,6 +67,12 @@ import { ThemeToggle } from '/snippets/theme-toggle.jsx';
           IBC
         </a>
         <a
+          href="/cometbft/latest/docs/README"
+          className="text-gray-900 dark:text-white px-5 py-2.5 hover:[text-shadow:0_0_8px_rgba(255,255,255,0.8)] transition-all duration-300"
+        >
+          CometBFT
+        </a>
+        <a
           href="/enterprise/overview"
           className="text-gray-900 dark:text-white px-5 py-2.5 hover:[text-shadow:0_0_8px_rgba(255,255,255,0.8)] transition-all duration-300"
         >

--- a/snippets/docs-navigation-drawer.jsx
+++ b/snippets/docs-navigation-drawer.jsx
@@ -212,6 +212,26 @@ export const DocsNavigationDrawer = () => {
                   transition: 'opacity 0.4s ease-out 0.4s, transform 0.4s ease-out 0.4s'
                 }}>
                   <a
+                    href="/cometbft/latest/docs/README"
+                    className="text-black dark:text-white hover:opacity-70"
+                    style={{
+                      textDecoration: 'none',
+                      fontSize: '48px',
+                      fontWeight: '300',
+                      display: 'block',
+                      transition: 'opacity 0.2s'
+                    }}
+                  >
+                    CometBFT
+                  </a>
+                </li>
+                <li style={{
+                  marginBottom: '32px',
+                  opacity: isAnimating ? 1 : 0,
+                  transform: isAnimating ? 'translateY(0)' : 'translateY(20px)',
+                  transition: 'opacity 0.4s ease-out 0.5s, transform 0.4s ease-out 0.5s'
+                }}>
+                  <a
                     href="/enterprise/overview"
                     className="text-black dark:text-white hover:opacity-70"
                     style={{
@@ -237,7 +257,7 @@ export const DocsNavigationDrawer = () => {
                 gap: '32px',
                 flexWrap: 'wrap',
                 opacity: isAnimating ? 1 : 0,
-                transition: 'opacity 0.4s ease-out 0.5s'
+                transition: 'opacity 0.4s ease-out 0.6s'
               }}
             >
               <a

--- a/snippets/mobile-menu-drawer.jsx
+++ b/snippets/mobile-menu-drawer.jsx
@@ -213,6 +213,26 @@ export const MobileMenuDrawer = () => {
                   transition: 'opacity 0.4s ease-out 0.4s, transform 0.4s ease-out 0.4s'
                 }}>
                   <a
+                    href="/cometbft/latest/docs/README"
+                    className="text-black dark:text-white hover:opacity-70"
+                    style={{
+                      textDecoration: 'none',
+                      fontSize: '48px',
+                      fontWeight: '300',
+                      display: 'block',
+                      transition: 'opacity 0.2s'
+                    }}
+                  >
+                    CometBFT
+                  </a>
+                </li>
+                <li style={{
+                  marginBottom: '32px',
+                  opacity: isAnimating ? 1 : 0,
+                  transform: isAnimating ? 'translateY(0)' : 'translateY(20px)',
+                  transition: 'opacity 0.4s ease-out 0.5s, transform 0.4s ease-out 0.5s'
+                }}>
+                  <a
                     href="/enterprise/overview"
                     className="text-black dark:text-white hover:opacity-70"
                     style={{
@@ -238,7 +258,7 @@ export const MobileMenuDrawer = () => {
                 gap: '32px',
                 flexWrap: 'wrap',
                 opacity: isAnimating ? 1 : 0,
-                transition: 'opacity 0.4s ease-out 0.5s'
+                transition: 'opacity 0.4s ease-out 0.6s'
               }}
             >
               <a

--- a/style.css
+++ b/style.css
@@ -1,3 +1,21 @@
+:root {
+  --background-light: 255 255 255;
+}
+
+/* Accent color overrides */
+.bg-primary\/10 {
+  background-color: #40b3ff;
+}
+
+.text-primary {
+  --tw-text-opacity: 1;
+  color: white;
+}
+
+.dark\:bg-primary-light\/10:is(.dark *) {
+  background-color: #4251fa;
+}
+
 /* The Future Font Family */
 @font-face {
   font-family: 'The Future';

--- a/style.css
+++ b/style.css
@@ -7,8 +7,12 @@
   background-color: #40b3ff;
 }
 
-.text-primary {
-  --tw-text-opacity: 1;
+.dark .bg-primary\/10 {
+  background-color: #4251fa;
+}
+
+.bg-primary\/10.text-primary,
+.bg-primary\/10 .text-primary {
   color: white;
 }
 

--- a/work-log/landing-fixes.md
+++ b/work-log/landing-fixes.md
@@ -1,0 +1,6 @@
+## 2026-05-29
+
+- Added CometBFT to landing page top nav, mobile menu drawer, and docs navigation drawer — it was already in the DocCard grid but missing from all nav menus
+- Added `navbar.links` to docs.json with all five products so the nav links appear on every docs page, not just the landing page
+- Changed light theme background to white by overriding `--background-light` in style.css
+- Added accent color overrides in style.css: `.bg-primary/10` → cyan (#40b3ff), `.text-primary` → white, `.dark:bg-primary-light/10` → cobalt (#4251fa)

--- a/work-log/landing-fixes.md
+++ b/work-log/landing-fixes.md
@@ -3,4 +3,4 @@
 - Added CometBFT to landing page top nav, mobile menu drawer, and docs navigation drawer — it was already in the DocCard grid but missing from all nav menus
 - Added `navbar.links` to docs.json with all five products so the nav links appear on every docs page, not just the landing page
 - Changed light theme background to white by overriding `--background-light` in style.css
-- Added accent color overrides in style.css: `.bg-primary/10` → cyan (#40b3ff), `.text-primary` → white, `.dark:bg-primary-light/10` → cobalt (#4251fa)
+- Added accent color overrides in style.css: `.bg-primary/10` → cyan (#40b3ff) in light mode, cobalt (#4251fa) in dark mode; scoped white text to `.bg-primary/10` elements only to avoid invisible text in the product dropdown


### PR DESCRIPTION
- Added CometBFT to landing page top nav, mobile menu drawer, and docs navigation drawer — it was already in the DocCard grid but missing from all nav menus
- Added `navbar.links` to docs.json with all five products so the nav links appear on every docs page, not just the landing page
- Changed light theme background to white by overriding `--background-light` in style.css
- Added accent color overrides in style.css: `.bg-primary/10` → cyan (#40b3ff), `.text-primary` → white, `.dark:bg-primary-light/10` → cobalt (#4251fa)