### PR TITLE
fix(ci): check out the sync branch before transforming, and serialize runs

### DIFF
--- a/.github/workflows/docs-sync-to-example.yml
+++ b/.github/workflows/docs-sync-to-example.yml
@@ -11,6 +11,19 @@ on:
       - main
     paths:
       - "sdk/next/tutorials/example/**"
+  # Manual trigger. The push trigger only fires on tutorial .mdx changes, so a
+  # workflow-only fix cannot re-run the sync, and a sync PR left stale by a
+  # failed run has no way to catch up until the next docs edit.
+  workflow_dispatch:
+
+# Serialize runs. Two overlapping runs would each check out the same revision of
+# the open sync branch, commit divergently, and the loser's push would be
+# rejected as non-fast-forward, silently dropping its update. Queue instead of
+# cancelling: the transform is deterministic from the source docs, so the last
+# run to finish always produces the correct final state.
+concurrency:
+  group: docs-sync-to-example
+  cancel-in-progress: false
 
 jobs:
   sync:
@@ -37,33 +50,18 @@ jobs:
           path: cosmos-example
           persist-credentials: false
 
-      - name: Transform Mintlify → example repo format
-        run: |
-          python3 scripts/docs-sync/transform.py \
-            --direction to-example \
-            --input sdk/next/tutorials/example/ \
-            --output-dir cosmos-example/docs/
-
-      - name: Check for changes
-        id: diff
-        run: |
-          cd cosmos-example
-          [ -n "$(git status --porcelain docs/)" ] \
-            && echo "changed=true" >> "$GITHUB_OUTPUT" \
-            || echo "changed=false" >> "$GITHUB_OUTPUT"
-
-      - name: Open or update PR on cosmos/example
-        if: steps.diff.outputs.changed == 'true'
+      # Select the target branch BEFORE transforming. If an open sync PR exists we
+      # check its branch out while the tree is still clean, so the transform writes
+      # directly onto that branch. Switching branches after the transform would
+      # either abort ("local changes would be overwritten") or, via stash, conflict
+      # against changes the branch already carries and exit 1 under bash -e.
+      - name: Select target branch
+        id: target
         env:
           GH_TOKEN: ${{ secrets.EXAMPLE_REPO_TOKEN }}
         run: |
           cd cosmos-example
 
-          git config user.name  "docs-sync[bot]"
-          git config user.email "docs-sync[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${{ secrets.EXAMPLE_REPO_TOKEN }}@github.com/cosmos/example.git"
-
-          # Check for an existing open sync PR
           EXISTING=$(gh pr list \
             --repo cosmos/example \
             --label "docs-sync" \
@@ -74,39 +72,60 @@ jobs:
           if [ -n "$EXISTING" ]; then
             PR_NUMBER=$(echo "$EXISTING" | jq -r '.number')
             BRANCH=$(echo "$EXISTING" | jq -r '.headRefName')
-
-            # Stash the transform output before switching branches,
-            # then restore it on top of the existing sync branch.
-            git stash
-            git fetch origin "$BRANCH"
-            git checkout "$BRANCH"
-            git stash pop
-            git add docs/
-
-            if git diff --cached --quiet; then
-              echo "Existing sync branch is already up to date — nothing to commit."
-            else
-              git commit -m "docs: sync example tutorials from cosmos/docs [docs-sync]"
-              git push origin "$BRANCH"
-
-              gh pr comment "$PR_NUMBER" \
-                --repo cosmos/example \
-                --body "Sync updated: cosmos/docs was updated before this PR merged. Branch has been refreshed — please re-review."
-              echo "Updated existing PR #$PR_NUMBER"
-            fi
-
+            git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+            git checkout -B "$BRANCH" "origin/${BRANCH}"
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "Reusing open sync PR #$PR_NUMBER on branch $BRANCH"
           else
             BRANCH="docs-sync/from-docs-$(date +%Y%m%d-%H%M%S)"
             git checkout -b "$BRANCH"
-            git add docs/
-            git commit -m "docs: sync example tutorials from cosmos/docs [docs-sync]"
-            git push origin "$BRANCH"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            echo "No open sync PR, will create branch $BRANCH"
+          fi
 
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Transform Mintlify → example repo format
+        run: |
+          python3 scripts/docs-sync/transform.py \
+            --direction to-example \
+            --input sdk/next/tutorials/example/ \
+            --output-dir cosmos-example/docs/
+
+      - name: Commit, then open or update the PR on cosmos/example
+        env:
+          GH_TOKEN: ${{ secrets.EXAMPLE_REPO_TOKEN }}
+          BRANCH: ${{ steps.target.outputs.branch }}
+          PR_NUMBER: ${{ steps.target.outputs.pr_number }}
+        run: |
+          cd cosmos-example
+
+          git config user.name  "docs-sync[bot]"
+          git config user.email "docs-sync[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.EXAMPLE_REPO_TOKEN }}@github.com/cosmos/example.git"
+
+          git add docs/
+
+          if git diff --cached --quiet; then
+            echo "No doc changes to sync, nothing to commit."
+            exit 0
+          fi
+
+          git commit -m "docs: sync example tutorials from cosmos/docs [docs-sync]"
+          git push origin "HEAD:refs/heads/${BRANCH}"
+
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr comment "$PR_NUMBER" \
+              --repo cosmos/example \
+              --body "Sync updated: cosmos/docs was updated before this PR merged. Branch has been refreshed, please re-review."
+            echo "Updated existing PR #$PR_NUMBER"
+          else
             gh pr create \
               --repo cosmos/example \
               --head "$BRANCH" \
               --base main \
               --title "docs: sync example tutorials from cosmos/docs" \
               --label "docs-sync" \
-              --body "Auto-synced from cosmos/docs. Transforms sdk/next/tutorials/example/*.mdx to docs/*.md. Do not edit docs/ files directly in cosmos/example — edit the source and let the sync bot update them."
+              --body "Auto-synced from cosmos/docs. Transforms sdk/next/tutorials/example/*.mdx to docs/*.md. Do not edit docs/ files directly in cosmos/example, edit the source and let the sync bot update them."
+            echo "Opened a new sync PR on branch $BRANCH"
           fi


### PR DESCRIPTION
Mirrors [cosmos/example#16](https://github.com/cosmos/example/pull/16) and [#17](https://github.com/cosmos/example/pull/17) in the reverse direction. The forward workflow had the same structural bug; it has been fixed and verified in CI, and this brings the two back into parity.

## Problem

`docs-sync-to-example.yml` transforms the tutorials into `cosmos-example/` while still on `main`, then switches to the open sync branch to commit:

```bash
git stash
git fetch origin "$BRANCH"
git checkout "$BRANCH"
git stash pop
```

Popping a stash taken against `main` onto a branch that already carries overlapping changes conflicts:

```
CONFLICT (content): Merge conflict in docs/02-quickstart.md
$ echo $?
1
```

`run:` blocks execute under `bash -e`, so exit 1 fails the step. This is conditional, not constant: it fires when the transform output touches lines the sync branch already changed, which is exactly what happens when that branch carries an earlier version of the same edit. This is the likely cause of the unexplained [2026-04-10 failure](https://github.com/cosmos/docs/actions/runs/24263862815), which ran while `cosmos/example#9` had been open since March 31. That run's logs have expired, so the attribution is inference, not proof.

Without the stash, `git checkout` aborts outright with "local changes would be overwritten," which is how the forward workflow was failing.

## Fix

Select the target branch and check it out **first**, while the tree is still clean, then transform directly onto it. Nothing is stashed and nothing is merged, so there is no conflict to hit.

Three supporting changes:

- Replaces the separate change-detection step with a `git diff --cached --quiet` guard, so an already-current branch exits cleanly rather than creating an empty commit.
- Adds a `concurrency` group, so two overlapping runs cannot derive divergent commits from the same branch revision and race on push, where the loser is rejected non-fast-forward and its update silently lost.
- Adds `workflow_dispatch`, so a sync PR left stale by a failed run can be brought current without waiting for the next docs edit. The loop guard is unaffected: with no `head_commit` on a dispatch, `contains()` is false and the job runs.

## Verification

Against real clones of both repos, using the stale `cosmos/example#9` branch as the existing-PR case, with the transform output edited to overlap lines that branch already changed:

- Old sequence: `CONFLICT (content): Merge conflict in docs/02-quickstart.md`, exit 1
- New sequence: exit 0, stages the correct refresh of all five doc files
- New sequence run twice: reports no changes instead of committing again

The equivalent fix in `cosmos/example` has since run green in CI twice, once updating an open sync PR and once correctly reporting nothing to do.

## Note on cosmos/example#9

That sync PR has been open since 2026-03-31 and its branch is five months stale. Once this merges, the next reverse sync will reuse and wholesale refresh it, turning it into a large diff (~225 insertions, ~50 deletions) rather than the small one a reviewer might expect. Closing it first is probably cleaner, so the next run opens a fresh PR.