### PR TITLE
add Rate limit docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2923,6 +2923,15 @@
                           "ibc/latest/middleware/callbacks/gas",
                           "ibc/latest/middleware/callbacks/callbacks-IBCv2"
                         ]
+                      },
+                      {
+                        "group": "Rate Limit Middleware",
+                        "pages": [
+                          "ibc/latest/middleware/rate-limit-middleware/overview",
+                          "ibc/latest/middleware/rate-limit-middleware/integration",
+                          "ibc/latest/middleware/rate-limit-middleware/setting-limits",
+                          "ibc/latest/middleware/rate-limit-middleware/migration"
+                        ]
                       }
                     ]
                   },
@@ -3471,6 +3480,15 @@
                           "ibc/next/middleware/callbacks/end-users",
                           "ibc/next/middleware/callbacks/gas",
                           "ibc/next/middleware/callbacks/callbacks-IBCv2"
+                        ]
+                      },
+                      {
+                        "group": "Rate Limit Middleware",
+                        "pages": [
+                          "ibc/next/middleware/rate-limit-middleware/overview",
+                          "ibc/next/middleware/rate-limit-middleware/integration",
+                          "ibc/next/middleware/rate-limit-middleware/setting-limits",
+                          "ibc/next/middleware/rate-limit-middleware/migration"
                         ]
                       }
                     ]

--- a/docs.json
+++ b/docs.json
@@ -2721,7 +2721,7 @@
         "dropdown": "IBC Protocol",
         "versions": [
           {
-            "version": "v11.0.x",
+            "version": "v11.x.x",
             "tabs": [
               {
                 "tab": "Documentation",
@@ -2784,6 +2784,8 @@
                       {
                         "group": "Version Upgrades",
                         "pages": [
+                          "ibc/latest/migrations/v11-to-v11-1",
+                          "ibc/latest/migrations/v10-to-v11-1",
                           "ibc/latest/migrations/v10-to-v11",
                           "ibc/latest/migrations/v8_1-to-v10",
                           "ibc/latest/migrations/v8-to-v8_1",

--- a/ibc/CLAUDE.md
+++ b/ibc/CLAUDE.md
@@ -139,7 +139,8 @@ next/
 │   └── rate-limit-middleware/
 │       ├── overview.mdx
 │       ├── integration.mdx
-│       └── setting-limits.mdx
+│       ├── setting-limits.mdx
+│       └── migration.mdx
 │
 ├── migrations/                 # Version migration guides
 │   ├── sdk-to-v1.mdx

--- a/ibc/latest/ibc/middleware/develop.mdx
+++ b/ibc/latest/ibc/middleware/develop.mdx
@@ -521,7 +521,7 @@ func GetAppVersion(
   // unwrap channel version
   metadata, err := Unmarshal(version)
     if err != nil {
-    panic(fmt.Errof("unable to unmarshal version: %w", err))
+    panic(fmt.Errorf("unable to unmarshal version: %w", err))
 }
 
 return metadata.AppVersion, true

--- a/ibc/latest/middleware/rate-limit-middleware/integration.mdx
+++ b/ibc/latest/middleware/rate-limit-middleware/integration.mdx
@@ -1,53 +1,51 @@
 ---
 title: Integration
-description: Integrate and configure Rate
-  Limit Middleware.
+description: Wire the rate limiting middleware into a chain for IBC v1 and v2.
 ---
 
-This document provides instructions on integrating and configuring the Rate Limit Middleware within your existing chain implementation.
+This guide wires the rate limiting middleware into a chain's `app.go`, using simapp as the reference. It assumes an ibc-go application that already has the transfer module wired. Wire the middleware for IBC v1, IBC v2, or both.
 
-## Example integration of the Rate Limit Middleware
+The middleware only understands ICS-20 transfer packets, so it must wrap the transfer application. It cannot sit on a non-transfer route.
+
+## Before you begin
+
+Confirm the application already has the middleware's dependencies:
+
+- The transfer keeper and, for IBC v2, the transfer v2 module.
+- The IBC keeper, including its `ChannelKeeper`, `ClientKeeper`, and for v2 its `ChannelKeeperV2`.
+- The bank keeper.
+- A governance authority address, the only account allowed to change limits.
+
+The module needs no manual genesis. It defaults to empty state: no limits, no whitelist, and no blacklist. To preload a whitelist or blacklist, see [configure rate limits](/ibc/latest/middleware/rate-limit-middleware/setting-limits).
+
+## Wire rate limiting for IBC v1
+
+These changes give a complete v1 integration. They add the keeper, register the middleware at the top of the transfer stack, and add the module to the manager.
 
 ```go
 // app.go
 
-// Import the rate limit middleware
 import (
-    ratelimiting "github.com/cosmos/ibc-go/v10/modules/apps/rate-limiting"
-    ratelimitkeeper "github.com/cosmos/ibc-go/v10/modules/apps/rate-limiting/keeper"
-    ratelimittypes "github.com/cosmos/ibc-go/v10/modules/apps/rate-limiting/types"
+    // ...
+    porttypes "github.com/cosmos/ibc-go/v11/modules/core/05-port/types"
+    ratelimiting "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting"
+    ratelimitkeeper "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/keeper"
+    ratelimittypes "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/types"
 )
 
-...
-
-// Register the AppModule for the rate limiting module
-ModuleBasics = module.NewBasicManager(
-    ...
-    ratelimiting.AppModuleBasic{},
-    ...
-)
-
-...
-
-// Add rate limiting Keeper
+// Add the keeper to the application struct.
 type App struct {
-    ...
+    // ...
     RateLimitKeeper *ratelimitkeeper.Keeper
-    ...
 }
 
-...
-
-// Create store keys
-keys := sdk.NewKVStoreKeys(
-    ...
+// Register the module's store key.
+keys := storetypes.NewKVStoreKeys(
+    // ...
     ratelimittypes.StoreKey,
-    ...
 )
 
-...
-
-// Initialize the rate limit middleware Keeper
+// Create the rate limit keeper.
 app.RateLimitKeeper = ratelimitkeeper.NewKeeper(
     appCodec,
     app.AccountKeeper.AddressCodec(),
@@ -55,94 +53,138 @@ app.RateLimitKeeper = ratelimitkeeper.NewKeeper(
     app.IBCKeeper.ChannelKeeper,
     app.IBCKeeper.ClientKeeper,
     app.BankKeeper,
-    authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+    authtypes.NewModuleAddress(govtypes.ModuleName).String(), // authority
 )
 
-// See the section below for configuring an application stack with the rate limit middleware
+// Build the transfer stack with rate limiting on top.
+//
+// The stack, from top to bottom:
+// - core IBC
+// - rate limiting
+// - transfer
+transferStack := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper)
+transferStack.
+    Base(transfer.NewIBCModule(app.TransferKeeper)).
+    Next(ratelimiting.NewIBCMiddleware(app.RateLimitKeeper))
 
-...
+// Add the stack to the IBC router.
+ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack.Build())
 
-// Register rate limiting AppModule
-app.moduleManager = module.NewManager(
-    ...
+// Register the app module with the module manager.
+app.ModuleManager = module.NewManager(
+    // ...
     ratelimiting.NewAppModule(app.RateLimitKeeper),
 )
 
-...
-
-// Add rate limiting to begin blocker logic (required for periodic rate limit resets)
-app.moduleManager.SetOrderBeginBlockers(
-    ...
+// Add the module to the begin blocker, end blocker, and genesis orders.
+app.ModuleManager.SetOrderBeginBlockers(
+    // ...
     ratelimittypes.ModuleName,
-    ...
 )
-
-// Add rate limiting to end blocker logic
-app.moduleManager.SetOrderEndBlockers(
-    ...
+app.ModuleManager.SetOrderEndBlockers(
+    // ...
     ratelimittypes.ModuleName,
-    ...
 )
-
-// Add rate limiting to init genesis logic
-app.moduleManager.SetOrderInitGenesis(
-    ...
+genesisModuleOrder := []string{
+    // ...
     ratelimittypes.ModuleName,
-    ...
-)
+}
 ```
 
-## Configuring the transfer application stack with Rate Limit Middleware
+Key details:
 
-Here is an example of how to create an application stack using `transfer` and `rate-limiting`.
-The following `transferStack` is configured in `app/app.go` and added to the IBC `Router`.
-The in-line comments describe the execution flow of packets between the application stack and IBC core.
+- The last keeper argument is the governance authority. The keeper stores it and enforces it on every message. A chain that uses the standard governance module passes `authtypes.NewModuleAddress(govtypes.ModuleName).String()`.
+- The module runs a begin-block hook and has genesis state, so it must appear in the begin-blocker order and the init and export genesis orderings.
+- If the chain already wires transfer middleware such as packet forward, add rate limiting to the existing stack with another `Next` call rather than creating a new stack.
 
-For more information on configuring an IBC application stack see the [middleware development guide](/ibc/latest/ibc/middleware/develop).
+## Wire rate limiting for IBC v2
+
+These changes give a complete v2 integration. IBC v2 uses a separate router, and the middleware wraps the transfer v2 module directly.
+
+<Note>
+The keeper, store key, module registration, and ordering are shared across versions. If the chain already wired v1 rate limiting above, those parts are done. Only the v2 router wiring is new, so skip to the step that builds `transferModuleV2`.
+</Note>
 
 ```go
-// Create Transfer Stack
-// SendPacket, since it is originating from the application to core IBC:
-// transferKeeper.SendPacket -> ratelimit.SendPacket -> channel.SendPacket
+// app.go
 
-// RecvPacket, message that originates from core IBC and goes down to app, the flow is the other way
-// channel.RecvPacket -> ratelimit.OnRecvPacket -> transfer.OnRecvPacket
+import (
+    // ...
+    ratelimiting "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting"
+    ratelimitkeeper "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/keeper"
+    ratelimittypes "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/types"
+    ratelimitingv2 "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/v2"
+)
 
-// transfer stack contains (from top to bottom):
-// - Rate Limit Middleware
-// - Transfer
+// Add the keeper to the application struct.
+type App struct {
+    // ...
+    RateLimitKeeper *ratelimitkeeper.Keeper
+}
 
-// create IBC module from bottom to top of stack
-transferStack := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper)
-transferStack.Base(transfer.NewIBCModule(app.TransferKeeper)).
-    Next(ratelimiting.NewIBCMiddleware(app.RateLimitKeeper))
+// Register the module's store key.
+keys := storetypes.NewKVStoreKeys(
+    // ...
+    ratelimittypes.StoreKey,
+)
 
-// Add transfer stack to IBC Router
-ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack.Build())
+// Create the rate limit keeper.
+app.RateLimitKeeper = ratelimitkeeper.NewKeeper(
+    appCodec,
+    app.AccountKeeper.AddressCodec(),
+    runtime.NewKVStoreService(keys[ratelimittypes.StoreKey]),
+    app.IBCKeeper.ChannelKeeper,
+    app.IBCKeeper.ClientKeeper,
+    app.BankKeeper,
+    authtypes.NewModuleAddress(govtypes.ModuleName).String(), // authority
+)
+
+// Wrap the transfer v2 module with rate limiting.
+transferModuleV2 := ratelimitingv2.NewIBCMiddleware(
+    *app.RateLimitKeeper, // v2 takes the keeper by value, so dereference it
+    transferv2.NewIBCModule(app.TransferKeeper),
+    app.IBCKeeper.ChannelKeeperV2, // write-acknowledgement wrapper
+    app.IBCKeeper.ChannelKeeperV2, // v2 channel keeper
+)
+
+// Add the wrapped module to the v2 router.
+ibcRouterV2.AddRoute(ibctransfertypes.PortID, transferModuleV2)
+
+// Register the app module with the module manager.
+app.ModuleManager = module.NewManager(
+    // ...
+    ratelimiting.NewAppModule(app.RateLimitKeeper),
+)
+
+// Add the module to the begin blocker, end blocker, and genesis orders.
+app.ModuleManager.SetOrderBeginBlockers(
+    // ...
+    ratelimittypes.ModuleName,
+)
+app.ModuleManager.SetOrderEndBlockers(
+    // ...
+    ratelimittypes.ModuleName,
+)
+genesisModuleOrder := []string{
+    // ...
+    ratelimittypes.ModuleName,
+}
 ```
 
-## Using Rate Limit Middleware with Packet Forward Middleware
+The v2 constructor takes four arguments: the keeper by value, the module being wrapped, a write-acknowledgement wrapper, and the v2 channel keeper. In simapp the last two are both `app.IBCKeeper.ChannelKeeperV2`. Both are required, and the constructor panics if either is nil.
 
-If both PFM and Rate Limit Middleware are integrated, they can be stacked together. In the reference implementation, Rate Limit Middleware is placed above PFM so that rate limits are enforced on the final inbound transfer before forwarding:
+The v2 middleware enforces the same limits as v1. It converts each v2 payload to the internal packet form and calls the same keeper logic, so a denom's limit applies identically regardless of which IBC version carried the transfer.
 
-```go
-// transfer stack contains (from top to bottom):
-// - Rate Limit Middleware
-// - Packet Forward Middleware
-// - Transfer
+<Warning>
+The transfer v2 route through rate limiting is added by [pull request #8984](https://github.com/cosmos/ibc-go/pull/8984). On an ibc-go version from before that change, only the v1 stack is wired. Confirm the version in use includes it before wiring v2.
+</Warning>
 
-// SendPacket flow: transferKeeper.SendPacket -> PFM.SendPacket -> RateLimit.SendPacket -> channel.SendPacket
-// RecvPacket flow: channel.RecvPacket -> RateLimit.OnRecvPacket -> PFM.OnRecvPacket -> transfer.OnRecvPacket
+## What can go wrong
 
-// create IBC module from bottom to top of stack
-transferStack := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper)
-transferStack.Base(transfer.NewIBCModule(app.TransferKeeper)).
-    Next(packetforward.NewIBCMiddleware(
-        app.PFMKeeper,
-        0, // retries on timeout
-        packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp,
-    )).
-    Next(ratelimiting.NewIBCMiddleware(app.RateLimitKeeper))
+- The application panics on start. The store key is likely unregistered, or a nil dependency reached the v2 constructor.
+- Limits never trigger. Confirm the middleware is on the route the transfers use, and that the module is in the begin-blocker order so windows advance.
 
-ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack.Build())
-```
+## Next steps
+
+- [Configure rate limits](/ibc/latest/middleware/rate-limit-middleware/setting-limits) through governance.
+- Review how limits are evaluated in the [rate limiting overview](/ibc/latest/middleware/rate-limit-middleware/overview).

--- a/ibc/latest/middleware/rate-limit-middleware/integration.mdx
+++ b/ibc/latest/middleware/rate-limit-middleware/integration.mdx
@@ -89,13 +89,40 @@ genesisModuleOrder := []string{
     // ...
     ratelimittypes.ModuleName,
 }
+app.ModuleManager.SetOrderInitGenesis(genesisModuleOrder...)
+app.ModuleManager.SetOrderExportGenesis(genesisModuleOrder...)
 ```
 
 Key details:
 
 - The last keeper argument is the governance authority. The keeper stores it and enforces it on every message. A chain that uses the standard governance module passes `authtypes.NewModuleAddress(govtypes.ModuleName).String()`.
 - The module runs a begin-block hook and has genesis state, so it must appear in the begin-blocker order and the init and export genesis orderings.
-- If the chain already wires transfer middleware such as packet forward, add rate limiting to the existing stack with another `Next` call rather than creating a new stack.
+- If the chain already wires other transfer middleware, add rate limiting to the same stack with another `Next` call rather than creating a new stack. See the packet forward example below.
+
+### With packet forward middleware
+
+If the chain runs packet forward middleware, place rate limiting above it in the same stack, so limits apply to the final inbound transfer before it is forwarded:
+
+```go
+// transfer stack, from top to bottom:
+// - rate limiting
+// - packet forward
+// - transfer
+//
+// SendPacket: transfer -> packet forward -> rate limiting -> core IBC
+// RecvPacket: core IBC -> rate limiting -> packet forward -> transfer
+transferStack := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper)
+transferStack.
+    Base(transfer.NewIBCModule(app.TransferKeeper)).
+    Next(packetforward.NewIBCMiddleware(
+        app.PFMKeeper,
+        0, // retries on timeout
+        packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp,
+    )).
+    Next(ratelimiting.NewIBCMiddleware(app.RateLimitKeeper))
+
+ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack.Build())
+```
 
 ## Wire rate limiting for IBC v2
 
@@ -169,6 +196,8 @@ genesisModuleOrder := []string{
     // ...
     ratelimittypes.ModuleName,
 }
+app.ModuleManager.SetOrderInitGenesis(genesisModuleOrder...)
+app.ModuleManager.SetOrderExportGenesis(genesisModuleOrder...)
 ```
 
 The v2 constructor takes four arguments: the keeper by value, the module being wrapped, a write-acknowledgement wrapper, and the v2 channel keeper. In simapp the last two are both `app.IBCKeeper.ChannelKeeperV2`. Both are required, and the constructor panics if either is nil.

--- a/ibc/latest/middleware/rate-limit-middleware/migration.mdx
+++ b/ibc/latest/middleware/rate-limit-middleware/migration.mdx
@@ -3,7 +3,7 @@ title: Migration
 description: Move an existing ibc-apps rate limiting integration to ibc-go.
 ---
 
-The rate limiting middleware moved from the standalone `ibc-apps` repository into ibc-go. Migrating is a code change across `app.go`. The import paths, the package name, the keeper constructor, and both middleware constructors all change. This guide moves an integration from `ibc-apps` v10 to ibc-go v11. For the full current wiring, see [integrate the rate limiting middleware](/ibc/latest/middleware/rate-limit-middleware/integration).
+The rate limiting middleware moved from the standalone `ibc-apps` repository into ibc-go. Migrating is a code change across `app.go`. The import paths, the package name, the keeper constructor, and both middleware constructors all change. This guide moves an integration from `ibc-apps` v10 to ibc-go v11.2. For the full current wiring, see [integrate the rate limiting middleware](/ibc/latest/middleware/rate-limit-middleware/integration).
 
 ## Update the imports
 
@@ -93,6 +93,21 @@ The v2 constructor gains two required arguments, a write-acknowledgement wrapper
 - ratelimit.NewAppModule(appCodec, app.RateLimitKeeper)
 + ratelimiting.NewAppModule(app.RateLimitKeeper)
 ```
+
+## Add store upgrades
+
+If rate limiting is being added to a chain for the first time, you must [manually add store upgrades](/sdk/latest/guides/upgrades/upgrade#adding-new-modules-during-an-upgrade) for the new module and configure the store loader to apply them in `app.go`:
+
+```go
+if upgradeInfo.Name == "v11_2" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+    storeUpgrades := store.StoreUpgrades{
+        Added: []string{ratelimittypes.StoreKey},
+    }
+    app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+}
+```
+
+This ensures the new module's stores are added to the multistore before the migrations begin.
 
 ## Verify the migration
 

--- a/ibc/latest/middleware/rate-limit-middleware/migration.mdx
+++ b/ibc/latest/middleware/rate-limit-middleware/migration.mdx
@@ -1,0 +1,108 @@
+---
+title: Migration
+description: Move an existing ibc-apps rate limiting integration to ibc-go.
+---
+
+The rate limiting middleware moved from the standalone `ibc-apps` repository into ibc-go. Migrating is a code change across `app.go`. The import paths, the package name, the keeper constructor, and both middleware constructors all change. This guide moves an integration from `ibc-apps` v10 to ibc-go v11. For the full current wiring, see [integrate the rate limiting middleware](/ibc/latest/middleware/rate-limit-middleware/integration).
+
+## Update the imports
+
+The module path changes, and the root package is renamed from `ratelimit` to `ratelimiting`.
+
+```diff
+- ratelimit "github.com/cosmos/ibc-apps/modules/rate-limiting/v10"
+- ratelimitkeeper "github.com/cosmos/ibc-apps/modules/rate-limiting/v10/keeper"
+- ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v10/types"
+- ratelimitv2 "github.com/cosmos/ibc-apps/modules/rate-limiting/v10/v2"
++ ratelimiting "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting"
++ ratelimitkeeper "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/keeper"
++ ratelimittypes "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/types"
++ ratelimitingv2 "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/v2"
+```
+
+## Update the keeper
+
+The keeper field becomes a pointer. The constructor drops the parameter subspace and the trailing ICS4 wrapper argument, adds an address codec, and moves the authority to the end. It returns a pointer, so drop the dereference.
+
+```diff
+  // app struct field
+- RateLimitKeeper ratelimitkeeper.Keeper
++ RateLimitKeeper *ratelimitkeeper.Keeper
+
+  // keeper construction
+- app.RateLimitKeeper = *ratelimitkeeper.NewKeeper(
+-     appCodec,
+-     runtime.NewKVStoreService(keys[ratelimittypes.StoreKey]),
+-     app.GetSubspace(ratelimittypes.ModuleName),
+-     authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+-     app.BankKeeper,
+-     app.IBCKeeper.ChannelKeeper,
+-     app.IBCKeeper.ClientKeeper,
+-     app.IBCKeeper.ChannelKeeper, // ICS4Wrapper
+- )
++ app.RateLimitKeeper = ratelimitkeeper.NewKeeper(
++     appCodec,
++     app.AccountKeeper.AddressCodec(),
++     runtime.NewKVStoreService(keys[ratelimittypes.StoreKey]),
++     app.IBCKeeper.ChannelKeeper,
++     app.IBCKeeper.ClientKeeper,
++     app.BankKeeper,
++     authtypes.NewModuleAddress(govtypes.ModuleName).String(),
++ )
+```
+
+## Update the v1 wiring
+
+The v1 middleware no longer takes the wrapped app as an argument. Build the stack with `NewIBCStackBuilder`, which injects the underlying app and sets the ICS4 wrapper, replacing the ICS4 argument the old keeper constructor took.
+
+```diff
+- var transferStack ibcporttypes.IBCModule = transfer.NewIBCModule(app.TransferKeeper)
+- transferStack = ratelimit.NewIBCMiddleware(app.RateLimitKeeper, transferStack)
++ transferStack := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper)
++ transferStack.
++     Base(transfer.NewIBCModule(app.TransferKeeper)).
++     Next(ratelimiting.NewIBCMiddleware(app.RateLimitKeeper))
++ ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack.Build())
+```
+
+This example shows a minimal stack. If the chain already runs other transfer middleware, such as packet forward, keep those layers as additional `.Next(...)` calls; only the rate-limiting layer changes.
+
+## Update the v2 wiring
+
+The v2 constructor gains two required arguments, a write-acknowledgement wrapper and the v2 channel keeper, and takes the keeper by value.
+
+```diff
+- transferStackV2 := ratelimitv2.NewIBCMiddleware(
+-     app.RateLimitKeeper,
+-     transferv2.NewIBCModule(app.TransferKeeper),
+- )
++ transferModuleV2 := ratelimitingv2.NewIBCMiddleware(
++     *app.RateLimitKeeper,
++     transferv2.NewIBCModule(app.TransferKeeper),
++     app.IBCKeeper.ChannelKeeperV2,
++     app.IBCKeeper.ChannelKeeperV2,
++ )
++ ibcRouterV2.AddRoute(ibctransfertypes.PortID, transferModuleV2)
+```
+
+## Update the app module
+
+`NewAppModule` no longer takes the codec.
+
+```diff
+- ratelimit.NewAppModule(appCodec, app.RateLimitKeeper)
++ ratelimiting.NewAppModule(app.RateLimitKeeper)
+```
+
+## Verify the migration
+
+After the app compiles, confirm the module is active by querying the existing limits.
+
+```bash
+simd query ratelimiting list-rate-limits
+```
+
+## Next steps
+
+- Confirm limits behave as expected using the [setting rate limits](/ibc/latest/middleware/rate-limit-middleware/setting-limits) queries.
+- Review the full wiring in [integrate the rate limiting middleware](/ibc/latest/middleware/rate-limit-middleware/integration).

--- a/ibc/latest/middleware/rate-limit-middleware/overview.mdx
+++ b/ibc/latest/middleware/rate-limit-middleware/overview.mdx
@@ -1,26 +1,124 @@
 ---
 title: Overview
-description: About Rate Limit Middleware
+description: A governance-configured middleware that caps net token flow across IBC transfers.
 ---
 
-Learn about Rate Limit Middleware, a middleware that can be used in combination with token transfers (ICS-20) to control the amount of in and outflows of assets in a certain time period.
+Rate limiting is a governance-configured middleware that caps net token flow across IBC transfers, protecting a chain from draining faster than governance allows. It sits on top of the ICS-20 fungible token transfer application. It measures how much of a token moves over a given path, in each direction, within a rolling time window. When a transfer would push the running total past its configured cap, the middleware rejects it.
 
-## What is Rate Limit Middleware?
-
-The rate limit middleware enforces rate limits on IBC token transfers coming into and out of a chain. It supports:
-
-* **Risk Mitigation:** In case of a bug exploit, attack or economic failure of a connected chain, it limits the impact to the in/outflow specified for a given time period.
-* **Token Filtering:** Through the use of a blacklist, the middleware can completely block tokens entering or leaving a domain, relevant for compliance or giving asset issuers greater control over the domains token can be sent to.
-* **Uninterrupted Packet Flow:** When desired, rate limits can be bypassed by using the whitelist, to avoid any restriction on asset in or outflows.
+To wire it into a chain, see [integrate the rate limiting middleware](/ibc/latest/middleware/rate-limit-middleware/integration). To configure limits through governance, see [configure rate limits](/ibc/latest/middleware/rate-limit-middleware/setting-limits).
 
 ## How it works
 
-The rate limiting middleware determines whether tokens can flow into or out of a chain. The middleware does this by:
+A rate limit is a ceiling on how much value can leave or enter a chain over one path in one window. When tokens start moving abnormally fast, the limit throttles the flow without freezing normal transfer activity, buying governance time to respond.
 
-1. Check transfer limits for an asset (Quota): When tokens are received or sent, the middleware determines whether the amount of tokens flowing in or out have exceeded the limit.
+The middleware applies to ICS-20 transfers only. Limits are defined and configured independently per pair of denom and path. A path is identified by a channel ID (IBC v1) or a client ID (IBC v2).
 
-2. Track in or outflow: When tokens enter or leave the chain, the amount transferred is tracked in state.
+Flow limits are set by chain governance.
 
-3. Block or allow token flow: Dependent on the limit, the middleware will either allow the tokens to pass through or block the tokens.
+### Rate limiting and transfers
 
-4. Handle failures: If the packet timesout or fails to be delivered, the middleware ensures limits are correctly recorded.
+The middleware wraps the transfer application. Every transfer passes through its accounting before reaching core IBC on the way out or the application on the way in. On a typical chain, the outbound path runs from the transfer module, up through any packet forward middleware, through rate limiting, and finally to the IBC core that sends the packet. The inbound path runs in reverse.
+
+```mermaid
+sequenceDiagram
+    participant Core as IBC core
+    participant RL as Rate limiting
+    participant App as Transfer app
+    Note over Core,App: Outbound (send)
+    App->>RL: SendPacket
+    RL->>RL: check and record outflow
+    RL->>Core: SendPacket (if allowed)
+    Note over Core,App: Inbound (receive)
+    Core->>RL: OnRecvPacket
+    RL->>RL: check and record inflow
+    RL->>App: OnRecvPacket (if allowed)
+```
+
+The middleware acts on four points in a packet's life:
+
+- It checks the outflow when a packet is sent.
+- It checks the inflow when a packet is received.
+- It reverts a recorded outflow when a sent packet fails.
+- It reverts a recorded outflow when a sent packet times out.
+
+A blocked outbound transfer fails at the source, so the sender's tokens are never escrowed. A blocked inbound transfer returns an error acknowledgement, so the sending chain refunds its user.
+
+### Quotas, flows, and channel value
+
+Three pieces decide every transfer:
+
+- Quota: the outbound cap, the inbound cap, and the window length.
+- Flow: the inflow so far, the outflow so far, and the channel value for this window.
+- Channel value: the total on-chain supply of the denom, read from the bank module. It is the denominator that turns a percentage cap into an absolute amount.
+
+The caps are percentages of the channel value. The middleware reads the channel value when the limit is created and again at each window reset, not on every packet. A single window therefore measures flow against a fixed supply figure.
+
+Governance configures the quota fields directly:
+
+```go
+type Quota struct {
+    MaxPercentSend math.Int // outbound cap as a percent of channel value
+    MaxPercentRecv math.Int // inbound cap as a percent of channel value
+    DurationHours  uint64   // window length before the flow resets
+}
+```
+
+The middleware measures net flow, not gross flow:
+
+- Net outflow is the outflow minus the inflow plus the new amount.
+- Net inflow is the inflow minus the outflow plus the new amount.
+
+Transfers in the opposite direction free up headroom, so balanced traffic does not throttle a chain that both sends and receives a token.
+
+A transfer is denied when its net flow is strictly greater than the threshold. The threshold is the channel value times the cap percent, divided by 100.
+
+Consider a denom with a total supply of 1,000,000 and a `MaxPercentSend` of 10.
+
+The outbound threshold is 100,000, which is 10% of supply. Suppose the current window has recorded 60,000 of outflow and 20,000 of inflow.
+
+A new outbound transfer is allowed only if the net outflow stays at or below 100,000:
+
+| New send | Net outflow (60,000 - 20,000 + send) | Result |
+| --- | --- | --- |
+| 70,000 | 110,000 | Denied, exceeds 100,000 |
+| 50,000 | 90,000 | Allowed |
+
+### Rolling windows and resets
+
+A flow accumulates within a fixed window and returns to zero when the window elapses. The window length is the quota's duration in hours. The module tracks time as an hourly epoch that advances once per block, and each limit resets when the elapsed epoch count is a multiple of its duration. A limit with a 24-hour duration therefore resets once a day.
+
+A reset does three things:
+
+- It zeroes the inflow and outflow.
+- It re-reads the channel value from current supply, so the caps track the token's supply as it changes.
+- It clears the record of packets still in flight for that path.
+
+### Reversal on failed acknowledgements and timeouts
+
+An outbound transfer counts against the flow the moment it is sent, before the receiving chain has confirmed it. That count is provisional:
+
+- If the packet is acknowledged successfully, the outflow stands.
+- If the acknowledgement carries an error or the packet times out, the middleware reverts the outflow so a failed transfer does not consume the limit.
+
+The reversal is conditional on the window. The middleware reverts an outflow only if the packet was sent during the window that is still open. A packet sent in an earlier window that has already reset is not reverted, because that window's totals are already gone.
+
+### Whitelists and blacklists
+
+Two lists override the quota logic at the edges:
+
+- A whitelist entry is a specific sender and receiver address pair. Transfers between a whitelisted pair skip rate limiting entirely and do not update the flow. This suits trusted or protocol-controlled routes.
+- A blacklist entry is a denom. Any transfer of a blacklisted denom is rejected outright, regardless of quota.
+
+The module evaluates a transfer in a fixed order:
+
+1. It rejects a blacklisted denom.
+2. It allows any path that has no limit configured.
+3. It exempts a whitelisted address pair.
+4. It applies the quota.
+
+Whitelist and blacklist entries are set in genesis rather than through governance messages. To configure them, see [configure rate limits](/ibc/latest/middleware/rate-limit-middleware/setting-limits).
+
+## Next steps
+
+- [Integrate the rate limiting middleware](/ibc/latest/middleware/rate-limit-middleware/integration) into a chain for IBC v1 and v2.
+- [Configure rate limits](/ibc/latest/middleware/rate-limit-middleware/setting-limits) through governance.

--- a/ibc/latest/middleware/rate-limit-middleware/setting-limits.mdx
+++ b/ibc/latest/middleware/rate-limit-middleware/setting-limits.mdx
@@ -1,21 +1,100 @@
 ---
 title: Setting Rate Limits
-description: >-
-  Rate limits are set through a governance-gated authority on a per denom, and
-  per channel / client basis. To add a rate limit, the MsgAddRateLimit message
-  must be executed which includes:
+description: Configure rate limits through governance, and set whitelists and blacklists in genesis.
 ---
 
-Rate limits are set through a governance-gated authority on a per denom, and per channel / client basis. To add a rate limit, the [`MsgAddRateLimit`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/rate-limiting/types/msgs.go#L27-L35) message must be executed which includes:
+This guide covers configuring limits on a chain that already has the middleware wired. Every change to a limit is a governance message, submitted inside [a Cosmos SDK governance proposal](https://docs.cosmos.network/sdk/latest/modules/gov/README), and it takes effect only if the proposal passes. This guide assumes familiarity with submitting and voting on proposals.
 
-* Denom: the asset that the rate limit should be applied to
-* ChannelOrClientId: the channelID for use with IBC classic connections, or the clientID for use with IBC v2 connections
-* MaxPercentSend: the outflow threshold as a percentage of the `channelValue`. More explicitly, a packet being sent would exceed the threshold quota if: (Outflow - Inflow + Packet Amount) / channelValue is greater than MaxPercentSend / 100
-* MaxPercentRecv: the inflow threshold as a percentage of the `channelValue`
-* DurationHours: the length of time, after which the rate limits reset
+## The four governance messages
 
-## Updating, Removing or Resetting Rate Limits
+The module accepts [four governance messages](https://github.com/cosmos/ibc-go/blob/2619d6ec8543b2e0cbc1a234dad38b4ae2299a27/proto/ibc/applications/rate_limiting/v1/tx.proto), each requiring the governance authority as the signer. Together they cover the full life of a limit:
 
-* If rate limits were set to be too low or high for a given channel/client, they can be updated with [`MsgUpdateRateLimit`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/rate-limiting/types/msgs.go#L81-L89).
-* If rate limits are no longer needed, they can be removed with [`MsgRemoveRateLimit`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/rate-limiting/types/msgs.go#L135-L140).
-* If the flow counter needs to be reset for a given rate limit, it is possible to do so with [`MsgResetRateLimit`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/rate-limiting/types/msgs.go#L167-L172).
+- `MsgAddRateLimit` creates a limit.
+- `MsgUpdateRateLimit` replaces a limit's quota and resets its flow.
+- `MsgRemoveRateLimit` deletes a limit.
+- `MsgResetRateLimit` keeps a limit but zeroes its flow.
+
+Each field means:
+
+| Field | Description |
+| --- | --- |
+| `denom` | The token the limit applies to, as it appears on this chain. Use the `ibc/...` denom for a non-native token. |
+| `channel_or_client_id` | The channel ID under IBC v1, or the client ID under IBC v2, that the limit applies to. |
+| `max_percent_send` | The outbound cap, as a percent of channel value. For example, 10 means 10%. |
+| `max_percent_recv` | The inbound cap, as a percent of channel value. For example, 10 means 10%. |
+| `duration_hours` | The window length in hours before the flow resets. For example, 24 means daily. |
+
+`MsgAddRateLimit` and `MsgUpdateRateLimit` take all five fields. `MsgRemoveRateLimit` and `MsgResetRateLimit` take only `denom` and `channel_or_client_id`. Every message also carries `signer`, the governance authority.
+
+Fields are validated before a message is accepted:
+
+- `channel_or_client_id` is a channel in the form `channel-<n>` or a valid client ID.
+- Each percentage is between 0 and 100.
+- At least one of send or receive is greater than zero.
+- `duration_hours` is greater than zero.
+
+## Choose quota values
+
+The caps are percentages of the denom's total supply on the chain.
+
+A `max_percent_send` of 10 caps net outflow at 10 percent of supply per window. To limit only one direction, set the unused side to 0 and keep the other above zero. To set a daily limit, set `duration_hours` to 24.
+
+## Whitelist and blacklist entries
+
+The module supports two overrides beyond quotas:
+
+- A whitelist exempts a specific sender and receiver address pair from rate limiting.
+- A blacklist blocks a denom outright.
+
+Neither has a governance message. Set both in the module's genesis state, under `app_state.ratelimiting`, in the `whitelisted_address_pairs` and `blacklisted_denoms` fields. Change them only at chain launch or through a coordinated upgrade.
+
+```json
+{
+  "app_state": {
+    "ratelimiting": {
+      "whitelisted_address_pairs": [
+        { "sender": "cosmos1sender...", "receiver": "cosmos1receiver..." }
+      ],
+      "blacklisted_denoms": ["uatom"]
+    }
+  }
+}
+```
+
+## Verify a limit
+
+The module exposes query commands under the `ratelimiting` subcommand. Use them to confirm a proposal took effect.
+
+List every limit on the chain:
+
+```bash
+simd query ratelimiting list-rate-limits
+```
+
+Query one limit by path and denom:
+
+```bash
+simd query ratelimiting rate-limit [channel-or-client-id] --denom [denom]
+```
+
+Query the limits that target a given chain:
+
+```bash
+simd query ratelimiting rate-limits-by-chain [chain-id]
+```
+
+Read the current whitelist:
+
+```bash
+simd query ratelimiting list-whitelisted-addresses
+```
+
+Read the current blacklist:
+
+```bash
+simd query ratelimiting list-blacklisted-denoms
+```
+
+## Next steps
+
+- Review how limits are evaluated in the [rate limiting overview](/ibc/latest/middleware/rate-limit-middleware/overview).

--- a/ibc/latest/middleware/rate-limit-middleware/setting-limits.mdx
+++ b/ibc/latest/middleware/rate-limit-middleware/setting-limits.mdx
@@ -12,7 +12,7 @@ The module accepts [four governance messages](https://github.com/cosmos/ibc-go/b
 - `MsgAddRateLimit` creates a limit.
 - `MsgUpdateRateLimit` replaces a limit's quota and resets its flow.
 - `MsgRemoveRateLimit` deletes a limit.
-- `MsgResetRateLimit` keeps a limit but zeroes its flow.
+- `MsgResetRateLimit` keeps a limit but zeroes its flow and clears its in-flight packet records.
 
 Each field means:
 
@@ -46,12 +46,12 @@ The module supports two overrides beyond quotas:
 - A whitelist exempts a specific sender and receiver address pair from rate limiting.
 - A blacklist blocks a denom outright.
 
-Neither has a governance message. Set both in the module's genesis state, under `app_state.ratelimiting`, in the `whitelisted_address_pairs` and `blacklisted_denoms` fields. Change them only at chain launch or through a coordinated upgrade.
+Neither has a governance message. Set both in the module's genesis state, under `app_state.ratelimit`, in the `whitelisted_address_pairs` and `blacklisted_denoms` fields. Change them only at chain launch or through a coordinated upgrade.
 
 ```json
 {
   "app_state": {
-    "ratelimiting": {
+    "ratelimit": {
       "whitelisted_address_pairs": [
         { "sender": "cosmos1sender...", "receiver": "cosmos1receiver..." }
       ],

--- a/ibc/latest/migrations/v10-to-v11-1.mdx
+++ b/ibc/latest/migrations/v10-to-v11-1.mdx
@@ -1,0 +1,116 @@
+---
+title: IBC-Go v10 to v11.1
+description: This guide provides instructions for migrating from ibc-go v10 to v11.1.
+---
+
+ibc-go supports golang semantic versioning and therefore all imports must be updated on major version releases.
+
+This guide is for chains upgrading directly from ibc-go v10 to ibc-go v11.1. It includes the changes from the ibc-go v11.0 migration and the Packet Forward Middleware changes introduced in ibc-go v11.1.
+
+The following changes from v10 to v11 are relevant to this upgrade:
+
+- Chains will need to remove the `ParamSubspace` arg from all calls to `Keeper` constructors
+
+```diff
+  app.IBCKeeper = ibckeeper.NewKeeper(
+    appCodec,
+    runtime.NewKVStoreService(keys[ibcexported.StoreKey]),
+-   app.GetSubspace(ibcexported.ModuleName),
+    app.UpgradeKeeper,
+    authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+  )
+```
+
+The transfer module, the packet forward middleware, and the rate limiting middleware support custom address codecs. This feature is primarily added to support Cosmos EVM for IBC transfers. In a standard Cosmos SDK app, they are wired as follows:
+
+```diff
+  app.TransferKeeper = ibctransferkeeper.NewKeeper(
+    appCodec,
++    app.AccountKeeper.AddressCodec(),
+    runtime.NewKVStoreService(keys[ibctransfertypes.StoreKey]),
+    app.IBCKeeper.ChannelKeeper,
+    app.MsgServiceRouter(),
+    app.AccountKeeper, app.BankKeeper,
+    authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+  )
+```
+
+```diff
+  app.RateLimitKeeper = ratelimitkeeper.NewKeeper(
+    appCodec,
++    app.AccountKeeper.AddressCodec(),
+    runtime.NewKVStoreService(keys[ratelimittypes.StoreKey]),
+    app.IBCKeeper.ChannelKeeper,
+    app.IBCKeeper.ClientKeeper,
+    app.BankKeeper,
+    authtypes.NewModuleAddress(govtypes.ModuleName).String()
+  )
+```
+
+```diff
+  app.PFMKeeper = packetforwardkeeper.NewKeeper(
+    appCodec,
++    app.AccountKeeper.AddressCodec(),
+    runtime.NewKVStoreService(keys[packetforwardtypes.StoreKey]),
+    app.TransferKeeper,
+    app.IBCKeeper.ChannelKeeper,
+    app.BankKeeper,
+    authtypes.NewModuleAddress(govtypes.ModuleName).String()
+  )
+```
+
+## ICS27-GMP
+
+ICS27 General Message Passing (GMP) has been added as a supported IBC application of ibc-go. It has no parameters.
+
+### Add `StoreUpgrades` for ICS27-GMP module
+
+If ICS27-GMP is being added to an existing chain, you must [manually add store upgrades](https://docs.cosmos.network/sdk/v0.53/learn/advanced/upgrade#add-storeupgrades-for-new-modules) for the new GMP module and configure the store loader to apply those upgrades in `app.go`:
+
+```go
+if upgradeInfo.Name == "v11_1" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+  storeUpgrades := store.StoreUpgrades{
+    Added: []string{gmptypes.StoreKey},
+  }
+
+  app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+}
+```
+
+This ensures that the new module's stores are added to the multistore before the migrations begin.
+If a chain does not integrate ICS27-GMP, it does not need to add the GMP key to the `Added` field.
+
+## Packet Forward Middleware (New in v11.1)
+
+Packet Forward Middleware (PFM) has been moved from [cosmos/ibc-apps](https://github.com/cosmos/ibc-apps) to ibc-go in this release. PFM is now available under `modules/apps/packet-forward-middleware`.
+
+Your migration path depends on whether your chain already uses PFM from ibc-apps.
+
+### If your chain already uses PFM from ibc-apps
+
+Replace all ibc-apps PFM imports with the new ibc-go imports and review the [integration instructions](/ibc/latest/middleware/packet-forward-middleware/integration).
+
+If your chain already has a PFM store from a previous upgrade, do not add `packetforwardtypes.StoreKey` as a new store in this upgrade. The ibc-go PFM module intentionally preserves the original module name and store key, including the `packetfowardmiddleware` spelling, for compatibility with the legacy implementation.
+
+The PFM module includes in-place migrations for existing PFM state. Before upgrading, ensure there are no non-refundable in-flight packets. The v3-to-v4 PFM migration removes the deprecated `nonrefundable` field from in-flight packet state and aborts if any stored in-flight packet has `nonrefundable=true`.
+
+### If your chain is adding PFM for the first time
+
+First follow the [integration instructions](/ibc/latest/middleware/packet-forward-middleware/integration).
+
+If PFM is being added to an existing chain, you must [manually add store upgrades](https://docs.cosmos.network/sdk/latest/guides/upgrades/upgrade#adding-new-modules-during-an-upgrade) for the new PFM module and configure the store loader to apply those upgrades in `app.go`.
+
+If your upgrade also introduces ICS27-GMP, include both store keys:
+
+```go
+if upgradeInfo.Name == "v11_1" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+  storeUpgrades := store.StoreUpgrades{
+    Added: []string{gmptypes.StoreKey, packetforwardtypes.StoreKey},
+  }
+
+  app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+}
+```
+
+This ensures that the new module's stores are added to the multistore before the migrations begin.
+If your chain already added the ICS27-GMP store key in a previous upgrade, do not add `gmptypes.StoreKey` again. If your chain does not integrate PFM, it does not need to add the PFM key to the `Added` field.

--- a/ibc/latest/migrations/v11-to-v11-1.mdx
+++ b/ibc/latest/migrations/v11-to-v11-1.mdx
@@ -1,0 +1,35 @@
+---
+title: IBC-Go v11.0 to v11.1
+description: This guide provides instructions for migrating from ibc-go v11.0 to v11.1.
+---
+
+This guide assumes that your chain is already using ibc-go v11.0 and is upgrading to ibc-go v11.1. If you are upgrading directly from ibc-go v10 to ibc-go v11.1, see the [migration guide for v10 to v11](/ibc/latest/migrations/v10-to-v11).
+
+## Packet Forward Middleware
+
+Packet Forward Middleware (PFM) has been moved from [cosmos/ibc-apps](https://github.com/cosmos/ibc-apps) to ibc-go in this release. PFM is now available under `modules/apps/packet-forward-middleware`.
+
+This guide assumes that your chain has not previously integrated PFM from ibc-apps. If your chain already uses PFM from ibc-apps, follow the [migration guide for v10 to v11](/ibc/latest/migrations/v10-to-v11), which includes guidance for preserving existing PFM state.
+
+If you want to enable PFM, first follow the [integration instructions](/ibc/latest/middleware/packet-forward-middleware/integration).
+
+### Add `StoreUpgrades` for the PFM module
+
+If PFM is being added to an existing chain, you must [manually add store upgrades](https://docs.cosmos.network/sdk/latest/guides/upgrades/upgrade#adding-new-modules-during-an-upgrade) for the new PFM module and configure the store loader to apply those upgrades in `app.go`:
+
+```go
+if upgradeInfo.Name == "v11_1" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+  storeUpgrades := store.StoreUpgrades{
+    Added: []string{packetforwardtypes.StoreKey},
+  }
+
+  app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+}
+```
+
+This ensures that the new module's stores are added to the multistore before the migrations begin.
+If a chain does not integrate PFM, it does not need to add the PFM key to the `Added` field.
+
+<Note>
+The PFM module name and store key intentionally preserve the original `packetfowardmiddleware` spelling for compatibility with the legacy implementation.
+</Note>

--- a/ibc/next/ibc/middleware/develop.mdx
+++ b/ibc/next/ibc/middleware/develop.mdx
@@ -523,7 +523,7 @@ func GetAppVersion(
   // unwrap channel version
   metadata, err := Unmarshal(version)
     if err != nil {
-    panic(fmt.Errof("unable to unmarshal version: %w", err))
+    panic(fmt.Errorf("unable to unmarshal version: %w", err))
 }
 
 return metadata.AppVersion, true

--- a/ibc/next/middleware/rate-limit-middleware/integration.mdx
+++ b/ibc/next/middleware/rate-limit-middleware/integration.mdx
@@ -89,13 +89,40 @@ genesisModuleOrder := []string{
     // ...
     ratelimittypes.ModuleName,
 }
+app.ModuleManager.SetOrderInitGenesis(genesisModuleOrder...)
+app.ModuleManager.SetOrderExportGenesis(genesisModuleOrder...)
 ```
 
 Key details:
 
 - The last keeper argument is the governance authority. The keeper stores it and enforces it on every message. A chain that uses the standard governance module passes `authtypes.NewModuleAddress(govtypes.ModuleName).String()`.
 - The module runs a begin-block hook and has genesis state, so it must appear in the begin-blocker order and the init and export genesis orderings.
-- If the chain already wires transfer middleware such as packet forward, add rate limiting to the existing stack with another `Next` call rather than creating a new stack.
+- If the chain already wires other transfer middleware, add rate limiting to the same stack with another `Next` call rather than creating a new stack. See the packet forward example below.
+
+### With packet forward middleware
+
+If the chain runs packet forward middleware, place rate limiting above it in the same stack, so limits apply to the final inbound transfer before it is forwarded:
+
+```go
+// transfer stack, from top to bottom:
+// - rate limiting
+// - packet forward
+// - transfer
+//
+// SendPacket: transfer -> packet forward -> rate limiting -> core IBC
+// RecvPacket: core IBC -> rate limiting -> packet forward -> transfer
+transferStack := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper)
+transferStack.
+    Base(transfer.NewIBCModule(app.TransferKeeper)).
+    Next(packetforward.NewIBCMiddleware(
+        app.PFMKeeper,
+        0, // retries on timeout
+        packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp,
+    )).
+    Next(ratelimiting.NewIBCMiddleware(app.RateLimitKeeper))
+
+ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack.Build())
+```
 
 ## Wire rate limiting for IBC v2
 
@@ -169,6 +196,8 @@ genesisModuleOrder := []string{
     // ...
     ratelimittypes.ModuleName,
 }
+app.ModuleManager.SetOrderInitGenesis(genesisModuleOrder...)
+app.ModuleManager.SetOrderExportGenesis(genesisModuleOrder...)
 ```
 
 The v2 constructor takes four arguments: the keeper by value, the module being wrapped, a write-acknowledgement wrapper, and the v2 channel keeper. In simapp the last two are both `app.IBCKeeper.ChannelKeeperV2`. Both are required, and the constructor panics if either is nil.

--- a/ibc/next/middleware/rate-limit-middleware/integration.mdx
+++ b/ibc/next/middleware/rate-limit-middleware/integration.mdx
@@ -1,55 +1,51 @@
 ---
-noindex: true
-canonical: 'https://docs.cosmos.network/ibc/latest/middleware/rate-limit-middleware/integration'
 title: Integration
-description: Integrate and configure Rate
-  Limit Middleware.
+description: Wire the rate limiting middleware into a chain for IBC v1 and v2.
 ---
 
-This document provides instructions on integrating and configuring the Rate Limit Middleware within your existing chain implementation.
+This guide wires the rate limiting middleware into a chain's `app.go`, using simapp as the reference. It assumes an ibc-go application that already has the transfer module wired. Wire the middleware for IBC v1, IBC v2, or both.
 
-## Example integration of the Rate Limit Middleware
+The middleware only understands ICS-20 transfer packets, so it must wrap the transfer application. It cannot sit on a non-transfer route.
+
+## Before you begin
+
+Confirm the application already has the middleware's dependencies:
+
+- The transfer keeper and, for IBC v2, the transfer v2 module.
+- The IBC keeper, including its `ChannelKeeper`, `ClientKeeper`, and for v2 its `ChannelKeeperV2`.
+- The bank keeper.
+- A governance authority address, the only account allowed to change limits.
+
+The module needs no manual genesis. It defaults to empty state: no limits, no whitelist, and no blacklist. To preload a whitelist or blacklist, see [configure rate limits](/ibc/next/middleware/rate-limit-middleware/setting-limits).
+
+## Wire rate limiting for IBC v1
+
+These changes give a complete v1 integration. They add the keeper, register the middleware at the top of the transfer stack, and add the module to the manager.
 
 ```go
 // app.go
 
-// Import the rate limit middleware
 import (
-    ratelimiting "github.com/cosmos/ibc-go/v10/modules/apps/rate-limiting"
-    ratelimitkeeper "github.com/cosmos/ibc-go/v10/modules/apps/rate-limiting/keeper"
-    ratelimittypes "github.com/cosmos/ibc-go/v10/modules/apps/rate-limiting/types"
+    // ...
+    porttypes "github.com/cosmos/ibc-go/v11/modules/core/05-port/types"
+    ratelimiting "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting"
+    ratelimitkeeper "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/keeper"
+    ratelimittypes "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/types"
 )
 
-...
-
-// Register the AppModule for the rate limiting module
-ModuleBasics = module.NewBasicManager(
-    ...
-    ratelimiting.AppModuleBasic{},
-    ...
-)
-
-...
-
-// Add rate limiting Keeper
+// Add the keeper to the application struct.
 type App struct {
-    ...
+    // ...
     RateLimitKeeper *ratelimitkeeper.Keeper
-    ...
 }
 
-...
-
-// Create store keys
-keys := sdk.NewKVStoreKeys(
-    ...
+// Register the module's store key.
+keys := storetypes.NewKVStoreKeys(
+    // ...
     ratelimittypes.StoreKey,
-    ...
 )
 
-...
-
-// Initialize the rate limit middleware Keeper
+// Create the rate limit keeper.
 app.RateLimitKeeper = ratelimitkeeper.NewKeeper(
     appCodec,
     app.AccountKeeper.AddressCodec(),
@@ -57,94 +53,138 @@ app.RateLimitKeeper = ratelimitkeeper.NewKeeper(
     app.IBCKeeper.ChannelKeeper,
     app.IBCKeeper.ClientKeeper,
     app.BankKeeper,
-    authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+    authtypes.NewModuleAddress(govtypes.ModuleName).String(), // authority
 )
 
-// See the section below for configuring an application stack with the rate limit middleware
+// Build the transfer stack with rate limiting on top.
+//
+// The stack, from top to bottom:
+// - core IBC
+// - rate limiting
+// - transfer
+transferStack := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper)
+transferStack.
+    Base(transfer.NewIBCModule(app.TransferKeeper)).
+    Next(ratelimiting.NewIBCMiddleware(app.RateLimitKeeper))
 
-...
+// Add the stack to the IBC router.
+ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack.Build())
 
-// Register rate limiting AppModule
-app.moduleManager = module.NewManager(
-    ...
+// Register the app module with the module manager.
+app.ModuleManager = module.NewManager(
+    // ...
     ratelimiting.NewAppModule(app.RateLimitKeeper),
 )
 
-...
-
-// Add rate limiting to begin blocker logic (required for periodic rate limit resets)
-app.moduleManager.SetOrderBeginBlockers(
-    ...
+// Add the module to the begin blocker, end blocker, and genesis orders.
+app.ModuleManager.SetOrderBeginBlockers(
+    // ...
     ratelimittypes.ModuleName,
-    ...
 )
-
-// Add rate limiting to end blocker logic
-app.moduleManager.SetOrderEndBlockers(
-    ...
+app.ModuleManager.SetOrderEndBlockers(
+    // ...
     ratelimittypes.ModuleName,
-    ...
 )
-
-// Add rate limiting to init genesis logic
-app.moduleManager.SetOrderInitGenesis(
-    ...
+genesisModuleOrder := []string{
+    // ...
     ratelimittypes.ModuleName,
-    ...
-)
+}
 ```
 
-## Configuring the transfer application stack with Rate Limit Middleware
+Key details:
 
-Here is an example of how to create an application stack using `transfer` and `rate-limiting`.
-The following `transferStack` is configured in `app/app.go` and added to the IBC `Router`.
-The in-line comments describe the execution flow of packets between the application stack and IBC core.
+- The last keeper argument is the governance authority. The keeper stores it and enforces it on every message. A chain that uses the standard governance module passes `authtypes.NewModuleAddress(govtypes.ModuleName).String()`.
+- The module runs a begin-block hook and has genesis state, so it must appear in the begin-blocker order and the init and export genesis orderings.
+- If the chain already wires transfer middleware such as packet forward, add rate limiting to the existing stack with another `Next` call rather than creating a new stack.
 
-For more information on configuring an IBC application stack see the [middleware development guide](/ibc/next/ibc/middleware/develop).
+## Wire rate limiting for IBC v2
+
+These changes give a complete v2 integration. IBC v2 uses a separate router, and the middleware wraps the transfer v2 module directly.
+
+<Note>
+The keeper, store key, module registration, and ordering are shared across versions. If the chain already wired v1 rate limiting above, those parts are done. Only the v2 router wiring is new, so skip to the step that builds `transferModuleV2`.
+</Note>
 
 ```go
-// Create Transfer Stack
-// SendPacket, since it is originating from the application to core IBC:
-// transferKeeper.SendPacket -> ratelimit.SendPacket -> channel.SendPacket
+// app.go
 
-// RecvPacket, message that originates from core IBC and goes down to app, the flow is the other way
-// channel.RecvPacket -> ratelimit.OnRecvPacket -> transfer.OnRecvPacket
+import (
+    // ...
+    ratelimiting "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting"
+    ratelimitkeeper "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/keeper"
+    ratelimittypes "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/types"
+    ratelimitingv2 "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/v2"
+)
 
-// transfer stack contains (from top to bottom):
-// - Rate Limit Middleware
-// - Transfer
+// Add the keeper to the application struct.
+type App struct {
+    // ...
+    RateLimitKeeper *ratelimitkeeper.Keeper
+}
 
-// create IBC module from bottom to top of stack
-transferStack := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper)
-transferStack.Base(transfer.NewIBCModule(app.TransferKeeper)).
-    Next(ratelimiting.NewIBCMiddleware(app.RateLimitKeeper))
+// Register the module's store key.
+keys := storetypes.NewKVStoreKeys(
+    // ...
+    ratelimittypes.StoreKey,
+)
 
-// Add transfer stack to IBC Router
-ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack.Build())
+// Create the rate limit keeper.
+app.RateLimitKeeper = ratelimitkeeper.NewKeeper(
+    appCodec,
+    app.AccountKeeper.AddressCodec(),
+    runtime.NewKVStoreService(keys[ratelimittypes.StoreKey]),
+    app.IBCKeeper.ChannelKeeper,
+    app.IBCKeeper.ClientKeeper,
+    app.BankKeeper,
+    authtypes.NewModuleAddress(govtypes.ModuleName).String(), // authority
+)
+
+// Wrap the transfer v2 module with rate limiting.
+transferModuleV2 := ratelimitingv2.NewIBCMiddleware(
+    *app.RateLimitKeeper, // v2 takes the keeper by value, so dereference it
+    transferv2.NewIBCModule(app.TransferKeeper),
+    app.IBCKeeper.ChannelKeeperV2, // write-acknowledgement wrapper
+    app.IBCKeeper.ChannelKeeperV2, // v2 channel keeper
+)
+
+// Add the wrapped module to the v2 router.
+ibcRouterV2.AddRoute(ibctransfertypes.PortID, transferModuleV2)
+
+// Register the app module with the module manager.
+app.ModuleManager = module.NewManager(
+    // ...
+    ratelimiting.NewAppModule(app.RateLimitKeeper),
+)
+
+// Add the module to the begin blocker, end blocker, and genesis orders.
+app.ModuleManager.SetOrderBeginBlockers(
+    // ...
+    ratelimittypes.ModuleName,
+)
+app.ModuleManager.SetOrderEndBlockers(
+    // ...
+    ratelimittypes.ModuleName,
+)
+genesisModuleOrder := []string{
+    // ...
+    ratelimittypes.ModuleName,
+}
 ```
 
-## Using Rate Limit Middleware with Packet Forward Middleware
+The v2 constructor takes four arguments: the keeper by value, the module being wrapped, a write-acknowledgement wrapper, and the v2 channel keeper. In simapp the last two are both `app.IBCKeeper.ChannelKeeperV2`. Both are required, and the constructor panics if either is nil.
 
-If both PFM and Rate Limit Middleware are integrated, they can be stacked together. In the reference implementation, Rate Limit Middleware is placed above PFM so that rate limits are enforced on the final inbound transfer before forwarding:
+The v2 middleware enforces the same limits as v1. It converts each v2 payload to the internal packet form and calls the same keeper logic, so a denom's limit applies identically regardless of which IBC version carried the transfer.
 
-```go
-// transfer stack contains (from top to bottom):
-// - Rate Limit Middleware
-// - Packet Forward Middleware
-// - Transfer
+<Warning>
+The transfer v2 route through rate limiting is added by [pull request #8984](https://github.com/cosmos/ibc-go/pull/8984). On an ibc-go version from before that change, only the v1 stack is wired. Confirm the version in use includes it before wiring v2.
+</Warning>
 
-// SendPacket flow: transferKeeper.SendPacket -> PFM.SendPacket -> RateLimit.SendPacket -> channel.SendPacket
-// RecvPacket flow: channel.RecvPacket -> RateLimit.OnRecvPacket -> PFM.OnRecvPacket -> transfer.OnRecvPacket
+## What can go wrong
 
-// create IBC module from bottom to top of stack
-transferStack := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper)
-transferStack.Base(transfer.NewIBCModule(app.TransferKeeper)).
-    Next(packetforward.NewIBCMiddleware(
-        app.PFMKeeper,
-        0, // retries on timeout
-        packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp,
-    )).
-    Next(ratelimiting.NewIBCMiddleware(app.RateLimitKeeper))
+- The application panics on start. The store key is likely unregistered, or a nil dependency reached the v2 constructor.
+- Limits never trigger. Confirm the middleware is on the route the transfers use, and that the module is in the begin-blocker order so windows advance.
 
-ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack.Build())
-```
+## Next steps
+
+- [Configure rate limits](/ibc/next/middleware/rate-limit-middleware/setting-limits) through governance.
+- Review how limits are evaluated in the [rate limiting overview](/ibc/next/middleware/rate-limit-middleware/overview).

--- a/ibc/next/middleware/rate-limit-middleware/migration.mdx
+++ b/ibc/next/middleware/rate-limit-middleware/migration.mdx
@@ -3,7 +3,7 @@ title: Migration
 description: Move an existing ibc-apps rate limiting integration to ibc-go.
 ---
 
-The rate limiting middleware moved from the standalone `ibc-apps` repository into ibc-go. Migrating is a code change across `app.go`. The import paths, the package name, the keeper constructor, and both middleware constructors all change. This guide moves an integration from `ibc-apps` v10 to ibc-go v11. For the full current wiring, see [integrate the rate limiting middleware](/ibc/next/middleware/rate-limit-middleware/integration).
+The rate limiting middleware moved from the standalone `ibc-apps` repository into ibc-go. Migrating is a code change across `app.go`. The import paths, the package name, the keeper constructor, and both middleware constructors all change. This guide moves an integration from `ibc-apps` v10 to ibc-go v11.2. For the full current wiring, see [integrate the rate limiting middleware](/ibc/next/middleware/rate-limit-middleware/integration).
 
 ## Update the imports
 
@@ -93,6 +93,21 @@ The v2 constructor gains two required arguments, a write-acknowledgement wrapper
 - ratelimit.NewAppModule(appCodec, app.RateLimitKeeper)
 + ratelimiting.NewAppModule(app.RateLimitKeeper)
 ```
+
+## Add store upgrades
+
+If rate limiting is being added to a chain for the first time, you must [manually add store upgrades](/sdk/next/guides/upgrades/upgrade#adding-new-modules-during-an-upgrade) for the new module and configure the store loader to apply them in `app.go`:
+
+```go
+if upgradeInfo.Name == "v11_2" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+    storeUpgrades := store.StoreUpgrades{
+        Added: []string{ratelimittypes.StoreKey},
+    }
+    app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+}
+```
+
+This ensures the new module's stores are added to the multistore before the migrations begin.
 
 ## Verify the migration
 

--- a/ibc/next/middleware/rate-limit-middleware/migration.mdx
+++ b/ibc/next/middleware/rate-limit-middleware/migration.mdx
@@ -1,0 +1,108 @@
+---
+title: Migration
+description: Move an existing ibc-apps rate limiting integration to ibc-go.
+---
+
+The rate limiting middleware moved from the standalone `ibc-apps` repository into ibc-go. Migrating is a code change across `app.go`. The import paths, the package name, the keeper constructor, and both middleware constructors all change. This guide moves an integration from `ibc-apps` v10 to ibc-go v11. For the full current wiring, see [integrate the rate limiting middleware](/ibc/next/middleware/rate-limit-middleware/integration).
+
+## Update the imports
+
+The module path changes, and the root package is renamed from `ratelimit` to `ratelimiting`.
+
+```diff
+- ratelimit "github.com/cosmos/ibc-apps/modules/rate-limiting/v10"
+- ratelimitkeeper "github.com/cosmos/ibc-apps/modules/rate-limiting/v10/keeper"
+- ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v10/types"
+- ratelimitv2 "github.com/cosmos/ibc-apps/modules/rate-limiting/v10/v2"
++ ratelimiting "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting"
++ ratelimitkeeper "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/keeper"
++ ratelimittypes "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/types"
++ ratelimitingv2 "github.com/cosmos/ibc-go/v11/modules/apps/rate-limiting/v2"
+```
+
+## Update the keeper
+
+The keeper field becomes a pointer. The constructor drops the parameter subspace and the trailing ICS4 wrapper argument, adds an address codec, and moves the authority to the end. It returns a pointer, so drop the dereference.
+
+```diff
+  // app struct field
+- RateLimitKeeper ratelimitkeeper.Keeper
++ RateLimitKeeper *ratelimitkeeper.Keeper
+
+  // keeper construction
+- app.RateLimitKeeper = *ratelimitkeeper.NewKeeper(
+-     appCodec,
+-     runtime.NewKVStoreService(keys[ratelimittypes.StoreKey]),
+-     app.GetSubspace(ratelimittypes.ModuleName),
+-     authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+-     app.BankKeeper,
+-     app.IBCKeeper.ChannelKeeper,
+-     app.IBCKeeper.ClientKeeper,
+-     app.IBCKeeper.ChannelKeeper, // ICS4Wrapper
+- )
++ app.RateLimitKeeper = ratelimitkeeper.NewKeeper(
++     appCodec,
++     app.AccountKeeper.AddressCodec(),
++     runtime.NewKVStoreService(keys[ratelimittypes.StoreKey]),
++     app.IBCKeeper.ChannelKeeper,
++     app.IBCKeeper.ClientKeeper,
++     app.BankKeeper,
++     authtypes.NewModuleAddress(govtypes.ModuleName).String(),
++ )
+```
+
+## Update the v1 wiring
+
+The v1 middleware no longer takes the wrapped app as an argument. Build the stack with `NewIBCStackBuilder`, which injects the underlying app and sets the ICS4 wrapper, replacing the ICS4 argument the old keeper constructor took.
+
+```diff
+- var transferStack ibcporttypes.IBCModule = transfer.NewIBCModule(app.TransferKeeper)
+- transferStack = ratelimit.NewIBCMiddleware(app.RateLimitKeeper, transferStack)
++ transferStack := porttypes.NewIBCStackBuilder(app.IBCKeeper.ChannelKeeper)
++ transferStack.
++     Base(transfer.NewIBCModule(app.TransferKeeper)).
++     Next(ratelimiting.NewIBCMiddleware(app.RateLimitKeeper))
++ ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack.Build())
+```
+
+This example shows a minimal stack. If the chain already runs other transfer middleware, such as packet forward, keep those layers as additional `.Next(...)` calls; only the rate-limiting layer changes.
+
+## Update the v2 wiring
+
+The v2 constructor gains two required arguments, a write-acknowledgement wrapper and the v2 channel keeper, and takes the keeper by value.
+
+```diff
+- transferStackV2 := ratelimitv2.NewIBCMiddleware(
+-     app.RateLimitKeeper,
+-     transferv2.NewIBCModule(app.TransferKeeper),
+- )
++ transferModuleV2 := ratelimitingv2.NewIBCMiddleware(
++     *app.RateLimitKeeper,
++     transferv2.NewIBCModule(app.TransferKeeper),
++     app.IBCKeeper.ChannelKeeperV2,
++     app.IBCKeeper.ChannelKeeperV2,
++ )
++ ibcRouterV2.AddRoute(ibctransfertypes.PortID, transferModuleV2)
+```
+
+## Update the app module
+
+`NewAppModule` no longer takes the codec.
+
+```diff
+- ratelimit.NewAppModule(appCodec, app.RateLimitKeeper)
++ ratelimiting.NewAppModule(app.RateLimitKeeper)
+```
+
+## Verify the migration
+
+After the app compiles, confirm the module is active by querying the existing limits.
+
+```bash
+simd query ratelimiting list-rate-limits
+```
+
+## Next steps
+
+- Confirm limits behave as expected using the [setting rate limits](/ibc/next/middleware/rate-limit-middleware/setting-limits) queries.
+- Review the full wiring in [integrate the rate limiting middleware](/ibc/next/middleware/rate-limit-middleware/integration).

--- a/ibc/next/middleware/rate-limit-middleware/overview.mdx
+++ b/ibc/next/middleware/rate-limit-middleware/overview.mdx
@@ -1,28 +1,124 @@
 ---
-noindex: true
-canonical: 'https://docs.cosmos.network/ibc/latest/middleware/rate-limit-middleware/overview'
 title: Overview
-description: About Rate Limit Middleware
+description: A governance-configured middleware that caps net token flow across IBC transfers.
 ---
 
-Learn about Rate Limit Middleware, a middleware that can be used in combination with token transfers (ICS-20) to control the amount of in and outflows of assets in a certain time period.
+Rate limiting is a governance-configured middleware that caps net token flow across IBC transfers, protecting a chain from draining faster than governance allows. It sits on top of the ICS-20 fungible token transfer application. It measures how much of a token moves over a given path, in each direction, within a rolling time window. When a transfer would push the running total past its configured cap, the middleware rejects it.
 
-## What is Rate Limit Middleware?
-
-The rate limit middleware enforces rate limits on IBC token transfers coming into and out of a chain. It supports:
-
-* **Risk Mitigation:** In case of a bug exploit, attack or economic failure of a connected chain, it limits the impact to the in/outflow specified for a given time period.
-* **Token Filtering:** Through the use of a blacklist, the middleware can completely block tokens entering or leaving a domain, relevant for compliance or giving asset issuers greater control over the domains token can be sent to.
-* **Uninterrupted Packet Flow:** When desired, rate limits can be bypassed by using the whitelist, to avoid any restriction on asset in or outflows.
+To wire it into a chain, see [integrate the rate limiting middleware](/ibc/next/middleware/rate-limit-middleware/integration). To configure limits through governance, see [configure rate limits](/ibc/next/middleware/rate-limit-middleware/setting-limits).
 
 ## How it works
 
-The rate limiting middleware determines whether tokens can flow into or out of a chain. The middleware does this by:
+A rate limit is a ceiling on how much value can leave or enter a chain over one path in one window. When tokens start moving abnormally fast, the limit throttles the flow without freezing normal transfer activity, buying governance time to respond.
 
-1. Check transfer limits for an asset (Quota): When tokens are received or sent, the middleware determines whether the amount of tokens flowing in or out have exceeded the limit.
+The middleware applies to ICS-20 transfers only. Limits are defined and configured independently per pair of denom and path. A path is identified by a channel ID (IBC v1) or a client ID (IBC v2).
 
-2. Track in or outflow: When tokens enter or leave the chain, the amount transferred is tracked in state.
+Flow limits are set by chain governance.
 
-3. Block or allow token flow: Dependent on the limit, the middleware will either allow the tokens to pass through or block the tokens.
+### Rate limiting and transfers
 
-4. Handle failures: If the packet timesout or fails to be delivered, the middleware ensures limits are correctly recorded.
+The middleware wraps the transfer application. Every transfer passes through its accounting before reaching core IBC on the way out or the application on the way in. On a typical chain, the outbound path runs from the transfer module, up through any packet forward middleware, through rate limiting, and finally to the IBC core that sends the packet. The inbound path runs in reverse.
+
+```mermaid
+sequenceDiagram
+    participant Core as IBC core
+    participant RL as Rate limiting
+    participant App as Transfer app
+    Note over Core,App: Outbound (send)
+    App->>RL: SendPacket
+    RL->>RL: check and record outflow
+    RL->>Core: SendPacket (if allowed)
+    Note over Core,App: Inbound (receive)
+    Core->>RL: OnRecvPacket
+    RL->>RL: check and record inflow
+    RL->>App: OnRecvPacket (if allowed)
+```
+
+The middleware acts on four points in a packet's life:
+
+- It checks the outflow when a packet is sent.
+- It checks the inflow when a packet is received.
+- It reverts a recorded outflow when a sent packet fails.
+- It reverts a recorded outflow when a sent packet times out.
+
+A blocked outbound transfer fails at the source, so the sender's tokens are never escrowed. A blocked inbound transfer returns an error acknowledgement, so the sending chain refunds its user.
+
+### Quotas, flows, and channel value
+
+Three pieces decide every transfer:
+
+- Quota: the outbound cap, the inbound cap, and the window length.
+- Flow: the inflow so far, the outflow so far, and the channel value for this window.
+- Channel value: the total on-chain supply of the denom, read from the bank module. It is the denominator that turns a percentage cap into an absolute amount.
+
+The caps are percentages of the channel value. The middleware reads the channel value when the limit is created and again at each window reset, not on every packet. A single window therefore measures flow against a fixed supply figure.
+
+Governance configures the quota fields directly:
+
+```go
+type Quota struct {
+    MaxPercentSend math.Int // outbound cap as a percent of channel value
+    MaxPercentRecv math.Int // inbound cap as a percent of channel value
+    DurationHours  uint64   // window length before the flow resets
+}
+```
+
+The middleware measures net flow, not gross flow:
+
+- Net outflow is the outflow minus the inflow plus the new amount.
+- Net inflow is the inflow minus the outflow plus the new amount.
+
+Transfers in the opposite direction free up headroom, so balanced traffic does not throttle a chain that both sends and receives a token.
+
+A transfer is denied when its net flow is strictly greater than the threshold. The threshold is the channel value times the cap percent, divided by 100.
+
+Consider a denom with a total supply of 1,000,000 and a `MaxPercentSend` of 10.
+
+The outbound threshold is 100,000, which is 10% of supply. Suppose the current window has recorded 60,000 of outflow and 20,000 of inflow.
+
+A new outbound transfer is allowed only if the net outflow stays at or below 100,000:
+
+| New send | Net outflow (60,000 - 20,000 + send) | Result |
+| --- | --- | --- |
+| 70,000 | 110,000 | Denied, exceeds 100,000 |
+| 50,000 | 90,000 | Allowed |
+
+### Rolling windows and resets
+
+A flow accumulates within a fixed window and returns to zero when the window elapses. The window length is the quota's duration in hours. The module tracks time as an hourly epoch that advances once per block, and each limit resets when the elapsed epoch count is a multiple of its duration. A limit with a 24-hour duration therefore resets once a day.
+
+A reset does three things:
+
+- It zeroes the inflow and outflow.
+- It re-reads the channel value from current supply, so the caps track the token's supply as it changes.
+- It clears the record of packets still in flight for that path.
+
+### Reversal on failed acknowledgements and timeouts
+
+An outbound transfer counts against the flow the moment it is sent, before the receiving chain has confirmed it. That count is provisional:
+
+- If the packet is acknowledged successfully, the outflow stands.
+- If the acknowledgement carries an error or the packet times out, the middleware reverts the outflow so a failed transfer does not consume the limit.
+
+The reversal is conditional on the window. The middleware reverts an outflow only if the packet was sent during the window that is still open. A packet sent in an earlier window that has already reset is not reverted, because that window's totals are already gone.
+
+### Whitelists and blacklists
+
+Two lists override the quota logic at the edges:
+
+- A whitelist entry is a specific sender and receiver address pair. Transfers between a whitelisted pair skip rate limiting entirely and do not update the flow. This suits trusted or protocol-controlled routes.
+- A blacklist entry is a denom. Any transfer of a blacklisted denom is rejected outright, regardless of quota.
+
+The module evaluates a transfer in a fixed order:
+
+1. It rejects a blacklisted denom.
+2. It allows any path that has no limit configured.
+3. It exempts a whitelisted address pair.
+4. It applies the quota.
+
+Whitelist and blacklist entries are set in genesis rather than through governance messages. To configure them, see [configure rate limits](/ibc/next/middleware/rate-limit-middleware/setting-limits).
+
+## Next steps
+
+- [Integrate the rate limiting middleware](/ibc/next/middleware/rate-limit-middleware/integration) into a chain for IBC v1 and v2.
+- [Configure rate limits](/ibc/next/middleware/rate-limit-middleware/setting-limits) through governance.

--- a/ibc/next/middleware/rate-limit-middleware/setting-limits.mdx
+++ b/ibc/next/middleware/rate-limit-middleware/setting-limits.mdx
@@ -1,23 +1,100 @@
 ---
-noindex: true
-canonical: 'https://docs.cosmos.network/ibc/latest/middleware/rate-limit-middleware/setting-limits'
 title: Setting Rate Limits
-description: >-
-  Rate limits are set through a governance-gated authority on a per denom, and
-  per channel / client basis. To add a rate limit, the MsgAddRateLimit message
-  must be executed which includes:
+description: Configure rate limits through governance, and set whitelists and blacklists in genesis.
 ---
 
-Rate limits are set through a governance-gated authority on a per denom, and per channel / client basis. To add a rate limit, the [`MsgAddRateLimit`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/rate-limiting/types/msgs.go#L27-L35) message must be executed which includes:
+This guide covers configuring limits on a chain that already has the middleware wired. Every change to a limit is a governance message, submitted inside [a Cosmos SDK governance proposal](https://docs.cosmos.network/sdk/latest/modules/gov/README), and it takes effect only if the proposal passes. This guide assumes familiarity with submitting and voting on proposals.
 
-* Denom: the asset that the rate limit should be applied to
-* ChannelOrClientId: the channelID for use with IBC classic connections, or the clientID for use with IBC v2 connections
-* MaxPercentSend: the outflow threshold as a percentage of the `channelValue`. More explicitly, a packet being sent would exceed the threshold quota if: (Outflow - Inflow + Packet Amount) / channelValue is greater than MaxPercentSend / 100
-* MaxPercentRecv: the inflow threshold as a percentage of the `channelValue`
-* DurationHours: the length of time, after which the rate limits reset
+## The four governance messages
 
-## Updating, Removing or Resetting Rate Limits
+The module accepts [four governance messages](https://github.com/cosmos/ibc-go/blob/2619d6ec8543b2e0cbc1a234dad38b4ae2299a27/proto/ibc/applications/rate_limiting/v1/tx.proto), each requiring the governance authority as the signer. Together they cover the full life of a limit:
 
-* If rate limits were set to be too low or high for a given channel/client, they can be updated with [`MsgUpdateRateLimit`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/rate-limiting/types/msgs.go#L81-L89).
-* If rate limits are no longer needed, they can be removed with [`MsgRemoveRateLimit`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/rate-limiting/types/msgs.go#L135-L140).
-* If the flow counter needs to be reset for a given rate limit, it is possible to do so with [`MsgResetRateLimit`](https://github.com/cosmos/ibc-go/blob/main/modules/apps/rate-limiting/types/msgs.go#L167-L172).
+- `MsgAddRateLimit` creates a limit.
+- `MsgUpdateRateLimit` replaces a limit's quota and resets its flow.
+- `MsgRemoveRateLimit` deletes a limit.
+- `MsgResetRateLimit` keeps a limit but zeroes its flow.
+
+Each field means:
+
+| Field | Description |
+| --- | --- |
+| `denom` | The token the limit applies to, as it appears on this chain. Use the `ibc/...` denom for a non-native token. |
+| `channel_or_client_id` | The channel ID under IBC v1, or the client ID under IBC v2, that the limit applies to. |
+| `max_percent_send` | The outbound cap, as a percent of channel value. For example, 10 means 10%. |
+| `max_percent_recv` | The inbound cap, as a percent of channel value. For example, 10 means 10%. |
+| `duration_hours` | The window length in hours before the flow resets. For example, 24 means daily. |
+
+`MsgAddRateLimit` and `MsgUpdateRateLimit` take all five fields. `MsgRemoveRateLimit` and `MsgResetRateLimit` take only `denom` and `channel_or_client_id`. Every message also carries `signer`, the governance authority.
+
+Fields are validated before a message is accepted:
+
+- `channel_or_client_id` is a channel in the form `channel-<n>` or a valid client ID.
+- Each percentage is between 0 and 100.
+- At least one of send or receive is greater than zero.
+- `duration_hours` is greater than zero.
+
+## Choose quota values
+
+The caps are percentages of the denom's total supply on the chain.
+
+A `max_percent_send` of 10 caps net outflow at 10 percent of supply per window. To limit only one direction, set the unused side to 0 and keep the other above zero. To set a daily limit, set `duration_hours` to 24.
+
+## Whitelist and blacklist entries
+
+The module supports two overrides beyond quotas:
+
+- A whitelist exempts a specific sender and receiver address pair from rate limiting.
+- A blacklist blocks a denom outright.
+
+Neither has a governance message. Set both in the module's genesis state, under `app_state.ratelimiting`, in the `whitelisted_address_pairs` and `blacklisted_denoms` fields. Change them only at chain launch or through a coordinated upgrade.
+
+```json
+{
+  "app_state": {
+    "ratelimiting": {
+      "whitelisted_address_pairs": [
+        { "sender": "cosmos1sender...", "receiver": "cosmos1receiver..." }
+      ],
+      "blacklisted_denoms": ["uatom"]
+    }
+  }
+}
+```
+
+## Verify a limit
+
+The module exposes query commands under the `ratelimiting` subcommand. Use them to confirm a proposal took effect.
+
+List every limit on the chain:
+
+```bash
+simd query ratelimiting list-rate-limits
+```
+
+Query one limit by path and denom:
+
+```bash
+simd query ratelimiting rate-limit [channel-or-client-id] --denom [denom]
+```
+
+Query the limits that target a given chain:
+
+```bash
+simd query ratelimiting rate-limits-by-chain [chain-id]
+```
+
+Read the current whitelist:
+
+```bash
+simd query ratelimiting list-whitelisted-addresses
+```
+
+Read the current blacklist:
+
+```bash
+simd query ratelimiting list-blacklisted-denoms
+```
+
+## Next steps
+
+- Review how limits are evaluated in the [rate limiting overview](/ibc/next/middleware/rate-limit-middleware/overview).

--- a/ibc/next/middleware/rate-limit-middleware/setting-limits.mdx
+++ b/ibc/next/middleware/rate-limit-middleware/setting-limits.mdx
@@ -12,7 +12,7 @@ The module accepts [four governance messages](https://github.com/cosmos/ibc-go/b
 - `MsgAddRateLimit` creates a limit.
 - `MsgUpdateRateLimit` replaces a limit's quota and resets its flow.
 - `MsgRemoveRateLimit` deletes a limit.
-- `MsgResetRateLimit` keeps a limit but zeroes its flow.
+- `MsgResetRateLimit` keeps a limit but zeroes its flow and clears its in-flight packet records.
 
 Each field means:
 
@@ -46,12 +46,12 @@ The module supports two overrides beyond quotas:
 - A whitelist exempts a specific sender and receiver address pair from rate limiting.
 - A blacklist blocks a denom outright.
 
-Neither has a governance message. Set both in the module's genesis state, under `app_state.ratelimiting`, in the `whitelisted_address_pairs` and `blacklisted_denoms` fields. Change them only at chain launch or through a coordinated upgrade.
+Neither has a governance message. Set both in the module's genesis state, under `app_state.ratelimit`, in the `whitelisted_address_pairs` and `blacklisted_denoms` fields. Change them only at chain launch or through a coordinated upgrade.
 
 ```json
 {
   "app_state": {
-    "ratelimiting": {
+    "ratelimit": {
       "whitelisted_address_pairs": [
         { "sender": "cosmos1sender...", "receiver": "cosmos1receiver..." }
       ],

--- a/work-log/rate-limit.md
+++ b/work-log/rate-limit.md
@@ -1,0 +1,4 @@
+## 2026-07-09
+
+- Rewrote the rate limit middleware pages (overview, integration, setting-limits) in `ibc/latest` and `ibc/next` with code-verified content, and added a new `migration` page. Content verified against ibc-go `main` plus PR #8984 (v2 wiring) and ibc-apps rate-limiting v10.1.0 (migration before/after).
+- Added a "Rate Limit Middleware" group to the IBC Middleware navigation in `docs.json` for both `latest` and `next`; the pages existed as files but were not linked in the sidebar.


### PR DESCRIPTION
Add rate limit documentation to docs site. Includes migration from ibc-apps. 