### PR TITLE
fix landing

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -94,81 +94,83 @@ import { ThemeToggle } from '/snippets/theme-toggle.jsx';
     </div>
   </div>
 
-  {/* Background Image Section */}
-  <div className='relative w-full h-[1000px] overflow-hidden'>
+  {/* Hero Section: background art sized to the content it sits behind */}
+  <div className='relative w-full overflow-hidden'>
     {/* Background Image */}
-    <img
-      src="/assets/public/hero-banner.png"
-      alt=""
-      className='w-full h-full object-cover object-center'
-    />
+    <div className='absolute inset-0 overflow-hidden' aria-hidden="true">
+      <img
+        src="/assets/public/hero-banner.png"
+        alt=""
+        className='w-full h-full object-cover object-center'
+      />
 
-    {/* Color Overlay */}
-    <div className='absolute inset-0 bg-[#F1F1F1]/95 dark:bg-black/95'></div>
+      {/* Color Overlay */}
+      <div className='absolute inset-0 bg-[#F1F1F1]/95 dark:bg-black/95'></div>
 
-    {/* Bottom Gradient */}
-    <div className='absolute bottom-0 left-0 right-0 h-24 md:h-32 bg-gradient-to-b from-transparent to-[#F1F1F1] dark:to-[#000]'></div>
-  </div>
-
-  {/* Hero Content Section */}
-  <div className='relative w-full -mt-[1000px] flex flex-col'>
-    {/* Hero Text and Buttons */}
-    <div className='flex-1 flex flex-col gap-6 md:gap-8 items-center justify-center px-8 py-12 md:py-16 lg:py-20'>
-      <h1 className='text-3xl sm:text-4xl md:text-5xl lg:text-6xl leading-tight text-center text-black dark:text-white w-full max-w-4xl'>
-        Cosmos Developer Documentation
-      </h1>
-
-      <p className='text-[rgba(0,0,0,0.60)] dark:text-[rgba(255,255,255,0.50)] text-base sm:text-lg md:text-xl lg:text-2xl text-center max-w-3xl'>
-        The most widely adopted, battle-tested Layer 1 blockchain stack, trusted by 200+ chains live in production.
-      </p>
+      {/* Bottom Gradient */}
+      <div className='absolute bottom-0 left-0 right-0 h-24 md:h-32 bg-gradient-to-b from-transparent to-[#F1F1F1] dark:to-[#000]'></div>
     </div>
 
-    {/* Documentation Cards Section */}
-    <div className='w-full px-4 md:px-8 lg:px-12 pb-12 md:pb-16 max-w-[1920px] mx-auto'>
-      <DocCardGrid>
-        <DocCard
-          title="Start Building"
-          description="New to Cosmos? Start with the concepts, build a chain, or choose your own path."
-          isHighlighted={true}
-          links={[
-            { href: "/sdk/latest/learn/intro/overview", label: "Learn" },
-            { href: "/sdk/latest/tutorials/example/00-overview", label: "Build a chain" },
-            { href: "/sdk/latest/learn/start-here", label: "Choose a path" },
-          ]}
-        />
-        <DocCard
-          title="Cosmos SDK"
-          description="Modular framework for building secure, high-performance blockchains."
-          docsLink="/sdk/latest/learn"
-          githubLink="https://github.com/cosmos/cosmos-sdk"
-        />
-        <DocCard
-          title="Inter-Blockchain Communication Protocol"
-          description="Protocol for secure, fast inter-blockchain communication."
-          docsLink="/ibc/latest/intro"
-          githubLink="https://github.com/cosmos/ibc-go"
-        />
-        <DocCard
-          title="Cosmos EVM"
-          description="EVM compatibility layer with built-in Solidity support."
-          docsLink="/evm/latest/documentation/overview"
-          githubLink="https://github.com/cosmos/evm"
-        />
-        <DocCard
-          title="CometBFT"
-          description="Byzantine Fault Tolerant consensus with instant finality that processes 10,000+ transactions per second."
-          docsLink="/cometbft/latest/docs/README"
-          githubLink="https://github.com/cometbft/cometbft"
-        />
-        <DocCard
-          title="Get in touch"
-          description="Questions about building on Cosmos or running a production network? Reach out to the team."
-          links={[
-            { href: "https://discord.com/invite/interchain", label: "Join Discord" },
-            { href: "https://cosmos.network/contact", label: "Contact the team" },
-          ]}
-        />
-      </DocCardGrid>
+    {/* Hero Content Section */}
+    <div className='relative w-full flex flex-col'>
+      {/* Hero Text and Buttons */}
+      <div className='flex-1 flex flex-col gap-6 md:gap-8 items-center justify-center px-8 py-12 md:py-16 lg:py-20'>
+        <h1 className='text-3xl sm:text-4xl md:text-5xl lg:text-6xl leading-tight text-center text-black dark:text-white w-full max-w-4xl'>
+          Cosmos Developer Documentation
+        </h1>
+
+        <p className='text-[rgba(0,0,0,0.60)] dark:text-[rgba(255,255,255,0.50)] text-base sm:text-lg md:text-xl lg:text-2xl text-center max-w-3xl'>
+          The most widely adopted, battle-tested Layer 1 blockchain stack, trusted by 200+ chains live in production.
+        </p>
+      </div>
+
+      {/* Documentation Cards Section */}
+      <div className='w-full px-4 md:px-8 lg:px-12 pb-12 md:pb-16 max-w-[1920px] mx-auto'>
+        <DocCardGrid>
+          <DocCard
+            title="Start Building"
+            description="New to Cosmos? Start with the concepts, build a chain, or choose your own path."
+            isHighlighted={true}
+            links={[
+              { href: "/sdk/latest/learn/intro/overview", label: "Learn" },
+              { href: "/sdk/latest/tutorials/example/00-overview", label: "Build a chain" },
+              { href: "/sdk/latest/learn/start-here", label: "Choose a path" },
+            ]}
+          />
+          <DocCard
+            title="Cosmos SDK"
+            description="Modular framework for building secure, high-performance blockchains."
+            docsLink="/sdk/latest/learn"
+            githubLink="https://github.com/cosmos/cosmos-sdk"
+          />
+          <DocCard
+            title="Inter-Blockchain Communication Protocol"
+            description="Protocol for secure, fast inter-blockchain communication."
+            docsLink="/ibc/latest/intro"
+            githubLink="https://github.com/cosmos/ibc-go"
+          />
+          <DocCard
+            title="Cosmos EVM"
+            description="EVM compatibility layer with built-in Solidity support."
+            docsLink="/evm/latest/documentation/overview"
+            githubLink="https://github.com/cosmos/evm"
+          />
+          <DocCard
+            title="CometBFT"
+            description="Byzantine Fault Tolerant consensus with instant finality that processes 10,000+ transactions per second."
+            docsLink="/cometbft/latest/docs/README"
+            githubLink="https://github.com/cometbft/cometbft"
+          />
+          <DocCard
+            title="Get in touch"
+            description="Questions about building on Cosmos or running a production network? Reach out to the team."
+            links={[
+              { href: "https://discord.com/invite/interchain", label: "Join Discord" },
+              { href: "https://cosmos.network/contact", label: "Contact the team" },
+            ]}
+          />
+        </DocCardGrid>
+      </div>
     </div>
   </div>
 

--- a/snippets/theme-toggle.jsx
+++ b/snippets/theme-toggle.jsx
@@ -2,16 +2,19 @@ export const ThemeToggle = () => {
   const [mode, setMode] = useState('');
 
   useEffect(() => {
-    // Try to read active mode from Mintlify's hidden buttons
-    for (const m of ['light', 'dark']) {
-      const btn = document.querySelector(`[data-testid="mode-switch-${m}"]`);
-      if (btn && btn.classList.contains('bg-gray-200')) {
-        setMode(m);
-        return;
-      }
+    // Mintlify applies the resolved theme as a class on <html>, which is true
+    // regardless of which theme control version the theme ships.
+    const root = document.documentElement;
+    if (root.classList.contains('dark')) {
+      setMode('dark');
+      return;
     }
-    // Fall back to localStorage / OS preference
-    const stored = localStorage.getItem('isDarkMode');
+    if (root.classList.contains('light')) {
+      setMode('light');
+      return;
+    }
+    // Fall back to stored preference / OS preference
+    const stored = localStorage.getItem('theme') || localStorage.getItem('isDarkMode');
     if (stored === 'dark' || stored === 'light') {
       setMode(stored);
     } else {
@@ -19,23 +22,55 @@ export const ThemeToggle = () => {
     }
   }, []);
 
-  const handleSwitch = (newMode) => {
-    // Delegate to Mintlify's hidden button if present
-    const mintBtn = document.querySelector(`[data-testid="mode-switch-${newMode}"]`);
-    if (mintBtn) {
-      mintBtn.click();
-    } else {
-      // Direct fallback: manage dark class and localStorage ourselves
-      const root = document.documentElement;
-      if (newMode === 'dark') {
-        root.classList.add('dark');
-        localStorage.setItem('isDarkMode', 'dark');
-      } else if (newMode === 'light') {
-        root.classList.remove('dark');
-        localStorage.setItem('isDarkMode', 'light');
+  // Delegating to Mintlify's own control keeps the choice in sync with the rest
+  // of the site. Its markup has changed across releases, so try each known shape
+  // before falling back to driving the theme ourselves.
+  const waitForElement = (selector, timeout = 500) =>
+    new Promise((resolve) => {
+      const start = Date.now();
+      const poll = () => {
+        const el = document.querySelector(selector);
+        if (el) return resolve(el);
+        if (Date.now() - start > timeout) return resolve(null);
+        setTimeout(poll, 20);
+      };
+      poll();
+    });
+
+  const clickMintlifyControl = async (newMode) => {
+    // Current: a menu whose items only mount once the trigger is opened.
+    const trigger = document.querySelector('[data-testid="theme-preference-menu-trigger"]');
+    if (trigger) {
+      trigger.click();
+      const item = await waitForElement(`[data-testid="theme-preference-${newMode}"]`);
+      if (item) {
+        item.click();
+        return true;
       }
+      // Menu opened but the item never appeared: close it again.
+      trigger.click();
     }
+
+    // Older releases: a pair of always-present buttons.
+    const btn = document.querySelector(`[data-testid="mode-switch-${newMode}"]`);
+    if (btn) {
+      btn.click();
+      return true;
+    }
+
+    return false;
+  };
+
+  const handleSwitch = async (newMode) => {
     setMode(newMode);
+    if (await clickMintlifyControl(newMode)) return;
+
+    // Direct fallback: manage the theme class and stored preference ourselves.
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(newMode);
+    localStorage.setItem('theme', newMode);
+    localStorage.setItem('isDarkMode', newMode);
   };
 
   const base = "p-1.5 rounded-lg";

--- a/style.css
+++ b/style.css
@@ -1,3 +1,6 @@
+/* Code block font — Fira Code has full box-drawing character support */
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&display=swap');
+
 :root {
   --background-light: 255 255 255;
 }
@@ -178,13 +181,15 @@ body:has(#custom-index-content) #custom-index-content a {
   transform: translateX(100%) translateY(100%) rotate(45deg);
 }
 
-/* Show Mintlify footer on custom index page */
-body:has(#custom-index-content) #footer {
-  display: flex !important;
+/* Show Mintlify footer on custom index page.
+   Mintlify hides it with a layered Tailwind utility (`peer-[.is-custom]:hidden!`).
+   For !important declarations the cascade-layer order inverts, so an unlayered
+   override loses no matter how specific it is. Ours has to be layered too. */
+@layer utilities {
+  body:has(#custom-index-content) #footer {
+    display: flex !important;
+  }
 }
-
-/* Code block font — Fira Code has full box-drawing character support */
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&display=swap');
 
 pre, pre code, code {
   font-family: 'Fira Code', 'Cascadia Code', 'JetBrains Mono', monospace !important;

--- a/work-log/fix-landing-mintlify-shift.md
+++ b/work-log/fix-landing-mintlify-shift.md
@@ -1,0 +1,10 @@
+## 2026-08-25
+
+Landing page broke after a Mintlify release shifted its markup and CSS build (reported in Slack, tracked as MAR-1965).
+
+- `style.css`: moved the footer override into `@layer utilities`. Mintlify now hides the footer on custom pages with a layered Tailwind v4 utility (`peer-[.is-custom]:hidden!`). For `!important` declarations the cascade-layer order inverts, so our unlayered `!important` lost regardless of specificity.
+- `style.css`: moved the Fira Code `@import` to the top of the file. CSS ignores `@import` that follows other rules, so the code-block font was never loading.
+- `snippets/theme-toggle.jsx`: Mintlify replaced the `mode-switch-light` / `mode-switch-dark` buttons with a menu (`theme-preference-menu-trigger` plus `theme-preference-{system,light,dark}` items that only mount once the menu opens), and moved the stored preference from `isDarkMode` to `theme`. The toggle now opens the menu and clicks the matching item, falls back to the old buttons, and only as a last resort drives the theme class itself, writing both storage keys. Active state is read from the `light` / `dark` class on `<html>` instead of Mintlify's button styling.
+- `index.mdx`: hero background art was a fixed `h-[1000px]` block with the content pulled back over it via `-mt-[1000px]`. Content had grown to 1236px, so the art and its bottom gradient ended partway through the cards. The art is now absolutely positioned inside the hero wrapper, so it sizes to the content.
+
+Verified locally with `npx mint dev`: footer renders (662px, below the content at the page bottom), hero art and gradient span the full 1236px hero, both toggle buttons flip the theme and the active state follows, no console errors. Section offsets below the hero are unchanged from production.


### PR DESCRIPTION
## Summary

Repairs the landing page after a Mintlify release changed its markup and CSS build.

## Changes

- Footer override moved into `@layer utilities` so it beats Mintlify's layered `!important` rule. Fixes the missing footer.
- Theme toggle updated for Mintlify's new theme-preference menu and storage key, with fallbacks to the old buttons.
- Hero background art now sizes to its content instead of a fixed `h-[1000px]` block, so the art and gradient no longer stop partway through the cards.
- Fira Code `@import` moved to the top of `style.css`, where CSS honors it.

## Verification

`npx mint dev`: footer renders, hero art spans the full hero, both toggle buttons work, no console errors.