### PR TITLE
docs: sync example tutorials from cosmos/example

### DIFF
--- a/sdk/next/tutorials/example/03-build-a-module.mdx
+++ b/sdk/next/tutorials/example/03-build-a-module.mdx
@@ -721,10 +721,31 @@ Open a second terminal and submit a transaction that adds `4` to the counter:
 exampled tx counter add 4 --from alice --chain-id demo --yes
 ```
 
-If the transaction succeeds, the response should include `code: 0`, which means the chain accepted and executed the transaction without an application error:
+If the transaction succeeds, the response should include `code: 0`, which means the chain accepted the
+transaction and it passed validation without an application error:
 
-```
+```text
 code: 0
+codespace: ""
+data: ""
+events: []
+gas_used: "0"
+gas_wanted: "0"
+height: "0"
+info: ""
+logs: []
+raw_log: ""
+timestamp: ""
+tx: null
+txhash: 548D95784704575A347140E05A3ED84A05067DF4AD43F8E6FA20C94FAE8430E0
+```
+
+This is the broadcast acknowledgement, returned before the transaction is in a block, so `height: "0"`
+and the empty fields are expected rather than a sign of failure. To see the executed result, query the
+transaction by its hash:
+
+```bash
+exampled query tx <txhash>
 ```
 
 ### Query the chain

--- a/sdk/next/tutorials/example/05-run-and-test.mdx
+++ b/sdk/next/tutorials/example/05-run-and-test.mdx
@@ -119,9 +119,84 @@ exampled tx counter add 10 --from alice --chain-id demo --yes
 # Add with a gas limit
 exampled tx counter add 10 --from alice --chain-id demo --gas 200000 --yes
 
-# Update module parameters (requires governance authority)
-exampled tx counter update-params --from alice --chain-id demo --yes
 ```
+
+### Updating module parameters
+
+Counter params are governance-gated. `MsgUpdateParams` accepts only the gov module address as its
+authority, so there is no direct CLI command for it: signing `update-params` with a user key such as
+`alice` always fails with `ErrInvalidSigner`. Params change through a governance proposal instead.
+
+Look up the gov module address for your chain, which is the only valid authority:
+
+```bash
+exampled query auth module-account gov
+```
+
+Write a `proposal.json` containing the message, using that address as `authority`. On the local `demo`
+chain the value is `cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn`:
+
+```json
+{
+  "messages": [
+    {
+      "@type": "/example.counter.MsgUpdateParams",
+      "authority": "cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn",
+      "params": {
+        "max_add_value": "50",
+        "add_cost": [{"denom": "stake", "amount": "200"}]
+      }
+    }
+  ],
+  "metadata": "ipfs://CID",
+  "deposit": "10000000stake",
+  "title": "Update counter params",
+  "summary": "Set max_add_value to 50 and add_cost to 200stake"
+}
+```
+
+The `deposit` must meet the chain's `min_deposit`, which is `10000000stake` locally. Check it with
+`exampled query gov params`. Then submit and vote:
+
+```bash
+exampled tx gov submit-proposal proposal.json --from alice --chain-id demo --yes
+exampled tx gov vote 1 yes --from alice --chain-id demo --yes
+```
+
+Check progress with `exampled query gov proposals`.
+
+<Note>
+The local chain uses the default 48 hour `voting_period`, so a proposal submitted this way sits in
+`PROPOSAL_STATUS_VOTING_PERIOD` for two days and the params do not change during a normal dev session.
+</Note>
+
+To watch a param change actually take effect locally, shorten the voting period. Editing
+`genesis.json` before `make start` does not work, because `scripts/local_node.sh` deletes the whole
+home directory on every run. Let `make start` create the chain first, then stop it and edit in place:
+
+```bash
+# 1. Let make start create ~/.exampleapp, then stop it with Ctrl+C
+make start
+
+# 2. Lower the voting period in the generated genesis
+#    app_state.gov.params.voting_period, for example "20s"
+vi ~/.exampleapp/config/genesis.json
+
+# 3. Wipe block history so the edited genesis is re-read, keeping keys and config
+exampled comet unsafe-reset-all
+
+# 4. Start the node directly. Do not use make start again, it would delete your edit
+exampled start
+```
+
+Submit and vote as above, wait out the shortened period, and the proposal reaches
+`PROPOSAL_STATUS_PASSED` and `exampled query counter params` reflects the new values.
+
+`exampled tx gov draft-proposal` can generate a skeleton, but it is an interactive terminal picker rather
+than a scriptable command. Its top-level list offers only `text`, `community-pool-spend`,
+`software-upgrade`, `cancel-software-upgrade`, and `other`, and choosing `other` opens a scroll-only list
+of fully qualified message type URLs that typing does not filter. Writing the JSON by hand, as above, is
+the more direct path.
 
 ### Useful flags
 

--- a/sdk/next/tutorials/example/05-run-and-test.mdx
+++ b/sdk/next/tutorials/example/05-run-and-test.mdx
@@ -178,8 +178,9 @@ home directory on every run. Let `make start` create the chain first, then stop 
 # 1. Let make start create ~/.exampleapp, then stop it with Ctrl+C
 make start
 
-# 2. Lower the voting period in the generated genesis
+# 2. Lower both governance voting periods in the generated genesis.
 #    app_state.gov.params.voting_period, for example "20s"
+#    app_state.gov.params.expedited_voting_period must stay strictly shorter, for example "10s"
 vi ~/.exampleapp/config/genesis.json
 
 # 3. Wipe block history so the edited genesis is re-read, keeping keys and config


### PR DESCRIPTION
Auto-synced from cosmos/example. Transforms docs/*.md to sdk/next/tutorials/example/*.mdx. Do not edit these files directly — edit the source in cosmos/example and let the sync bot update them.