### PR TITLE
Add Valopers explorer

### DIFF
--- a/hub/v25/index.mdx
+++ b/hub/v25/index.mdx
@@ -48,6 +48,7 @@ These block explorers allow you to search, view and analyze Cosmos Hub data—li
 * [ATOMScan](https://atomscan.com)
 * [Ping.Pub](https://ping.pub/cosmos)
 * [BronBro](https://monitor.bronbro.io/d/cosmos-stats/cosmos)
+* [Valopers](https://cosmos.valopers.com)
 
 ## Cosmos Hub CLI
 


### PR DESCRIPTION
Title: Add Valopers explorer

Adds Valopers to the Cosmos Hub explorer list.

Explorer: https://cosmos.valopers.com
