### PR TITLE
fix(ibc): update links after repository move

### DIFF
--- a/ibc/latest/spec/core/ics-003-connection-semantics/README.mdx
+++ b/ibc/latest/spec/core/ics-003-connection-semantics/README.mdx
@@ -593,7 +593,7 @@ The consensus state can only be updated as allowed by the `updateConsensusState`
 
 ## History
 
-Parts of this document were inspired by the [previous IBC specification](https://github.com/cosmos/ibc/tree/main/archive).
+Parts of this document were inspired by the [previous IBC specification](https://github.com/cosmos/ibc/tree/31f41387942ee71188b6a9799d1a55849e008c97/archive).
 
 Mar 29, 2019 - Initial draft version submitted
 

--- a/ibc/latest/spec/ics-001-ics-standard/README.mdx
+++ b/ibc/latest/spec/ics-001-ics-standard/README.mdx
@@ -46,7 +46,7 @@ An ICS header contains metadata relevant to the ICS.
 
 `title` - ICS title (keep it short & sweet)
 
-`stage` - Current ICS stage, see [PROCESS.md](https://github.com/cosmos/ibc/blob/main/meta/PROCESS.md) for the list of possible stages.
+`stage` - Current ICS stage, see [PROCESS.md](https://github.com/cosmos/ibc/blob/main/spec/PROCESS.md) for the list of possible stages.
 
 See [README.md](https://github.com/cosmos/ibc/blob/main/README.md) for a description of the ICS acceptance stages.
 

--- a/ibc/next/spec/core/ics-003-connection-semantics/README.mdx
+++ b/ibc/next/spec/core/ics-003-connection-semantics/README.mdx
@@ -595,7 +595,7 @@ The consensus state can only be updated as allowed by the `updateConsensusState`
 
 ## History
 
-Parts of this document were inspired by the [previous IBC specification](https://github.com/cosmos/ibc/tree/main/archive).
+Parts of this document were inspired by the [previous IBC specification](https://github.com/cosmos/ibc/tree/31f41387942ee71188b6a9799d1a55849e008c97/archive).
 
 Mar 29, 2019 - Initial draft version submitted
 

--- a/ibc/next/spec/ics-001-ics-standard/README.mdx
+++ b/ibc/next/spec/ics-001-ics-standard/README.mdx
@@ -48,7 +48,7 @@ An ICS header contains metadata relevant to the ICS.
 
 `title` - ICS title (keep it short & sweet)
 
-`stage` - Current ICS stage, see [PROCESS.md](https://github.com/cosmos/ibc/blob/main/meta/PROCESS.md) for the list of possible stages.
+`stage` - Current ICS stage, see [PROCESS.md](https://github.com/cosmos/ibc/blob/main/spec/PROCESS.md) for the list of possible stages.
 
 See [README.md](https://github.com/cosmos/ibc/blob/main/README.md) for a description of the ICS acceptance stages.
 

--- a/ibc/v10.1.x/spec/core/ics-003-connection-semantics/README.mdx
+++ b/ibc/v10.1.x/spec/core/ics-003-connection-semantics/README.mdx
@@ -595,7 +595,7 @@ The consensus state can only be updated as allowed by the `updateConsensusState`
 
 ## History
 
-Parts of this document were inspired by the [previous IBC specification](https://github.com/cosmos/ibc/tree/main/archive).
+Parts of this document were inspired by the [previous IBC specification](https://github.com/cosmos/ibc/tree/31f41387942ee71188b6a9799d1a55849e008c97/archive).
 
 Mar 29, 2019 - Initial draft version submitted
 

--- a/ibc/v10.1.x/spec/ics-001-ics-standard/README.mdx
+++ b/ibc/v10.1.x/spec/ics-001-ics-standard/README.mdx
@@ -48,7 +48,7 @@ An ICS header contains metadata relevant to the ICS.
 
 `title` - ICS title (keep it short & sweet)
 
-`stage` - Current ICS stage, see [PROCESS.md](https://github.com/cosmos/ibc/blob/main/meta/PROCESS.md) for the list of possible stages.
+`stage` - Current ICS stage, see [PROCESS.md](https://github.com/cosmos/ibc/blob/main/spec/PROCESS.md) for the list of possible stages.
 
 See [README.md](https://github.com/cosmos/ibc/blob/main/README.md) for a description of the ICS acceptance stages.
 


### PR DESCRIPTION
## Summary

Repair external IBC specification links after [`cosmos/ibc#1340`](https://github.com/cosmos/ibc/pull/1340) promoted the reorganized repository to `main`:

- point `PROCESS.md` links at its new `spec/PROCESS.md` location
- pin deleted `archive/` links to the last commit containing the archive
- update the `next`, `latest`, and `v10.1.x` copies

Tracks [FOU-1223](https://linear.app/cosmoslabs/issue/FOU-1223/merge-ibc-link-development-branch-into-main).

## Validation

- verified `cosmos/ibc/main/spec/PROCESS.md` exists
- verified the pinned historical `archive/` snapshot exists
- confirmed no old `main/meta/PROCESS.md` or `main/archive` references remain under `ibc/`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
